### PR TITLE
fix: hotkey recording, data persistence, and menu bar UI improvements

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleExecutable</key>
     <string>AnyDoor</string>
     <key>CFBundleIdentifier</key>
-    <string>com.zingerbee.AnyDoor</string>
+    <string>dev.bybee.AnyDoor</string>
     <key>CFBundleName</key>
     <string>AnyDoor</string>
     <key>CFBundleVersion</key>

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -6,7 +6,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     override init() {
         do {
-            modelContainer = try ModelContainer(for: KeyBinding.self)
+            // Use a fixed storage path so data persists regardless of how the app is launched
+            // (swift run vs .app bundle). Without this, the default ModelConfiguration
+            // picks a path based on the process bundle ID, which differs between run modes.
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let storeDir = appSupport.appendingPathComponent("dev.bybee.AnyDoor", isDirectory: true)
+            try FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
+            let storeURL = storeDir.appendingPathComponent("AnyDoor.store")
+            let config = ModelConfiguration(url: storeURL)
+            modelContainer = try ModelContainer(for: KeyBinding.self, configurations: config)
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }

--- a/Sources/AnyDoor/Services/HotkeyService.swift
+++ b/Sources/AnyDoor/Services/HotkeyService.swift
@@ -24,6 +24,10 @@ final class HotkeyService {
     /// Periodically checks and re-enables the event tap if the system disabled it
     private var watchdogTimer: Timer?
 
+    /// Whether the tap is intentionally suspended (e.g. during hotkey recording).
+    /// Prevents the watchdog from restarting the tap while recording is in progress.
+    private var isSuspended = false
+
     /// Sendable value type for safely passing binding data across threads to the C callback
     struct BindingSnapshot: Sendable {
         let keyCode: Int
@@ -40,11 +44,13 @@ final class HotkeyService {
             BindingSnapshot(keyCode: $0.keyCode, modifierFlags: $0.modifierFlags,
                             appBundleID: $0.appBundleID, appPath: $0.appPath)
         }
-        // Ensure tap is running (may have been suspended during recording or disabled by system)
-        if eventTap == nil {
-            start()
-        } else {
-            resume()
+        // Ensure tap is running unless intentionally suspended during recording
+        if !isSuspended {
+            if eventTap == nil {
+                start()
+            } else {
+                resume()
+            }
         }
         print("AnyDoor: Updated \(bindingSnapshots.count) binding(s)")
         for b in bindingSnapshots {
@@ -87,6 +93,7 @@ final class HotkeyService {
 
     /// Suspend event listening (called during hotkey recording to avoid triggering existing bindings)
     func suspend() {
+        isSuspended = true
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
@@ -94,6 +101,7 @@ final class HotkeyService {
 
     /// Resume event listening
     func resume() {
+        isSuspended = false
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
@@ -133,7 +141,9 @@ final class HotkeyService {
         watchdogTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
             guard let self else { return }
             guard let tap = self.eventTap else { return }
-            if !CGEvent.tapIsEnabled(tap: tap) {
+            // Skip restart when intentionally suspended (e.g. during hotkey recording)
+            let suspended = MainActor.assumeIsolated { self.isSuspended }
+            if !suspended && !CGEvent.tapIsEnabled(tap: tap) {
                 print("AnyDoor: Watchdog detected disabled tap, performing full restart")
                 MainActor.assumeIsolated {
                     self.restart()

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -43,6 +43,8 @@ struct MenuBarView: View {
                 .padding(.horizontal, 4)
             }
 
+            Spacer(minLength: 0)
+
             // Footer actions
             HStack(spacing: 8) {
                 SettingsLink {
@@ -68,6 +70,7 @@ struct MenuBarView: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
         .frame(width: 260)
+        .frame(minHeight: 120)
     }
 }
 

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -6,71 +6,68 @@ struct MenuBarView: View {
     @Environment(\.modelContext) private var modelContext
 
     var body: some View {
-        GlassEffectContainer(spacing: 8) {
-            VStack(alignment: .leading, spacing: 8) {
-                // Header
-                HStack {
-                    Text("AnyDoor")
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                    Spacer()
-                    Text("\(bindings.filter(\.isEnabled).count) 个快捷键")
+        VStack(alignment: .leading, spacing: 6) {
+            // Header
+            HStack {
+                Text("AnyDoor")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text("\(bindings.filter(\.isEnabled).count) 个快捷键")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12)
+
+            // Bindings list
+            if bindings.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "keyboard")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.quaternary)
+                    Text("尚未配置快捷键")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text("点击下方「设置」添加")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, 12)
-
-                // Bindings list
-                if bindings.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "keyboard")
-                            .font(.system(size: 24))
-                            .foregroundStyle(.quaternary)
-                        Text("尚未配置快捷键")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text("点击下方「设置」添加")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            } else {
+                VStack(spacing: 4) {
+                    ForEach(bindings) { binding in
+                        BindingRow(binding: binding)
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                } else {
-                    VStack(spacing: 4) {
-                        ForEach(bindings) { binding in
-                            BindingRow(binding: binding)
-                        }
-                    }
-                    .padding(.horizontal, 8)
                 }
-
-                // Footer actions
-                HStack(spacing: 8) {
-                    SettingsLink {
-                        Label("设置", systemImage: "gear")
-                    }
-                    .buttonStyle(.glass)
-                    .simultaneousGesture(TapGesture().onEnded {
-                        NSApplication.shared.activate()
-                    })
-
-                    Button {
-                        NSApplication.shared.terminate(nil)
-                    } label: {
-                        Label("退出", systemImage: "power")
-                    }
-                    .buttonStyle(.glass)
-
-                    Spacer()
-                }
-                .focusEffectDisabled()
-                .padding(.horizontal, 12)
-                .padding(.bottom, 8)
+                .padding(.horizontal, 4)
             }
+
+            // Footer actions
+            HStack(spacing: 8) {
+                SettingsLink {
+                    Label("设置", systemImage: "gear")
+                }
+                .buttonStyle(.glass)
+                .simultaneousGesture(TapGesture().onEnded {
+                    NSApplication.shared.activate()
+                })
+
+                Button {
+                    NSApplication.shared.terminate(nil)
+                } label: {
+                    Label("退出", systemImage: "power")
+                }
+                .buttonStyle(.glass)
+
+                Spacer()
+            }
+            .focusEffectDisabled()
+            .padding(.horizontal, 8)
         }
-        .frame(width: 280)
-        .frame(minHeight: 140)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        .frame(width: 260)
     }
 }
 

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -64,8 +64,9 @@ struct MenuBarView: View {
 
                     Spacer()
                 }
+                .focusEffectDisabled()
                 .padding(.horizontal, 12)
-                .padding(.bottom, 10)
+                .padding(.bottom, 8)
             }
         }
         .frame(width: 280)

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -70,7 +70,7 @@ struct MenuBarView: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
         .frame(width: 260)
-        .frame(minHeight: 120)
+        .frame(minHeight: 400)
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix watchdog timer interfering with hotkey recording by adding `isSuspended` flag, preventing the watchdog from restarting the event tap during intentional suspend
- Fix SwiftData storage path to use a fixed location (`~/Library/Application Support/dev.bybee.AnyDoor/AnyDoor.store`) so data persists across `swift run` and `.app` launch modes
- Update bundle ID to `dev.bybee.AnyDoor`
- Remove focus ring on menu bar popover buttons
- Replace `GlassEffectContainer` with plain `VStack` to eliminate uncontrollable internal padding
- Add minimum height for the popover bindings area

## Test plan
- [x] Verify hotkey recording works after existing bindings are configured (previously blocked by watchdog restarting the tap within 2 seconds)
- [x] Verify key bindings persist across app restarts with both `swift run` and `make install` launch methods
- [x] Verify menu bar popover has no focus ring on buttons and has compact, balanced spacing