### PR TITLE
feat(port-manager): add port management submenu

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .testTarget(
             name: "AnyDoorTests",
             dependencies: ["AnyDoor"],
+            resources: [.process("Fixtures")],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -21,6 +21,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case restartMenuBar
     case flushDNS
     case keyboardLock
+    case portManager
 
     enum Kind: Sendable {
         case toggle
@@ -30,7 +31,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
 
     var kind: Kind {
         switch self {
-        case .appShortcuts: return .submenu
+        case .appShortcuts, .portManager: return .submenu
         case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
         case .lockScreen, .emptyTrash, .screenshot, .displaySleep, .systemSleep,
@@ -58,6 +59,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .restartMenuBar: return "重启菜单栏"
         case .flushDNS: return "刷新 DNS"
         case .keyboardLock: return "禁用键盘"
+        case .portManager: return "端口管理"
         }
     }
 
@@ -81,6 +83,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .restartMenuBar: return "menubar.arrow.up.rectangle"
         case .flushDNS: return "network"
         case .keyboardLock: return "keyboard.fill"
+        case .portManager: return "network"
         }
     }
 
@@ -105,6 +108,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .restartMenuBar: return 1600
         case .flushDNS: return 1700
         case .keyboardLock: return 1800
+        case .portManager: return 1900
         }
     }
 

--- a/Sources/AnyDoor/Models/PortRecord.swift
+++ b/Sources/AnyDoor/Models/PortRecord.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Darwin
+
+/// Listening TCP port discovered on the local machine. Identity is `(pid, port)`.
+struct PortRecord: Sendable, Hashable, Identifiable {
+    let port: UInt16
+    let pid: pid_t
+    let processName: String
+    let executablePath: String?
+    let commandLine: String?
+    /// Every distinct bind seen for this (pid, port). Never empty; ordered IPv4 first then IPv6.
+    let binds: [PortBind]
+    var id: String { "\(pid)-\(port)" }
+}
+
+struct PortBind: Sendable, Hashable {
+    let address: String          // "*", "127.0.0.1", "::1", "fe80::1%en0", ...
+    let family: AddressFamily
+}
+
+enum AddressFamily: String, Sendable, Hashable, CaseIterable {
+    case ipv4 = "IPv4"
+    case ipv6 = "IPv6"
+}
+
+/// Outcome of a `Darwin.kill(2)` syscall. `errno` is captured immediately into
+/// the failure case to avoid clobbering by subsequent system calls.
+enum SignalResult: Sendable, Equatable {
+    case success
+    case failure(POSIXErrorCode)
+}
+
+/// View-model grouping of records belonging to a single process. Used by the tree view.
+struct ProcessGroup: Sendable, Identifiable {
+    var id: pid_t { pid }
+    let pid: pid_t
+    let processName: String
+    let ports: [PortRecord]      // sorted by port ascending
+}

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Darwin
+import os
+
+@MainActor
+@Observable
+final class PortInventory {
+    // MARK: - Public state
+
+    private(set) var records: [PortRecord] = []
+    private(set) var isRefreshing: Bool = false
+    private(set) var lastError: PortInventoryError? = nil
+    private(set) var killingPIDs: Set<pid_t> = []
+    private(set) var failedKillPIDs: [pid_t: KillFailure] = [:]
+
+    var searchText: String = ""
+
+    var viewMode: ViewMode {
+        didSet {
+            defaults.set(viewMode.rawValue, forKey: Self.viewModeKey)
+        }
+    }
+
+    // MARK: - Dependencies
+
+    private let scanner: any PortScanning
+    private let defaults: UserDefaults
+    private static let viewModeKey = "PortInventory.viewMode"
+    private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")
+
+    // MARK: - Internal refresh state (Task 10)
+
+    private var refreshGeneration: UInt64 = 0
+    private var inflightCount: Int = 0
+
+    // MARK: - Lifecycle
+
+    static let shared: PortInventory = MainActor.assumeIsolated { PortInventory() }
+
+    init(
+        scanner: any PortScanning = PortScanner(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.scanner = scanner
+        self.defaults = defaults
+        let raw = defaults.string(forKey: Self.viewModeKey)
+        self.viewMode = raw.flatMap(ViewMode.init(rawValue:)) ?? .list
+    }
+
+    // Placeholder methods — real implementations land in Task 10 and Task 11.
+
+    func refresh() async {
+        // Implemented in Task 10.
+    }
+
+    func kill(pid: pid_t) async {
+        // Implemented in Task 11.
+    }
+
+    func dismissError(for pid: pid_t) {
+        failedKillPIDs.removeValue(forKey: pid)
+    }
+}
+
+enum ViewMode: String, Sendable, Equatable {
+    case list, tree
+}
+
+enum PortInventoryError: Equatable, Sendable {
+    case scanFailed(String)
+}
+
+struct KillFailure: Equatable, Sendable {
+    enum Reason: Equatable, Sendable {
+        case permissionDenied
+        case processGone
+        case other(Int32)
+    }
+    let reason: Reason
+    let timestamp: Date
+}

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -76,7 +76,56 @@ final class PortInventory {
     }
 
     func kill(pid: pid_t) async {
-        // Implemented in Task 11.
+        killingPIDs.insert(pid)
+
+        // Step 1: SIGTERM
+        switch scanner.kill(pid: pid, signal: SIGTERM) {
+        case .failure(.ESRCH):
+            // Process already gone — treat as success.
+            await refresh()
+            killingPIDs.remove(pid)
+            return
+        case .failure(let code):
+            let reason: KillFailure.Reason =
+                (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+            failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+            scheduleAutoDismiss(for: pid)
+            killingPIDs.remove(pid)
+            return
+        case .success:
+            break
+        }
+
+        // Step 2: give the process time to handle SIGTERM, then re-scan.
+        try? await Task.sleep(for: .milliseconds(500))
+        await refresh()
+
+        // Step 3: if still alive, escalate.
+        if records.contains(where: { $0.pid == pid }) {
+            switch scanner.kill(pid: pid, signal: SIGKILL) {
+            case .success:
+                try? await Task.sleep(for: .milliseconds(200))
+                await refresh()
+            case .failure(.ESRCH):
+                await refresh()
+            case .failure(let code):
+                let reason: KillFailure.Reason =
+                    (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+                failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+                scheduleAutoDismiss(for: pid)
+            }
+        }
+
+        killingPIDs.remove(pid)
+    }
+
+    private func scheduleAutoDismiss(for pid: pid_t) {
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            await MainActor.run {
+                self?.failedKillPIDs.removeValue(forKey: pid)
+            }
+        }
     }
 
     func dismissError(for pid: pid_t) {

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -131,6 +131,41 @@ final class PortInventory {
     func dismissError(for pid: pid_t) {
         failedKillPIDs.removeValue(forKey: pid)
     }
+
+    // MARK: - Derived views
+
+    var filteredRecords: [PortRecord] {
+        guard !searchText.isEmpty else {
+            return records.sorted { $0.port < $1.port }
+        }
+        let q = searchText.lowercased()
+        var seen = Set<PortRecord.ID>()
+        var ordered: [PortRecord] = []
+        func add(_ bucket: [PortRecord]) {
+            for r in bucket where !seen.contains(r.id) {
+                seen.insert(r.id)
+                ordered.append(r)
+            }
+        }
+        add(records.filter { String($0.port).contains(q) })
+        add(records.filter { $0.processName.lowercased().contains(q) })
+        add(records.filter { String($0.pid).contains(q) })
+        return ordered
+    }
+
+    var groupedByProcess: [ProcessGroup] {
+        let grouped = Dictionary(grouping: filteredRecords, by: \.pid)
+        return grouped.map { (pid, recs) in
+            ProcessGroup(
+                pid: pid,
+                processName: recs.first?.processName ?? "",
+                ports: recs.sorted { $0.port < $1.port }
+            )
+        }
+        .sorted {
+            $0.processName.localizedCaseInsensitiveCompare($1.processName) == .orderedAscending
+        }
+    }
 }
 
 enum ViewMode: String, Sendable, Equatable {

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -50,7 +50,29 @@ final class PortInventory {
     // Placeholder methods — real implementations land in Task 10 and Task 11.
 
     func refresh() async {
-        // Implemented in Task 10.
+        refreshGeneration &+= 1
+        let myGen = refreshGeneration
+        inflightCount += 1
+        isRefreshing = true
+
+        do {
+            let scanned = try await scanner.scanTCPListening()
+            inflightCount -= 1
+            if myGen == refreshGeneration {
+                records = scanned
+                lastError = nil
+            } else {
+                Self.logger.debug("dropping stale scan result (gen \(myGen), now \(self.refreshGeneration))")
+            }
+            isRefreshing = inflightCount > 0
+        } catch {
+            inflightCount -= 1
+            if myGen == refreshGeneration {
+                lastError = .scanFailed(String(describing: error))
+                // records intentionally preserved
+            }
+            isRefreshing = inflightCount > 0
+        }
     }
 
     func kill(pid: pid_t) async {

--- a/Sources/AnyDoor/Services/PortScanner.swift
+++ b/Sources/AnyDoor/Services/PortScanner.swift
@@ -97,12 +97,61 @@ actor PortScanner: PortScanning {
     }
 }
 
-// MARK: - LsofRunner placeholder (real implementation lands in Task 8)
+// MARK: - LsofRunner
 
 struct LsofRunner: SubprocessRunning {
     func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
-        // Placeholder; replaced in Task 8.
-        return SubprocessResult(stdout: "", stderr: "", exit: 0, timedOut: false)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = args
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        do { try process.run() }
+        catch { throw SubprocessError.spawnFailed("\(error)") }
+
+        // OSAllocatedUnfairLock<Bool> — no new dependency, watchdog and
+        // result-builder both read/write through .withLock.
+        let timedOut = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+        return await withTaskCancellationHandler {
+            // Drain pipes concurrently so the kernel buffer never fills.
+            async let outData: Data = readAll(outPipe.fileHandleForReading)
+            async let errData: Data = readAll(errPipe.fileHandleForReading)
+
+            let watchdog = Task {
+                try? await Task.sleep(for: timeout)
+                if process.isRunning {
+                    timedOut.withLock { $0 = true }
+                    process.terminate()
+                }
+            }
+
+            let out = await outData
+            let err = await errData
+            watchdog.cancel()
+            process.waitUntilExit()
+
+            return SubprocessResult(
+                stdout: String(data: out, encoding: .utf8) ?? "",
+                stderr: String(data: err, encoding: .utf8) ?? "",
+                exit: process.terminationStatus,
+                timedOut: timedOut.withLock { $0 }
+            )
+        } onCancel: {
+            if process.isRunning { process.terminate() }
+        }
+    }
+}
+
+private func readAll(_ handle: FileHandle) async -> Data {
+    await withCheckedContinuation { (cont: CheckedContinuation<Data, Never>) in
+        DispatchQueue.global().async {
+            let data = (try? handle.readToEnd()) ?? Data()
+            cont.resume(returning: data)
+        }
     }
 }
 
@@ -260,9 +309,47 @@ private func hexNibble(_ s: Unicode.Scalar) -> UInt8? {
     }
 }
 
-// MARK: - sysctl KERN_PROCARGS2 helper (filled in Task 8)
+// MARK: - sysctl KERN_PROCARGS2 helper
 
+/// Reads `KERN_PROCARGS2` for a pid and extracts the executable path and the
+/// space-joined argv. Returns `(nil, nil)` on any failure (permission, race,
+/// pid no longer alive). Silent by design — caller falls back to lsof's command.
 func parseProcArgs(forPid pid: pid_t) -> (path: String?, command: String?) {
-    // Task 8 replaces this stub with the real sysctl-based implementation.
-    return (nil, nil)
+    var size: Int = 0
+    var name: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+    // First call: ask for size.
+    if sysctl(&name, 3, nil, &size, nil, 0) != 0 || size == 0 {
+        return (nil, nil)
+    }
+    var buffer = [UInt8](repeating: 0, count: size)
+    if sysctl(&name, 3, &buffer, &size, nil, 0) != 0 {
+        return (nil, nil)
+    }
+
+    // Layout: <argc:Int32><executable path NUL>[padding NULs]<argv[0] NUL><argv[1] NUL>...
+    guard size >= MemoryLayout<Int32>.size else { return (nil, nil) }
+    let argc = buffer.withUnsafeBytes { $0.load(as: Int32.self) }
+    if argc < 0 { return (nil, nil) }
+
+    var cursor = MemoryLayout<Int32>.size
+    // Read NUL-terminated executable path.
+    let pathStart = cursor
+    while cursor < buffer.count && buffer[cursor] != 0 { cursor += 1 }
+    let pathBytes = buffer[pathStart..<cursor]
+    let path = String(decoding: pathBytes, as: UTF8.self)
+    // Skip padding NULs.
+    while cursor < buffer.count && buffer[cursor] == 0 { cursor += 1 }
+
+    // Read argc NUL-terminated argv entries.
+    var argv: [String] = []
+    var collected = 0
+    while collected < Int(argc) && cursor < buffer.count {
+        let start = cursor
+        while cursor < buffer.count && buffer[cursor] != 0 { cursor += 1 }
+        argv.append(String(decoding: buffer[start..<cursor], as: UTF8.self))
+        if cursor < buffer.count { cursor += 1 } // skip NUL
+        collected += 1
+    }
+    let command = argv.joined(separator: " ")
+    return (path.isEmpty ? nil : path, command.isEmpty ? nil : command)
 }

--- a/Sources/AnyDoor/Services/PortScanner.swift
+++ b/Sources/AnyDoor/Services/PortScanner.swift
@@ -47,8 +47,47 @@ actor PortScanner: PortScanning {
     }
 
     func scanTCPListening() async throws -> [PortRecord] {
-        // Implemented in Task 7.
-        return []
+        let result = try await runner.run(
+            path: "/usr/sbin/lsof",
+            args: ["-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pPcntL", "+c", "0"],
+            timeout: .seconds(3)
+        )
+
+        if result.timedOut { throw PortScanError.lsofTimeout }
+
+        // lsof returns exit 1 with empty stdout AND empty stderr when there is
+        // no matching open file. Treat that as a successful empty scan.
+        if result.exit == 1 && result.stdout.isEmpty && result.stderr.isEmpty {
+            return []
+        }
+        // Non-zero exit with any output on stderr (or stdout) is a real failure.
+        if result.exit != 0 {
+            throw PortScanError.lsofFailed(exitCode: result.exit, stderr: result.stderr)
+        }
+
+        var records = try parseLsofOutput(result.stdout)
+        records = enrichWithProcArgs(records)
+        return records
+    }
+
+    /// Enriches each record's `executablePath` and `commandLine` via sysctl.
+    /// One sysctl call per unique pid; failures are silent (record keeps lsof's data).
+    private func enrichWithProcArgs(_ records: [PortRecord]) -> [PortRecord] {
+        var cache: [pid_t: (path: String?, command: String?)] = [:]
+        return records.map { r in
+            if cache[r.pid] == nil {
+                cache[r.pid] = parseProcArgs(forPid: r.pid)
+            }
+            let info = cache[r.pid] ?? (nil, nil)
+            return PortRecord(
+                port: r.port,
+                pid: r.pid,
+                processName: r.processName,
+                executablePath: info.path,
+                commandLine: info.command,
+                binds: r.binds
+            )
+        }
     }
 
     nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult {
@@ -219,4 +258,11 @@ private func hexNibble(_ s: Unicode.Scalar) -> UInt8? {
     case "A"..."F": return UInt8(s.value - Unicode.Scalar("A").value + 10)
     default: return nil
     }
+}
+
+// MARK: - sysctl KERN_PROCARGS2 helper (filled in Task 8)
+
+func parseProcArgs(forPid pid: pid_t) -> (path: String?, command: String?) {
+    // Task 8 replaces this stub with the real sysctl-based implementation.
+    return (nil, nil)
 }

--- a/Sources/AnyDoor/Services/PortScanner.swift
+++ b/Sources/AnyDoor/Services/PortScanner.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Darwin
+import os
+
+// MARK: - Subprocess runner protocol
+
+protocol SubprocessRunning: Sendable {
+    func run(
+        path: String,
+        args: [String],
+        timeout: Duration
+    ) async throws -> SubprocessResult
+}
+
+struct SubprocessResult: Sendable, Equatable {
+    let stdout: String
+    let stderr: String
+    let exit: Int32
+    let timedOut: Bool
+}
+
+enum SubprocessError: Error, Equatable {
+    case spawnFailed(String)
+}
+
+// MARK: - Scanner protocol
+
+protocol PortScanning: Sendable {
+    func scanTCPListening() async throws -> [PortRecord]
+    func kill(pid: pid_t, signal: Int32) -> SignalResult
+}
+
+enum PortScanError: Error, Equatable {
+    case lsofTimeout
+    case lsofFailed(exitCode: Int32, stderr: String)
+    case parseFailed(line: String)
+}
+
+// MARK: - PortScanner actor (skeleton — implemented across later tasks)
+
+actor PortScanner: PortScanning {
+    private let runner: any SubprocessRunning
+    private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "PortScanner")
+
+    init(runner: any SubprocessRunning = LsofRunner()) {
+        self.runner = runner
+    }
+
+    func scanTCPListening() async throws -> [PortRecord] {
+        // Implemented in Task 7.
+        return []
+    }
+
+    nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult {
+        if Darwin.kill(pid, signal) == 0 { return .success }
+        let code = POSIXErrorCode(rawValue: errno) ?? .EINVAL
+        return .failure(code)
+    }
+}
+
+// MARK: - LsofRunner placeholder (real implementation lands in Task 8)
+
+struct LsofRunner: SubprocessRunning {
+    func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
+        // Placeholder; replaced in Task 8.
+        return SubprocessResult(stdout: "", stderr: "", exit: 0, timedOut: false)
+    }
+}

--- a/Sources/AnyDoor/Services/PortScanner.swift
+++ b/Sources/AnyDoor/Services/PortScanner.swift
@@ -66,3 +66,157 @@ struct LsofRunner: SubprocessRunning {
         return SubprocessResult(stdout: "", stderr: "", exit: 0, timedOut: false)
     }
 }
+
+// MARK: - lsof -F output parser
+
+/// Parses the output of `lsof -nP -iTCP -sTCP:LISTEN -F pPcntL +c 0`.
+///
+/// Field format reference (from `lsof -F?`):
+///   p = process id, c = command name, L = login name (process records)
+///   f = file descriptor (starts a new file record), P = protocol, t = file type
+///   (IPv4/IPv6), n = comment/name ("addr:port")
+///
+/// Each line is `<fieldChar><value>`. `p` starts a new process group; `f` starts
+/// a new file within the current process group.
+func parseLsofOutput(_ raw: String) throws -> [PortRecord] {
+    struct PartialFile {
+        var family: AddressFamily?
+        var name: String?
+        var protocolName: String?
+    }
+    struct PartialProcess {
+        var pid: pid_t?
+        var command: String = ""
+        var files: [PartialFile] = []
+    }
+
+    var partials: [PartialProcess] = []
+    var currentProcess: PartialProcess? = nil
+    var currentFile: PartialFile? = nil
+
+    func flushFile() {
+        if let file = currentFile, currentProcess != nil {
+            currentProcess!.files.append(file)
+        }
+        currentFile = nil
+    }
+    func flushProcess() {
+        flushFile()
+        if let proc = currentProcess { partials.append(proc) }
+        currentProcess = nil
+    }
+
+    for rawLine in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+        guard let first = rawLine.first else { continue }
+        let value = String(rawLine.dropFirst())
+
+        switch first {
+        case "p":
+            flushProcess()
+            currentProcess = PartialProcess(pid: pid_t(value), command: "", files: [])
+        case "c":
+            if currentProcess != nil { currentProcess!.command = decodeLsofEscapes(value) }
+        case "L":
+            break // login name unused
+        case "f":
+            flushFile()
+            currentFile = PartialFile()
+        case "P":
+            if currentFile != nil { currentFile!.protocolName = value }
+        case "t":
+            if currentFile != nil { currentFile!.family = AddressFamily(rawValue: value) }
+        case "n":
+            if currentFile != nil { currentFile!.name = value }
+        default:
+            break // unknown field — ignore for forward-compat
+        }
+    }
+    flushProcess()
+
+    // Group by (pid, port). Within a group, accumulate distinct binds.
+    struct Key: Hashable { let pid: pid_t; let port: UInt16 }
+    var groups: [Key: (processName: String, binds: [PortBind])] = [:]
+    var keyOrder: [Key] = []
+
+    for proc in partials {
+        guard let pid = proc.pid else { continue }
+        for file in proc.files {
+            guard let name = file.name,
+                  let (address, port) = parseAddressPort(name),
+                  let family = file.family else { continue }
+            let key = Key(pid: pid, port: port)
+            let bind = PortBind(address: address, family: family)
+            if var existing = groups[key] {
+                if !existing.binds.contains(bind) { existing.binds.append(bind) }
+                groups[key] = existing
+            } else {
+                groups[key] = (proc.command, [bind])
+                keyOrder.append(key)
+            }
+        }
+    }
+
+    return keyOrder.map { key in
+        let g = groups[key]!
+        let sortedBinds = g.binds.sorted { $0.family.rawValue < $1.family.rawValue }
+        return PortRecord(
+            port: key.port,
+            pid: key.pid,
+            processName: g.processName,
+            executablePath: nil,
+            commandLine: nil,
+            binds: sortedBinds
+        )
+    }
+}
+
+/// Parses the `n` field's `addr:port` value. Handles three forms:
+///   `*:3000`, `127.0.0.1:5000`, `[::1]:8080`, `[fe80::1%en0]:1234`.
+private func parseAddressPort(_ raw: String) -> (address: String, port: UInt16)? {
+    // IPv6 bracketed form
+    if raw.hasPrefix("[") {
+        guard let close = raw.firstIndex(of: "]") else { return nil }
+        let address = String(raw[raw.index(after: raw.startIndex)..<close])
+        let after = raw.index(after: close)
+        guard after < raw.endIndex, raw[after] == ":" else { return nil }
+        let portStr = raw[raw.index(after: after)...]
+        guard let port = UInt16(portStr) else { return nil }
+        return (address, port)
+    }
+    // Plain "address:port"
+    guard let lastColon = raw.lastIndex(of: ":") else { return nil }
+    let address = String(raw[raw.startIndex..<lastColon])
+    let portStr = raw[raw.index(after: lastColon)...]
+    guard let port = UInt16(portStr) else { return nil }
+    return (address, port)
+}
+
+/// lsof escapes non-printable bytes in command names as `\xHH`. Decode them back
+/// to UTF-8 bytes when possible. Spaces and printable ASCII pass through.
+private func decodeLsofEscapes(_ raw: String) -> String {
+    guard raw.contains("\\x") else { return raw }
+    var bytes: [UInt8] = []
+    let scalars = Array(raw.unicodeScalars)
+    var i = 0
+    while i < scalars.count {
+        if scalars[i] == "\\", i + 3 < scalars.count, scalars[i + 1] == "x",
+           let hi = hexNibble(scalars[i + 2]), let lo = hexNibble(scalars[i + 3]) {
+            bytes.append(UInt8(hi << 4 | lo))
+            i += 4
+        } else {
+            // Append the scalar's UTF-8 bytes
+            for byte in String(scalars[i]).utf8 { bytes.append(byte) }
+            i += 1
+        }
+    }
+    return String(decoding: bytes, as: UTF8.self)
+}
+
+private func hexNibble(_ s: Unicode.Scalar) -> UInt8? {
+    switch s {
+    case "0"..."9": return UInt8(s.value - Unicode.Scalar("0").value)
+    case "a"..."f": return UInt8(s.value - Unicode.Scalar("a").value + 10)
+    case "A"..."F": return UInt8(s.value - Unicode.Scalar("A").value + 10)
+    default: return nil
+    }
+}

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -1,57 +1,87 @@
 import SwiftUI
 import AppKit
+import Observation
 
-/// Hover-triggered NSWindow popover for the App Shortcuts submenu.
+/// Hover-triggered NSPanel popover.
 ///
-/// Owns its own NSWindow so it can position itself relative to the host view's screen frame,
-/// regardless of which window the trigger lives in. Uses a `HoverGate` to coordinate
-/// show/hide timing across the trigger view and the popover content.
+/// Used by both App Shortcuts (`needsKeyFocus = false`, read-only) and Port Manager
+/// (`needsKeyFocus = true`, needs to receive text input and local key events).
 ///
 /// Lifecycle:
-/// - Trigger view installs an `onHover` that arms the gate after 400ms.
-/// - Once shown, the popover keeps itself open while either the trigger or popover area
-///   contains the cursor; closes after 300ms of cursor leaving both.
+/// - Trigger view installs `onHover` that arms the gate after 400ms.
+/// - Popover stays open while either trigger or popover is hovered (gate manages).
+/// - Closes 300ms after both lose hover, OR immediately via `hide()`.
 @MainActor
+@Observable
 final class HoverPopover {
-    private let window: NSWindow
+    /// True while the underlying panel is keyWindow. Read by MenuBarView.onDisappear
+    /// to avoid hiding the popover when the menu bar panel collapses because we just
+    /// took key focus.
+    private(set) var isHoldingFocus: Bool = false
+
+    private let panel: KeyableHoverPanel
     private let hostingController: NSHostingController<AnyView>
     private var hideTask: Task<Void, Never>?
+    // nonisolated(unsafe) so deinit can access them without MainActor hop.
+    nonisolated(unsafe) private var keyObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var resignObserver: NSObjectProtocol?
+
+    /// Set to `true` for popovers whose SwiftUI content needs first-responder focus
+    /// (e.g. TextField). Leave `false` for read-only popovers — they keep the
+    /// historical "never becomes key" behaviour.
+    var needsKeyFocus: Bool = false {
+        didSet { panel.allowKey = needsKeyFocus }
+    }
 
     init<Content: View>(@ViewBuilder content: () -> Content) {
         let controller = NSHostingController(rootView: AnyView(content()))
-        // Let the hosting controller resize itself to match SwiftUI's fitting size,
-        // so the NSWindow tracks the content's intrinsic dimensions automatically.
         controller.sizingOptions = [.preferredContentSize]
         self.hostingController = controller
 
-        let window = NSWindow(
+        let panel = KeyableHoverPanel(
             contentRect: NSRect(x: 0, y: 0, width: 240, height: 200),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.hasShadow = true
-        window.level = .floating
-        window.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
-        window.contentViewController = controller
-        // .nonactivating equivalent: ignoresMouseEvents = false + level floating + don't make key
-        self.window = window
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+        panel.contentViewController = controller
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.hidesOnDeactivate = false
+        self.panel = panel
+
+        // Track key state so MenuBarView can guard onDisappear.
+        keyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isHoldingFocus = true }
+        }
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isHoldingFocus = false }
+        }
+    }
+
+    deinit {
+        if let keyObserver { NotificationCenter.default.removeObserver(keyObserver) }
+        if let resignObserver { NotificationCenter.default.removeObserver(resignObserver) }
     }
 
     func updateContent<Content: View>(@ViewBuilder content: () -> Content) {
         hostingController.rootView = AnyView(content())
-        // Force layout so fittingSize reflects the new content before show() reads it.
         hostingController.view.layoutSubtreeIfNeeded()
         let fitting = hostingController.view.fittingSize
         if fitting.width > 0 && fitting.height > 0 {
-            window.setContentSize(fitting)
+            panel.setContentSize(fitting)
         }
     }
 
     /// Show the popover anchored to the right side of `referenceFrame` (screen coordinates).
-    /// If insufficient space on the right, flips to the left.
     func show(anchoredTo referenceFrame: NSRect) {
         hideTask?.cancel()
         hideTask = nil
@@ -59,8 +89,7 @@ final class HoverPopover {
         let screen = NSScreen.screens.first(where: { $0.frame.intersects(referenceFrame) }) ?? NSScreen.main
         let screenFrame = screen?.visibleFrame ?? .zero
 
-        let size = window.frame.size
-
+        let size = panel.frame.size
         let rightX = referenceFrame.maxX + 4
         let leftX = referenceFrame.minX - 4 - size.width
         let originX = (rightX + size.width <= screenFrame.maxX) ? rightX : leftX
@@ -68,17 +97,19 @@ final class HoverPopover {
                           min(referenceFrame.midY - size.height / 2,
                               screenFrame.maxY - size.height))
 
-        window.setFrameOrigin(NSPoint(x: originX, y: originY))
-        window.orderFrontRegardless()
+        panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+        panel.orderFrontRegardless()
+        if needsKeyFocus {
+            panel.makeKey()
+        }
     }
 
-    /// Schedule a hide. Cancelled if `keepOpen()` is called within the delay.
     func scheduleHide(after delay: TimeInterval = 0.3) {
         hideTask?.cancel()
         hideTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             guard let self, !Task.isCancelled else { return }
-            self.window.orderOut(nil)
+            self.panel.orderOut(nil)
         }
     }
 
@@ -90,15 +121,20 @@ final class HoverPopover {
     func hide() {
         hideTask?.cancel()
         hideTask = nil
-        window.orderOut(nil)
+        panel.orderOut(nil)
     }
 }
 
-/// Coordinates hover-to-open / leave-to-close timing between a trigger view and a popover.
-///
-/// Use one instance per popover. The trigger view calls `hoverEnter()`/`hoverExit()`
-/// from a `.onHover` modifier; the popover content view does the same from its own
-/// `.onHover`. The popover stays open while either reports hovered.
+/// NSPanel subclass whose key-eligibility is controlled by an opt-in flag.
+/// App Shortcuts uses `allowKey = false` (read-only), Port Manager uses `true`.
+final class KeyableHoverPanel: NSPanel {
+    var allowKey: Bool = false
+    override var canBecomeKey: Bool { allowKey }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - HoverGate (unchanged plus new reset())
+
 @MainActor
 @Observable
 final class HoverGate {
@@ -130,12 +166,27 @@ final class HoverGate {
         }
     }
 
+    /// Forcibly reset all tracked hover state. Used by the port-manager ESC
+    /// path to clear the gate before the popover is dismissed programmatically.
+    func reset() {
+        showTask?.cancel()
+        hideTask?.cancel()
+        showTask = nil
+        hideTask = nil
+        triggerHovered = false
+        popoverHovered = false
+        if isShown {
+            isShown = false
+            onHide()
+        }
+    }
+
     private func scheduleShow() {
         guard !isShown else { return }
         hideTask?.cancel()
         showTask?.cancel()
         showTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 400_000_000) // 400ms
+            try? await Task.sleep(nanoseconds: 400_000_000)
             guard let self, !Task.isCancelled, self.triggerHovered else { return }
             self.isShown = true
             self.onShow()
@@ -146,7 +197,7 @@ final class HoverGate {
         guard isShown else { return }
         hideTask?.cancel()
         hideTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
+            try? await Task.sleep(nanoseconds: 300_000_000)
             guard let self, !Task.isCancelled else { return }
             guard !self.triggerHovered && !self.popoverHovered else { return }
             self.isShown = false

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -3,11 +3,13 @@ import AppKit
 
 struct MenuBarView: View {
     @State private var panel = PanelStore.shared
-    @State private var popover = HoverPopover {
-        EmptyView()
-    }
+    @State private var popover = HoverPopover { EmptyView() }
     @State private var gate = HoverGate()
-    @State private var triggerFrame: NSRect = .zero
+    // One trigger frame per submenu builtin so hover-anchored popovers can be
+    // mounted from any `.submenu`-kind row, not just App Shortcuts.
+    @State private var triggerFrames: [BuiltinItem: NSRect] = [:]
+    // The submenu whose popover should be mounted on the next `gate.onShow`.
+    @State private var activeSubmenu: BuiltinItem? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -54,42 +56,47 @@ struct MenuBarView: View {
             await panel.refreshAll()
         }
         .onAppear { wireGate() }
-        .onDisappear { popover.hide() }
+        .onDisappear {
+            // Don't hide if the popover took key focus deliberately (port-manager
+            // search field). Otherwise hide as before.
+            if !popover.isHoldingFocus { popover.hide() }
+        }
     }
 
     @ViewBuilder
     private func rowView(for entry: PanelEntry) -> some View {
-        if case .builtin(.appShortcuts) = entry.source {
+        if case let .builtin(item) = entry.source, item.kind == .submenu {
             PanelRowView(
                 entry: entry,
                 onToggle: {},
                 onAction: {},
-                onSubmenu: { triggerSubmenu() },
+                onSubmenu: { triggerSubmenu(item) },
                 onPermission: openPermissionsSettings
             )
             .background(
                 GeometryReader { proxy in
                     Color.clear.onAppear {
-                        triggerFrame = proxy.frame(in: .global)
+                        triggerFrames[item] = proxy.frame(in: .global)
                     }.onChange(of: proxy.frame(in: .global)) { _, new in
-                        triggerFrame = new
+                        triggerFrames[item] = new
                     }
                 }
             )
             .onHover { hovered in
+                if hovered { activeSubmenu = item }
                 gate.triggerHover(hovered)
             }
         } else {
             PanelRowView(
                 entry: entry,
                 onToggle: {
-                    if case let .builtin(item) = entry.source {
-                        Task { await panel.toggle(item) }
+                    if case let .builtin(builtin) = entry.source {
+                        Task { await panel.toggle(builtin) }
                     }
                 },
                 onAction: {
-                    if case let .builtin(item) = entry.source {
-                        Task { await panel.run(item) }
+                    if case let .builtin(builtin) = entry.source {
+                        Task { await panel.run(builtin) }
                     }
                 },
                 onSubmenu: {},
@@ -100,6 +107,22 @@ struct MenuBarView: View {
 
     private func wireGate() {
         gate.onShow = {
+            guard let item = activeSubmenu else { return }
+            mountPopoverContent(for: item)
+            popover.show(anchoredTo: convertedTriggerFrame(for: item))
+        }
+        gate.onHide = {
+            popover.scheduleHide()
+            popover.needsKeyFocus = false
+        }
+    }
+
+    /// Mount the SwiftUI content appropriate for `item` and toggle the
+    /// popover's `needsKeyFocus` flag for views that need first-responder.
+    private func mountPopoverContent(for item: BuiltinItem) {
+        switch item {
+        case .appShortcuts:
+            popover.needsKeyFocus = false
             popover.updateContent {
                 AppShortcutsPopoverView(
                     entries: panel.appShortcutChildren,
@@ -120,21 +143,36 @@ struct MenuBarView: View {
                     }
                 )
             }
-            popover.show(anchoredTo: convertedTriggerFrame())
+        case .portManager:
+            popover.needsKeyFocus = true
+            popover.updateContent {
+                PortManagerPopoverView(
+                    inventory: PortInventory.shared,
+                    onHoverChange: { gate.popoverHover($0) },
+                    onClose: {
+                        PortInventory.shared.searchText = ""
+                        gate.reset()
+                        popover.hide()
+                    }
+                )
+            }
+        default:
+            break
         }
-        gate.onHide = { popover.scheduleHide() }
     }
 
-    /// Convert the panel-local triggerFrame to global screen coordinates by adding
-    /// the menu bar window's frame origin (set by AppKit when the popover opens).
-    private func convertedTriggerFrame() -> NSRect {
-        guard let window = NSApp.windows.first(where: { $0.isVisible }) else {
-            return triggerFrame
-        }
-        return window.convertToScreen(triggerFrame)
+    /// Convert the panel-local rect to screen coordinates by adding the menu
+    /// bar window's origin. Same approach as the previous single-trigger impl.
+    private func convertedTriggerFrame(for item: BuiltinItem) -> NSRect {
+        let local = triggerFrames[item] ?? .zero
+        guard let window = NSApp.windows.first(where: { $0.isVisible }) else { return local }
+        return window.convertToScreen(local)
     }
 
-    private func triggerSubmenu() { gate.showImmediately() }
+    private func triggerSubmenu(_ item: BuiltinItem) {
+        activeSubmenu = item
+        gate.showImmediately()
+    }
 
     private func openPermissionsSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -161,12 +161,29 @@ struct MenuBarView: View {
         }
     }
 
-    /// Convert the panel-local rect to screen coordinates by adding the menu
-    /// bar window's origin. Same approach as the previous single-trigger impl.
+    /// Convert the panel-local rect (SwiftUI `.global`, top-left origin) to
+    /// screen coordinates. SwiftUI's Y increases downward while NSWindow uses
+    /// bottom-left origin, so we flip Y against the window's content height
+    /// before letting AppKit convert to screen space. The popover panel is
+    /// excluded from the lookup so a second hover doesn't accidentally anchor
+    /// against the already-open popover window.
     private func convertedTriggerFrame(for item: BuiltinItem) -> NSRect {
         let local = triggerFrames[item] ?? .zero
-        guard let window = NSApp.windows.first(where: { $0.isVisible }) else { return local }
-        return window.convertToScreen(local)
+        guard let window = menuBarPanelWindow() else { return local }
+        let panelHeight = window.frame.height
+        let flipped = NSRect(
+            x: local.origin.x,
+            y: panelHeight - local.origin.y - local.size.height,
+            width: local.size.width,
+            height: local.size.height
+        )
+        return window.convertToScreen(flipped)
+    }
+
+    private func menuBarPanelWindow() -> NSWindow? {
+        NSApp.windows.first { window in
+            window.isVisible && !(window is KeyableHoverPanel)
+        }
     }
 
     private func triggerSubmenu(_ item: BuiltinItem) {

--- a/Sources/AnyDoor/Views/PanelSettingsView.swift
+++ b/Sources/AnyDoor/Views/PanelSettingsView.swift
@@ -89,9 +89,10 @@ struct PanelSettingsView: View {
 
     @ViewBuilder
     private func hotkeyField(for entry: PanelEntry) -> some View {
-        if case .builtin(.appShortcuts) = entry.source {
-            // The submenu itself has no hotkey (children do); reserve column width
-            // for alignment without showing a meaningless placeholder.
+        // Any submenu-kind builtin has no hotkey (children carry their own, or
+        // the submenu is opened by hovering). Reserve the column width so the
+        // grid stays aligned.
+        if case let .builtin(item) = entry.source, item.kind == .submenu {
             Color.clear.frame(width: 130)
         } else {
             HotkeyRecorder(hotkey: .constant(entry.hotkey)) { newValue in

--- a/Sources/AnyDoor/Views/PortListView.swift
+++ b/Sources/AnyDoor/Views/PortListView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+struct PortListView: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(inventory.filteredRecords) { record in
+                    PortRowView(record: record, inventory: inventory)
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+struct PortRowView: View {
+    let record: PortRecord
+    @Bindable var inventory: PortInventory
+    @State private var isHovered = false
+
+    private var rowState: PortStatusDot.State {
+        if inventory.failedKillPIDs[record.pid] != nil { return .failed }
+        if inventory.killingPIDs.contains(record.pid)  { return .killing }
+        return .listening
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            PortStatusDot(state: rowState).frame(width: 10)
+            Text(":\(record.port)")
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .frame(minWidth: 60, alignment: .leading)
+            Text(record.processName)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("PID \(record.pid)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            trailingControl
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(isHovered ? Color.white.opacity(0.04) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .help(tooltipText)
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch rowState {
+        case .killing:
+            ProgressView().controlSize(.small)
+        case .failed:
+            Button {
+                inventory.dismissError(for: record.pid)
+            } label: {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+        case .listening:
+            if isHovered {
+                Button {
+                    Task { await inventory.kill(pid: record.pid) }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("kill PID \(record.pid)")
+            } else {
+                Color.clear.frame(width: 16, height: 16)
+            }
+        }
+    }
+
+    private var tooltipText: String {
+        var lines: [String] = [record.processName]
+        if let cmd = record.commandLine, !cmd.isEmpty, cmd != record.processName {
+            lines.append(cmd)
+        }
+        if let path = record.executablePath, !path.isEmpty { lines.append(path) }
+        lines.append("")
+        lines.append("Binds:")
+        for bind in record.binds {
+            lines.append("  \(bind.address) (\(bind.family.rawValue))")
+        }
+        if let failure = inventory.failedKillPIDs[record.pid] {
+            lines.append("")
+            switch failure.reason {
+            case .permissionDenied:
+                lines.append("kill 失败：权限不足（系统/其他用户进程）")
+            case .processGone:
+                lines.append("kill 失败：进程已退出")
+            case .other(let code):
+                lines.append("kill 失败 (errno: \(code))")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct PortStatusDot: View {
+    enum State { case listening, killing, failed }
+    let state: State
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+    }
+
+    private var color: Color {
+        switch state {
+        case .listening: return .green
+        case .killing:   return .gray
+        case .failed:    return .red
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/PortListView.swift
+++ b/Sources/AnyDoor/Views/PortListView.swift
@@ -8,7 +8,10 @@ struct PortListView: View {
             LazyVStack(spacing: 0) {
                 ForEach(inventory.filteredRecords) { record in
                     PortRowView(record: record, inventory: inventory)
-                    Divider()
+                    // Skip the trailing divider after the last row to avoid a dangling line.
+                    if record.id != inventory.filteredRecords.last?.id {
+                        Divider()
+                    }
                 }
             }
         }
@@ -19,6 +22,10 @@ struct PortRowView: View {
     let record: PortRecord
     @Bindable var inventory: PortInventory
     @State private var isHovered = false
+
+    /// Shared width for the trailing slot so kill / error / placeholder all align
+    /// and the row doesn't jitter as the hover state toggles the button in and out.
+    private static let trailingSlotWidth: CGFloat = 22
 
     private var rowState: PortStatusDot.State {
         if inventory.failedKillPIDs[record.pid] != nil { return .failed }
@@ -43,7 +50,10 @@ struct PortRowView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(isHovered ? Color.white.opacity(0.04) : Color.clear)
+        // Interactive Liquid Glass styling matches PanelRowView / AppShortcutsPopoverView.
+        // `.interactive()` handles its own hover affordance, replacing the previous
+        // hardcoded white tint that was invisible in Light Mode.
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }
         .help(tooltipText)
@@ -53,15 +63,20 @@ struct PortRowView: View {
     private var trailingControl: some View {
         switch rowState {
         case .killing:
-            ProgressView().controlSize(.small)
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
         case .failed:
             Button {
                 inventory.dismissError(for: record.pid)
             } label: {
                 Image(systemName: "exclamationmark.circle.fill")
                     .foregroundStyle(.red)
+                    .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
             }
             .buttonStyle(.plain)
+            .help("清除错误提示")
+            .accessibilityLabel("清除错误提示")
         case .listening:
             if isHovered {
                 Button {
@@ -69,11 +84,12 @@ struct PortRowView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(.secondary)
+                        .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
                 }
                 .buttonStyle(.plain)
-                .help("kill PID \(record.pid)")
+                .help("终止 PID \(record.pid)")
             } else {
-                Color.clear.frame(width: 16, height: 16)
+                Color.clear.frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
             }
         }
     }
@@ -85,7 +101,7 @@ struct PortRowView: View {
         }
         if let path = record.executablePath, !path.isEmpty { lines.append(path) }
         lines.append("")
-        lines.append("Binds:")
+        lines.append("绑定地址：")
         for bind in record.binds {
             lines.append("  \(bind.address) (\(bind.family.rawValue))")
         }
@@ -93,11 +109,11 @@ struct PortRowView: View {
             lines.append("")
             switch failure.reason {
             case .permissionDenied:
-                lines.append("kill 失败：权限不足（系统/其他用户进程）")
+                lines.append("终止失败：权限不足（系统/其他用户进程）")
             case .processGone:
-                lines.append("kill 失败：进程已退出")
+                lines.append("终止失败：进程已退出")
             case .other(let code):
-                lines.append("kill 失败 (errno: \(code))")
+                lines.append("终止失败 (errno: \(code))")
             }
         }
         return lines.joined(separator: "\n")

--- a/Sources/AnyDoor/Views/PortListView.swift
+++ b/Sources/AnyDoor/Views/PortListView.swift
@@ -36,14 +36,14 @@ struct PortRowView: View {
     var body: some View {
         HStack(spacing: 12) {
             PortStatusDot(state: rowState).frame(width: 10)
-            Text(":\(record.port)")
+            Text(verbatim: ":\(record.port)")
                 .font(.system(.body, design: .monospaced).weight(.semibold))
                 .frame(minWidth: 60, alignment: .leading)
             Text(record.processName)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text("PID \(record.pid)")
+            Text(verbatim: "PID \(record.pid)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             trailingControl

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -1,0 +1,265 @@
+import SwiftUI
+import AppKit
+
+/// Root SwiftUI view shown inside the Port Manager `HoverPopover`.
+///
+/// Assembles the header (search + count badge), optional error banner, the
+/// scrollable content area (PortListView / PortTreeView / loading / empty),
+/// and the bottom toolbar (refresh + view-mode toggle). A `KeyboardMonitor`
+/// helper is mounted as a background view so ⌘R / ⌘T / ESC work while the
+/// popover holds key focus.
+struct PortManagerPopoverView: View {
+    @Bindable var inventory: PortInventory
+    var onHoverChange: (Bool) -> Void
+    var onClose: () -> Void
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PortManagerHeader(
+                inventory: inventory,
+                searchFocused: $searchFocused
+            )
+            if let err = inventory.lastError {
+                PortScanErrorBanner(error: err) {
+                    Task { await inventory.refresh() }
+                }
+            }
+            content
+            Divider()
+            PortManagerToolbar(inventory: inventory)
+        }
+        .frame(width: 340)
+        .frame(minHeight: 280, maxHeight: 560)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .task {
+            await inventory.refresh()
+            searchFocused = true
+        }
+        .onHover(perform: onHoverChange)
+        .background(KeyboardMonitor(inventory: inventory, onClose: onClose))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if inventory.isRefreshing && inventory.records.isEmpty {
+            VStack {
+                Spacer()
+                ProgressView("扫描中...")
+                Spacer()
+            }
+        } else if inventory.filteredRecords.isEmpty {
+            VStack {
+                Spacer()
+                Text("无匹配的端口").foregroundStyle(.secondary)
+                Spacer()
+            }
+        } else {
+            switch inventory.viewMode {
+            case .list: PortListView(inventory: inventory)
+            case .tree: PortTreeView(inventory: inventory)
+            }
+        }
+    }
+}
+
+// MARK: - Header
+
+private struct PortManagerHeader: View {
+    @Bindable var inventory: PortInventory
+    var searchFocused: FocusState<Bool>.Binding
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "globe").foregroundStyle(.secondary)
+            TextField("搜索端口或进程...", text: $inventory.searchText)
+                .textFieldStyle(.plain)
+                .focused(searchFocused)
+            ZStack {
+                if inventory.isRefreshing {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("\(inventory.filteredRecords.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 8).padding(.vertical, 2)
+            .background(Capsule().fill(Color.secondary.opacity(0.15)))
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+    }
+}
+
+// MARK: - Toolbar
+
+private struct PortManagerToolbar: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            toolbarButton(
+                action: { Task { await inventory.refresh() } },
+                label: "刷新",
+                systemImage: "arrow.clockwise",
+                shortcut: "⌘R"
+            )
+            toolbarButton(
+                action: {
+                    inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list
+                },
+                label: inventory.viewMode == .list ? "树状视图" : "列表视图",
+                systemImage: "list.bullet.indent",
+                shortcut: "⌘T"
+            )
+        }
+        .padding(.horizontal, 6).padding(.vertical, 4)
+    }
+
+    private func toolbarButton(
+        action: @escaping () -> Void,
+        label: String,
+        systemImage: String,
+        shortcut: String
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Label(label, systemImage: systemImage)
+                Spacer()
+                Text(shortcut).foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 6)
+            // Make the entire row strip clickable (label + spacer + shortcut),
+            // not just the text/icon. Matches the pattern used in PortListView /
+            // PortTreeView / AppShortcutsPopoverView for consistent affordance.
+            .contentShape(Rectangle())
+            .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Error banner
+
+private struct PortScanErrorBanner: View {
+    let error: PortInventoryError
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+            Text(message).font(.caption)
+            Spacer()
+            Button(action: retry) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .help("刷新")
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+        // Flat yellow tint keeps the banner visually distinct from the
+        // `.regularMaterial` parent background. Intentionally no clipShape:
+        // the popover already rounds the outer envelope, and rounding this
+        // strip would create misaligned corners against the header divider.
+        .background(Color.yellow.opacity(0.15))
+    }
+
+    private var message: String {
+        switch error {
+        case .scanFailed(let detail):
+            return "刷新失败：\(detail)"
+        }
+    }
+}
+
+// MARK: - Keyboard monitor
+
+/// Installs a local NSEvent key-down monitor while mounted. Handles ⌘R, ⌘T, ESC.
+///
+/// `NSEvent.addLocalMonitorForEvents` delivers its handler on the main thread,
+/// so the closure body uses `MainActor.assumeIsolated` to access the
+/// `@MainActor`-isolated `PortInventory` directly without a `Task` hop. The
+/// Coordinator itself is `@MainActor`-isolated to satisfy Swift 6 strict
+/// concurrency when its properties are captured by the handler closure.
+private struct KeyboardMonitor: NSViewRepresentable {
+    @Bindable var inventory: PortInventory
+    var onClose: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(inventory: inventory, onClose: onClose)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.install()
+        return NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onClose = onClose
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    @MainActor
+    final class Coordinator {
+        let inventory: PortInventory
+        var onClose: () -> Void
+        // The NSEvent monitor token is created and torn down on the main
+        // thread; `nonisolated(unsafe)` lets `uninstall()` run safely.
+        nonisolated(unsafe) private var monitor: Any?
+
+        init(inventory: PortInventory, onClose: @escaping () -> Void) {
+            self.inventory = inventory
+            self.onClose = onClose
+        }
+
+        deinit {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+        }
+
+        func install() {
+            uninstall()
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                // addLocalMonitorForEvents dispatches on the main thread, so we
+                // can safely access @MainActor-isolated state via
+                // `MainActor.assumeIsolated`. We avoid carrying `event` across
+                // the isolation boundary (NSEvent isn't Sendable) by extracting
+                // only the bits we need and computing a bool result.
+                let cmd = event.modifierFlags.contains(.command)
+                let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
+                let keyCode = event.keyCode
+                let consumed: Bool = MainActor.assumeIsolated {
+                    guard let self else { return false }
+                    if cmd && chars == "r" {
+                        Task { await self.inventory.refresh() }
+                        return true
+                    }
+                    if cmd && chars == "t" {
+                        self.inventory.viewMode =
+                            (self.inventory.viewMode == .list) ? .tree : .list
+                        return true
+                    }
+                    if keyCode == 53 { // ESC
+                        if self.inventory.searchText.isEmpty {
+                            self.onClose()
+                        } else {
+                            self.inventory.searchText = ""
+                        }
+                        return true
+                    }
+                    return false
+                }
+                return consumed ? nil : event
+            }
+        }
+
+        func uninstall() {
+            if let m = monitor { NSEvent.removeMonitor(m) }
+            monitor = nil
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/PortTreeView.swift
+++ b/Sources/AnyDoor/Views/PortTreeView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+struct PortTreeView: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(inventory.groupedByProcess) { group in
+                    PortProcessGroupRow(group: group, inventory: inventory)
+                    // Skip the trailing divider after the last row to avoid a dangling line.
+                    if group.id != inventory.groupedByProcess.last?.id {
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct PortProcessGroupRow: View {
+    let group: ProcessGroup
+    @Bindable var inventory: PortInventory
+    @State private var isExpanded: Bool = false
+    @State private var isHeaderHovered: Bool = false
+
+    /// Shared width for the trailing slot so kill / error / placeholder all align
+    /// and the row doesn't jitter as the hover state toggles the button in and out.
+    private static let trailingSlotWidth: CGFloat = 22
+
+    private var rowState: PortStatusDot.State {
+        if inventory.failedKillPIDs[group.pid] != nil { return .failed }
+        if inventory.killingPIDs.contains(group.pid)  { return .killing }
+        return .listening
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if isExpanded {
+                ForEach(group.ports) { record in
+                    leaf(record)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 8) {
+            Button {
+                isExpanded.toggle()
+            } label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .frame(width: 12)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+            PortStatusDot(state: rowState).frame(width: 10)
+            Text(group.processName)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("PID \(group.pid)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if !isExpanded {
+                Text("\(group.ports.count)")
+                    .font(.caption)
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Capsule().fill(Color.secondary.opacity(0.15)))
+            }
+            trailingControl
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        // `contentShape` before `glassEffect` ensures the entire header row remains
+        // hit-testable (chevron button + hover detection) even with the glass overlay.
+        .contentShape(Rectangle())
+        // Interactive Liquid Glass styling matches PortListView / PanelRowView /
+        // AppShortcutsPopoverView. `.interactive()` provides its own hover affordance,
+        // replacing the previous hardcoded white tint that was invisible in Light Mode.
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        .onHover { isHeaderHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch rowState {
+        case .killing:
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
+        case .failed:
+            Button {
+                inventory.dismissError(for: group.pid)
+            } label: {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
+            }
+            .buttonStyle(.plain)
+            .help("清除错误提示")
+            .accessibilityLabel("清除错误提示")
+        case .listening:
+            if isHeaderHovered {
+                Button {
+                    Task { await inventory.kill(pid: group.pid) }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                        .frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
+                }
+                .buttonStyle(.plain)
+                .help("终止 PID \(group.pid)")
+            } else {
+                Color.clear.frame(width: Self.trailingSlotWidth, height: Self.trailingSlotWidth)
+            }
+        }
+    }
+
+    private func leaf(_ record: PortRecord) -> some View {
+        HStack(spacing: 12) {
+            Spacer().frame(width: 28)
+            Text(":\(record.port)")
+                .font(.system(.body, design: .monospaced))
+                .frame(minWidth: 60, alignment: .leading)
+            Text(bindSummary(for: record))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .help(record.binds.map { "\($0.address) (\($0.family.rawValue))" }.joined(separator: "\n"))
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    private func bindSummary(for record: PortRecord) -> String {
+        let binds = record.binds
+        switch binds.count {
+        case 0:
+            return ""
+        case 1:
+            return binds[0].address
+        case 2:
+            if Set(binds.map(\.family)) == Set([.ipv4, .ipv6]) {
+                let v4 = binds.first(where: { $0.family == .ipv4 })?.address ?? ""
+                let v6 = binds.first(where: { $0.family == .ipv6 })?.address ?? ""
+                return "\(v4) · \(v6)"
+            }
+            return binds.map(\.address).joined(separator: " · ")
+        default:
+            return "\(binds.count) 个绑定"
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/PortTreeView.swift
+++ b/Sources/AnyDoor/Views/PortTreeView.swift
@@ -62,11 +62,11 @@ private struct PortProcessGroupRow: View {
                 .fontWeight(.semibold)
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text("PID \(group.pid)")
+            Text(verbatim: "PID \(group.pid)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if !isExpanded {
-                Text("\(group.ports.count)")
+                Text(verbatim: "\(group.ports.count)")
                     .font(.caption)
                     .padding(.horizontal, 6).padding(.vertical, 2)
                     .background(Capsule().fill(Color.secondary.opacity(0.15)))
@@ -123,7 +123,7 @@ private struct PortProcessGroupRow: View {
     private func leaf(_ record: PortRecord) -> some View {
         HStack(spacing: 12) {
             Spacer().frame(width: 28)
-            Text(":\(record.port)")
+            Text(verbatim: ":\(record.port)")
                 .font(.system(.body, design: .monospaced))
                 .frame(minWidth: 60, alignment: .leading)
             Text(bindSummary(for: record))

--- a/Tests/AnyDoorTests/Fixtures/lsof-command-spaces.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-command-spaces.txt
@@ -1,0 +1,7 @@
+p1234
+cGoogle Chrome Helper
+LZinger
+f99
+PTCP
+tIPv4
+n*:9222

--- a/Tests/AnyDoorTests/Fixtures/lsof-dual-stack.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-dual-stack.txt
@@ -1,0 +1,11 @@
+p75837
+cControlCenter
+LZinger
+f17
+PTCP
+tIPv4
+n*:5000
+f18
+PTCP
+tIPv6
+n*:5000

--- a/Tests/AnyDoorTests/Fixtures/lsof-escape.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-escape.txt
@@ -1,0 +1,7 @@
+p5555
+cweird\x20name
+LZinger
+f1
+PTCP
+tIPv4
+n*:7777

--- a/Tests/AnyDoorTests/Fixtures/lsof-ipv6-zone.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-ipv6-zone.txt
@@ -1,0 +1,7 @@
+p999
+clinkservice
+LZinger
+f7
+PTCP
+tIPv6
+n[fe80::1%en0]:1234

--- a/Tests/AnyDoorTests/Fixtures/lsof-multi-bind.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-multi-bind.txt
@@ -1,0 +1,11 @@
+p4242
+cmyserver
+LZinger
+f10
+PTCP
+tIPv4
+n127.0.0.1:5000
+f11
+PTCP
+tIPv4
+n0.0.0.0:5000

--- a/Tests/AnyDoorTests/Fixtures/lsof-multi-port.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-multi-port.txt
@@ -1,0 +1,15 @@
+p898
+cOrbStack Helper
+LZinger
+f17
+PTCP
+tIPv4
+n*:80
+f18
+PTCP
+tIPv4
+n*:443
+f19
+PTCP
+tIPv4
+n*:5432

--- a/Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt
+++ b/Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt
@@ -1,0 +1,7 @@
+p67035
+cnode
+LZinger
+f17
+PTCP
+tIPv4
+n*:3000

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -8,4 +8,22 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertEqual(BuiltinItem.portManager.title, "端口管理")
         XCTAssertEqual(BuiltinItem.portManager.symbol, "network")
     }
+
+    func testPortRecordIdComposition() {
+        let r = PortRecord(
+            port: 3000,
+            pid: 67035,
+            processName: "node",
+            executablePath: nil,
+            commandLine: nil,
+            binds: [PortBind(address: "*", family: .ipv4)]
+        )
+        XCTAssertEqual(r.id, "67035-3000")
+    }
+
+    func testSignalResultEquatable() {
+        XCTAssertEqual(SignalResult.success, SignalResult.success)
+        XCTAssertEqual(SignalResult.failure(.EPERM), SignalResult.failure(.EPERM))
+        XCTAssertNotEqual(SignalResult.success, SignalResult.failure(.EPERM))
+    }
 }

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -36,4 +36,44 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertEqual(r.exit, 0)
         XCTAssertFalse(r.timedOut)
     }
+
+    @MainActor
+    func testViewModeDefaultsToList() {
+        let defaults = isolatedDefaults()
+        let inventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        XCTAssertEqual(inventory.viewMode, .list)
+    }
+
+    @MainActor
+    func testViewModePersistsToDefaults() {
+        let defaults = isolatedDefaults()
+        let inventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        inventory.viewMode = .tree
+
+        // New instance reads back the persisted value.
+        let inventory2 = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        XCTAssertEqual(inventory2.viewMode, .tree)
+    }
+
+    // Test helpers
+    private struct StubScanner: PortScanning {
+        let records: [PortRecord]
+        var killBehavior: @Sendable (pid_t, Int32) -> SignalResult = { _, _ in .success }
+        func scanTCPListening() async throws -> [PortRecord] { records }
+        func kill(pid: pid_t, signal: Int32) -> SignalResult { killBehavior(pid, signal) }
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suite = "PortInventoryTests-\(UUID().uuidString)"
+        return UserDefaults(suiteName: suite)!
+    }
 }

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -76,4 +76,95 @@ final class PortInventoryTests: XCTestCase {
         let suite = "PortInventoryTests-\(UUID().uuidString)"
         return UserDefaults(suiteName: suite)!
     }
+
+    /// Scanner that lets the test resolve `scanTCPListening()` on demand.
+    private actor BlockingScanner: PortScanning {
+        struct Pending {
+            let continuation: CheckedContinuation<[PortRecord], Error>
+        }
+        private var queue: [Pending] = []
+        private(set) var calls = 0
+        func resolve(with records: [PortRecord]) async {
+            calls += 1
+            if let next = queue.first {
+                queue.removeFirst()
+                next.continuation.resume(returning: records)
+            }
+        }
+        func fail(with error: Error) async {
+            if let next = queue.first {
+                queue.removeFirst()
+                next.continuation.resume(throwing: error)
+            }
+        }
+        func scanTCPListening() async throws -> [PortRecord] {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<[PortRecord], Error>) in
+                queue.append(Pending(continuation: cont))
+            }
+        }
+        nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
+    }
+
+    @MainActor
+    func testRefreshPopulatesRecords() async {
+        let stub = StubScanner(records: [
+            PortRecord(port: 3000, pid: 1, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        let inv = PortInventory(scanner: stub, defaults: isolatedDefaults())
+        await inv.refresh()
+        XCTAssertEqual(inv.records.count, 1)
+        XCTAssertEqual(inv.records[0].port, 3000)
+        XCTAssertFalse(inv.isRefreshing)
+        XCTAssertNil(inv.lastError)
+    }
+
+    @MainActor
+    func testRefreshFailurePreservesRecordsAndSetsError() async {
+        struct ThrowingScanner: PortScanning {
+            func scanTCPListening() async throws -> [PortRecord] {
+                throw PortScanError.lsofFailed(exitCode: 2, stderr: "boom")
+            }
+            func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
+        }
+        let inv = PortInventory(scanner: ThrowingScanner(), defaults: isolatedDefaults())
+        // Seed records via a stub first refresh would be ideal; here we just verify error path.
+        await inv.refresh()
+        XCTAssertNotNil(inv.lastError)
+        XCTAssertFalse(inv.isRefreshing)
+    }
+
+    @MainActor
+    func testIsRefreshingClearsOnlyWhenAllInflightFinish() async throws {
+        let scanner = BlockingScanner()
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+
+        // Start refresh #1 — it blocks awaiting the scanner.
+        let t1: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "first refresh should mark isRefreshing")
+
+        // Start refresh #2 — also blocked.
+        let t2: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "still refreshing with two in flight")
+
+        // Resolve the older one (refresh #1) first.
+        await scanner.resolve(with: [])
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "stale completion must NOT clear isRefreshing while #2 is still running")
+
+        // Resolve the newer one.
+        await scanner.resolve(with: [
+            PortRecord(port: 9, pid: 2, processName: "x",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        await t1.value
+        await t2.value
+        XCTAssertFalse(inv.isRefreshing)
+        XCTAssertEqual(inv.records.count, 1)
+        XCTAssertEqual(inv.records[0].port, 9)
+    }
 }

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import AnyDoor
+
+final class PortInventoryTests: XCTestCase {
+    func testBuiltinItemPortManagerExists() {
+        XCTAssertTrue(BuiltinItem.allCases.contains(.portManager))
+        XCTAssertEqual(BuiltinItem.portManager.kind, .submenu)
+        XCTAssertEqual(BuiltinItem.portManager.title, "端口管理")
+        XCTAssertEqual(BuiltinItem.portManager.symbol, "network")
+    }
+}

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -240,4 +240,69 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertEqual(inv.records.count, 1)
         XCTAssertEqual(inv.records[0].port, 9)
     }
+
+    @MainActor
+    func testFilteredEmptyQueryReturnsPortAscending() async {
+        let recs = [
+            PortRecord(port: 5000, pid: 1, processName: "a", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 80, pid: 2, processName: "b", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 3000, pid: 3, processName: "c", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        XCTAssertEqual(inv.filteredRecords.map(\.port), [80, 3000, 5000])
+    }
+
+    @MainActor
+    func testSearchPriorityPortBeforeNameBeforePid() async {
+        let recs = [
+            PortRecord(port: 3000, pid: 99, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 8080, pid: 30,  processName: "java",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        inv.searchText = "30"
+        // Port :3000 matches the "30" substring; pid 30 also matches. Port should come first.
+        XCTAssertEqual(inv.filteredRecords.map(\.port), [3000, 8080])
+    }
+
+    @MainActor
+    func testSearchIsCaseInsensitive() async {
+        let recs = [
+            PortRecord(port: 1, pid: 1, processName: "NodeProcess",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        inv.searchText = "node"
+        XCTAssertEqual(inv.filteredRecords.count, 1)
+    }
+
+    @MainActor
+    func testGroupedByProcessSortsByNameThenPort() async {
+        let recs = [
+            PortRecord(port: 5000, pid: 10, processName: "bravo",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 80, pid: 10, processName: "bravo",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 22, pid: 20, processName: "alpha",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        let groups = inv.groupedByProcess
+        XCTAssertEqual(groups.map(\.processName), ["alpha", "bravo"])
+        XCTAssertEqual(groups[1].ports.map(\.port), [80, 5000])
+    }
 }

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -135,6 +135,79 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertFalse(inv.isRefreshing)
     }
 
+    /// Records every kill call and lets the test choose what `SignalResult` to return.
+    private final class RecordingKillScanner: PortScanning, @unchecked Sendable {
+        var records: [PortRecord]
+        let killHandler: (pid_t, Int32) -> SignalResult
+        private(set) var killCalls: [(pid: pid_t, sig: Int32)] = []
+        init(records: [PortRecord], killHandler: @escaping (pid_t, Int32) -> SignalResult) {
+            self.records = records
+            self.killHandler = killHandler
+        }
+        func scanTCPListening() async throws -> [PortRecord] { records }
+        func kill(pid: pid_t, signal: Int32) -> SignalResult {
+            killCalls.append((pid, signal))
+            return killHandler(pid, signal)
+        }
+    }
+
+    @MainActor
+    func testKillEPERMRecordsPermissionDenied() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "root-thing",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .failure(.EPERM) }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        await inv.kill(pid: 99)
+        XCTAssertEqual(inv.failedKillPIDs[99]?.reason, .permissionDenied)
+        XCTAssertFalse(inv.killingPIDs.contains(99))
+    }
+
+    @MainActor
+    func testKillESRCHIsNotRecordedAsFailure() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "x",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .failure(.ESRCH) }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        scanner.records = [] // pretend the process is already gone
+        await inv.kill(pid: 99)
+        XCTAssertNil(inv.failedKillPIDs[99])
+        XCTAssertFalse(inv.killingPIDs.contains(99))
+    }
+
+    @MainActor
+    func testKillSuccessEscalatesToSIGKILLWhenProcessSurvives() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "stubborn",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .success }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        // Pid still present after SIGTERM, so SIGKILL should be sent.
+        await inv.kill(pid: 99)
+        let sigs = scanner.killCalls.map(\.sig)
+        XCTAssertTrue(sigs.contains(SIGTERM))
+        XCTAssertTrue(sigs.contains(SIGKILL))
+    }
+
+    @MainActor
+    func testKillSuccessNoEscalateWhenProcessExits() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "fast-exit",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .success }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        // After SIGTERM, simulate the process being gone before refresh checks.
+        scanner.records = []
+        await inv.kill(pid: 99)
+        let sigs = scanner.killCalls.map(\.sig)
+        XCTAssertEqual(sigs, [SIGTERM])
+    }
+
     @MainActor
     func testIsRefreshingClearsOnlyWhenAllInflightFinish() async throws {
         let scanner = BlockingScanner()

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -26,4 +26,14 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertEqual(SignalResult.failure(.EPERM), SignalResult.failure(.EPERM))
         XCTAssertNotEqual(SignalResult.success, SignalResult.failure(.EPERM))
     }
+
+    func testSubprocessResultStruct() {
+        let r = SubprocessResult(
+            stdout: "out", stderr: "err", exit: 0, timedOut: false
+        )
+        XCTAssertEqual(r.stdout, "out")
+        XCTAssertEqual(r.stderr, "err")
+        XCTAssertEqual(r.exit, 0)
+        XCTAssertFalse(r.timedOut)
+    }
 }

--- a/Tests/AnyDoorTests/PortScannerTests.swift
+++ b/Tests/AnyDoorTests/PortScannerTests.swift
@@ -21,4 +21,57 @@ final class PortScannerTests: XCTestCase {
         XCTAssertEqual(r.processName, "node")
         XCTAssertEqual(r.binds, [PortBind(address: "*", family: .ipv4)])
     }
+
+    func testParseMultiPort() throws {
+        let raw = try fixture("lsof-multi-port")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 3)
+        XCTAssertEqual(records.map(\.port), [80, 443, 5432])
+        for r in records { XCTAssertEqual(r.pid, 898); XCTAssertEqual(r.processName, "OrbStack Helper") }
+    }
+
+    func testParseDualStackMergesBinds() throws {
+        let raw = try fixture("lsof-dual-stack")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.pid, 75837)
+        XCTAssertEqual(r.port, 5000)
+        XCTAssertEqual(r.binds.count, 2)
+        XCTAssertEqual(Set(r.binds.map(\.family)), Set([.ipv4, .ipv6]))
+        // Ordering: IPv4 first then IPv6 (sorted by rawValue).
+        XCTAssertEqual(r.binds.map(\.family), [.ipv4, .ipv6])
+    }
+
+    func testParseMultiBindSamePort() throws {
+        let raw = try fixture("lsof-multi-bind")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.binds.count, 2)
+        XCTAssertEqual(Set(r.binds.map(\.address)), Set(["127.0.0.1", "0.0.0.0"]))
+    }
+
+    func testParseIPv6ZoneId() throws {
+        let raw = try fixture("lsof-ipv6-zone")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.port, 1234)
+        XCTAssertEqual(r.binds, [PortBind(address: "fe80::1%en0", family: .ipv6)])
+    }
+
+    func testParseCommandWithSpaces() throws {
+        let raw = try fixture("lsof-command-spaces")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].processName, "Google Chrome Helper")
+    }
+
+    func testParseEscapeSequence() throws {
+        let raw = try fixture("lsof-escape")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].processName, "weird name")
+    }
 }

--- a/Tests/AnyDoorTests/PortScannerTests.swift
+++ b/Tests/AnyDoorTests/PortScannerTests.swift
@@ -74,4 +74,59 @@ final class PortScannerTests: XCTestCase {
         XCTAssertEqual(records.count, 1)
         XCTAssertEqual(records[0].processName, "weird name")
     }
+
+    // Stub runner used to exercise scanner branches without spawning lsof.
+    private struct StubRunner: SubprocessRunning {
+        let result: SubprocessResult
+        func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
+            result
+        }
+    }
+
+    func testScanEmptyResultExit1BothStreamsEmpty() async throws {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "", stderr: "", exit: 1, timedOut: false)
+        ))
+        let records = try await scanner.scanTCPListening()
+        XCTAssertEqual(records, [])
+    }
+
+    func testScanExit1WithStderrIsFailure() async {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "", stderr: "lsof: permission denied\n", exit: 1, timedOut: false)
+        ))
+        do {
+            _ = try await scanner.scanTCPListening()
+            XCTFail("expected lsofFailed")
+        } catch let PortScanError.lsofFailed(code, stderr) {
+            XCTAssertEqual(code, 1)
+            XCTAssertTrue(stderr.contains("permission denied"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testScanTimeoutThrowsRegardlessOfExit() async {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "anything", stderr: "", exit: 0, timedOut: true)
+        ))
+        do {
+            _ = try await scanner.scanTCPListening()
+            XCTFail("expected lsofTimeout")
+        } catch PortScanError.lsofTimeout {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testScanSuccessfulParse() async throws {
+        let raw = try fixture("lsof-single-ipv4")
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: raw, stderr: "", exit: 0, timedOut: false)
+        ))
+        let records = try await scanner.scanTCPListening()
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].port, 3000)
+    }
 }

--- a/Tests/AnyDoorTests/PortScannerTests.swift
+++ b/Tests/AnyDoorTests/PortScannerTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import AnyDoor
+
+final class PortScannerTests: XCTestCase {
+    private func fixture(_ name: String) throws -> String {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "txt", subdirectory: "Fixtures")
+            ?? Bundle.module.url(forResource: name, withExtension: "txt") else {
+            XCTFail("fixture \(name).txt not found in test bundle")
+            throw XCTSkip("missing fixture")
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    func testParseSingleIPv4Listener() throws {
+        let raw = try fixture("lsof-single-ipv4")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.pid, 67035)
+        XCTAssertEqual(r.port, 3000)
+        XCTAssertEqual(r.processName, "node")
+        XCTAssertEqual(r.binds, [PortBind(address: "*", family: .ipv4)])
+    }
+}

--- a/docs/superpowers/plans/2026-05-21-port-management.md
+++ b/docs/superpowers/plans/2026-05-21-port-management.md
@@ -1,0 +1,2924 @@
+# Port Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a port management entry to the AnyDoor menu bar that, on hover, surfaces a popover listing all TCP listening ports with search, list/tree views, and pid-level kill.
+
+**Architecture:** Three new isolated units. `PortScanner` (actor + `SubprocessRunning` protocol + `LsofRunner`) runs `lsof` with proper concurrent pipe drainage and exposes a stubbable interface; `parseLsofOutput` is a free function for fixture-driven tests. `PortInventory` (`@MainActor @Observable`) owns UI state — records, search, view mode, refresh generation token + inflight count, kill state machine. UI layer wires a new `PortManagerPopoverView` through the existing `HoverPopover` + `HoverGate` (with focus-friendly tweaks).
+
+**Tech Stack:** Swift 6.2 (`.swiftLanguageMode(.v6)`), SwiftUI, SwiftData (no schema changes), `lsof`, `sysctl(KERN_PROCARGS2)`, `Darwin.kill(2)`, `OSAllocatedUnfairLock`, XCTest.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-port-management-design.md`.
+
+---
+
+## File Map
+
+**Created:**
+- `Sources/AnyDoor/Models/PortRecord.swift` — `PortRecord`, `PortBind`, `AddressFamily`, `SignalResult`, `ProcessGroup`.
+- `Sources/AnyDoor/Services/PortScanner.swift` — `PortScanning`, `SubprocessRunning`, `SubprocessResult`, `LsofRunner`, `parseLsofOutput`, `parseProcArgs`, `PortScanner` actor.
+- `Sources/AnyDoor/Services/PortInventory.swift` — `@MainActor @Observable final class PortInventory`, `ViewMode`, `KillFailure`, `PortInventoryError`.
+- `Sources/AnyDoor/Views/PortManagerPopoverView.swift` — popover root + `KeyboardMonitor` + header/toolbar/banner subviews.
+- `Sources/AnyDoor/Views/PortListView.swift` — list mode + `PortRowView` + `PortStatusDot`.
+- `Sources/AnyDoor/Views/PortTreeView.swift` — tree mode with `DisclosureGroup` + bind summary helper.
+- `Tests/AnyDoorTests/PortScannerTests.swift`
+- `Tests/AnyDoorTests/PortInventoryTests.swift`
+- `Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-multi-port.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-dual-stack.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-multi-bind.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-ipv6-zone.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-command-spaces.txt`
+- `Tests/AnyDoorTests/Fixtures/lsof-escape.txt`
+
+**Modified:**
+- `Sources/AnyDoor/Models/BuiltinItem.swift` — add `.portManager` case to enum + each switch + defaultOrder.
+- `Sources/AnyDoor/Views/HoverPopover.swift` — opt-in key-focus via `NSPanel(.nonactivatingPanel)`, `isHoldingFocus` observable.
+- `Sources/AnyDoor/Views/MenuBarView.swift` — generalise per-submenu trigger frames, dispatch `.portManager`, guard `onDisappear`.
+- `Sources/AnyDoor/Views/PanelSettingsView.swift` — generalise submenu hotkey-recorder filter.
+- `Package.swift` — bundle `Tests/AnyDoorTests/Fixtures/` as test resources.
+
+---
+
+## Task 1: Add `.portManager` to `BuiltinItem`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/BuiltinItem.swift`
+- Test: `Tests/AnyDoorTests/PortInventoryTests.swift` (new file with one regression test)
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class PortInventoryTests: XCTestCase {
+    func testBuiltinItemPortManagerExists() {
+        XCTAssertTrue(BuiltinItem.allCases.contains(.portManager))
+        XCTAssertEqual(BuiltinItem.portManager.kind, .submenu)
+        XCTAssertEqual(BuiltinItem.portManager.title, "端口管理")
+        XCTAssertEqual(BuiltinItem.portManager.symbol, "network")
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter PortInventoryTests/testBuiltinItemPortManagerExists`
+Expected: build error — `portManager` is not a case of `BuiltinItem`.
+
+- [ ] **Step 3: Add the enum case + every switch arm**
+
+Edit `Sources/AnyDoor/Models/BuiltinItem.swift`:
+
+Add `case portManager` after `case keyboardLock`:
+
+```swift
+    case keyboardLock
+    case portManager
+```
+
+Extend `kind`:
+
+```swift
+        case .appShortcuts, .portManager: return .submenu
+```
+(replace the existing `case .appShortcuts: return .submenu` line.)
+
+Extend `title`:
+
+```swift
+        case .portManager: return "端口管理"
+```
+(add to the `title` switch.)
+
+Extend `symbol`:
+
+```swift
+        case .portManager: return "network"
+```
+(add to the `symbol` switch. Note: this collides with `.flushDNS` which currently uses `"network"` — leave `.flushDNS` alone; SF Symbols allow duplicates.)
+
+Extend `defaultOrder` (place at the tail):
+
+```swift
+        case .portManager: return 1900
+```
+
+`requiresAutomation` and `feedbackSound` keep their `default` fallback — no change needed.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter PortInventoryTests/testBuiltinItemPortManagerExists`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/BuiltinItem.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(builtin): add portManager submenu case"
+```
+
+---
+
+## Task 2: Define domain types in `Models/PortRecord.swift`
+
+**Files:**
+- Create: `Sources/AnyDoor/Models/PortRecord.swift`
+- Test: extend `Tests/AnyDoorTests/PortInventoryTests.swift`
+
+- [ ] **Step 1: Add failing test for domain types**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+    func testPortRecordIdComposition() {
+        let r = PortRecord(
+            port: 3000,
+            pid: 67035,
+            processName: "node",
+            executablePath: nil,
+            commandLine: nil,
+            binds: [PortBind(address: "*", family: .ipv4)]
+        )
+        XCTAssertEqual(r.id, "67035-3000")
+    }
+
+    func testSignalResultEquatable() {
+        XCTAssertEqual(SignalResult.success, SignalResult.success)
+        XCTAssertEqual(SignalResult.failure(.EPERM), SignalResult.failure(.EPERM))
+        XCTAssertNotEqual(SignalResult.success, SignalResult.failure(.EPERM))
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: build error — `PortRecord`, `PortBind`, `SignalResult` undefined.
+
+- [ ] **Step 3: Create the domain model file**
+
+Create `Sources/AnyDoor/Models/PortRecord.swift`:
+
+```swift
+import Foundation
+import Darwin
+
+/// Listening TCP port discovered on the local machine. Identity is `(pid, port)`.
+struct PortRecord: Sendable, Hashable, Identifiable {
+    let port: UInt16
+    let pid: pid_t
+    let processName: String
+    let executablePath: String?
+    let commandLine: String?
+    /// Every distinct bind seen for this (pid, port). Never empty; ordered IPv4 first then IPv6.
+    let binds: [PortBind]
+    var id: String { "\(pid)-\(port)" }
+}
+
+struct PortBind: Sendable, Hashable {
+    let address: String          // "*", "127.0.0.1", "::1", "fe80::1%en0", ...
+    let family: AddressFamily
+}
+
+enum AddressFamily: String, Sendable, Hashable, CaseIterable {
+    case ipv4 = "IPv4"
+    case ipv6 = "IPv6"
+}
+
+/// Outcome of a `Darwin.kill(2)` syscall. `errno` is captured immediately into
+/// the failure case to avoid clobbering by subsequent system calls.
+enum SignalResult: Sendable, Equatable {
+    case success
+    case failure(POSIXErrorCode)
+}
+
+/// View-model grouping of records belonging to a single process. Used by the tree view.
+struct ProcessGroup: Sendable, Identifiable {
+    var id: pid_t { pid }
+    let pid: pid_t
+    let processName: String
+    let ports: [PortRecord]      // sorted by port ascending
+}
+```
+
+- [ ] **Step 4: Run to verify passes**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/PortRecord.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(model): add PortRecord/PortBind/SignalResult domain types"
+```
+
+---
+
+## Task 3: Wire test fixture resources in `Package.swift`
+
+**Files:**
+- Modify: `Package.swift`
+- Create: `Tests/AnyDoorTests/Fixtures/.gitkeep`
+
+- [ ] **Step 1: Confirm current Package.swift**
+
+Read `/Users/zingerbee/Bee/AnyDoor/Package.swift`. It currently has:
+```swift
+.testTarget(
+    name: "AnyDoorTests",
+    dependencies: ["AnyDoor"],
+    swiftSettings: [
+        .swiftLanguageMode(.v6),
+    ]
+),
+```
+
+- [ ] **Step 2: Add `resources:` to the existing test target**
+
+Edit `Package.swift`. Replace the test target with:
+
+```swift
+        .testTarget(
+            name: "AnyDoorTests",
+            dependencies: ["AnyDoor"],
+            resources: [.process("Fixtures")],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+```
+
+- [ ] **Step 3: Create the Fixtures directory placeholder**
+
+Create empty file `Tests/AnyDoorTests/Fixtures/.gitkeep` so the empty directory exists for SwiftPM resource processing.
+
+```bash
+mkdir -p Tests/AnyDoorTests/Fixtures
+touch Tests/AnyDoorTests/Fixtures/.gitkeep
+```
+
+- [ ] **Step 4: Verify build still succeeds**
+
+Run: `swift build`
+Expected: clean build, no warnings about missing resources.
+
+Run: `swift test --filter SmokeTest`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Package.swift Tests/AnyDoorTests/Fixtures/.gitkeep
+git commit -m "build(tests): enable fixture resources for AnyDoorTests"
+```
+
+---
+
+## Task 4: Skeleton `PortScanner.swift` with types
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/PortScanner.swift`
+- Test: extend `Tests/AnyDoorTests/PortInventoryTests.swift` with a compile-only check.
+
+- [ ] **Step 1: Add failing test**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+    func testSubprocessResultStruct() {
+        let r = SubprocessResult(
+            stdout: "out", stderr: "err", exit: 0, timedOut: false
+        )
+        XCTAssertEqual(r.stdout, "out")
+        XCTAssertEqual(r.stderr, "err")
+        XCTAssertEqual(r.exit, 0)
+        XCTAssertFalse(r.timedOut)
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests/testSubprocessResultStruct`
+Expected: build error — `SubprocessResult` undefined.
+
+- [ ] **Step 3: Create the scanner skeleton**
+
+Create `Sources/AnyDoor/Services/PortScanner.swift`:
+
+```swift
+import Foundation
+import Darwin
+import os
+
+// MARK: - Subprocess runner protocol
+
+protocol SubprocessRunning: Sendable {
+    func run(
+        path: String,
+        args: [String],
+        timeout: Duration
+    ) async throws -> SubprocessResult
+}
+
+struct SubprocessResult: Sendable, Equatable {
+    let stdout: String
+    let stderr: String
+    let exit: Int32
+    let timedOut: Bool
+}
+
+enum SubprocessError: Error, Equatable {
+    case spawnFailed(String)
+}
+
+// MARK: - Scanner protocol
+
+protocol PortScanning: Sendable {
+    func scanTCPListening() async throws -> [PortRecord]
+    func kill(pid: pid_t, signal: Int32) -> SignalResult
+}
+
+enum PortScanError: Error, Equatable {
+    case lsofTimeout
+    case lsofFailed(exitCode: Int32, stderr: String)
+    case parseFailed(line: String)
+}
+
+// MARK: - PortScanner actor (skeleton — implemented across later tasks)
+
+actor PortScanner: PortScanning {
+    private let runner: any SubprocessRunning
+    private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "PortScanner")
+
+    init(runner: any SubprocessRunning = LsofRunner()) {
+        self.runner = runner
+    }
+
+    func scanTCPListening() async throws -> [PortRecord] {
+        // Implemented in Task 7.
+        return []
+    }
+
+    nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult {
+        if Darwin.kill(pid, signal) == 0 { return .success }
+        let code = POSIXErrorCode(rawValue: errno) ?? .EINVAL
+        return .failure(code)
+    }
+}
+
+// MARK: - LsofRunner placeholder (real implementation lands in Task 8)
+
+struct LsofRunner: SubprocessRunning {
+    func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
+        // Placeholder; replaced in Task 8.
+        return SubprocessResult(stdout: "", stderr: "", exit: 0, timedOut: false)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift build`
+Expected: clean build.
+
+Run: `swift test --filter PortInventoryTests/testSubprocessResultStruct`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortScanner.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(scanner): add PortScanner skeleton with protocol surface"
+```
+
+---
+
+## Task 5: Implement `parseLsofOutput` — single IPv4 listener
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortScanner.swift`
+- Create: `Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt`
+- Create: `Tests/AnyDoorTests/PortScannerTests.swift`
+
+- [ ] **Step 1: Add the fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt` with these exact bytes (no trailing whitespace except final newline):
+
+```
+p67035
+cnode
+LZinger
+f17
+PTCP
+tIPv4
+n*:3000
+```
+
+This is real `lsof -F pPcntL` output: one process record (`p` introduces, `c L` are process fields), then one file record (`f` introduces, `P t n` are file fields).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `Tests/AnyDoorTests/PortScannerTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class PortScannerTests: XCTestCase {
+    private func fixture(_ name: String) throws -> String {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "txt", subdirectory: "Fixtures")
+            ?? Bundle.module.url(forResource: name, withExtension: "txt") else {
+            XCTFail("fixture \(name).txt not found in test bundle")
+            throw XCTSkip("missing fixture")
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    func testParseSingleIPv4Listener() throws {
+        let raw = try fixture("lsof-single-ipv4")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.pid, 67035)
+        XCTAssertEqual(r.port, 3000)
+        XCTAssertEqual(r.processName, "node")
+        XCTAssertEqual(r.binds, [PortBind(address: "*", family: .ipv4)])
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `swift test --filter PortScannerTests/testParseSingleIPv4Listener`
+Expected: build error — `parseLsofOutput` undefined.
+
+- [ ] **Step 4: Implement `parseLsofOutput`**
+
+Append to `Sources/AnyDoor/Services/PortScanner.swift`:
+
+```swift
+// MARK: - lsof -F output parser
+
+/// Parses the output of `lsof -nP -iTCP -sTCP:LISTEN -F pPcntL +c 0`.
+///
+/// Field format reference (from `lsof -F?`):
+///   p = process id, c = command name, L = login name (process records)
+///   f = file descriptor (starts a new file record), P = protocol, t = file type
+///   (IPv4/IPv6), n = comment/name ("addr:port")
+///
+/// Each line is `<fieldChar><value>`. `p` starts a new process group; `f` starts
+/// a new file within the current process group.
+func parseLsofOutput(_ raw: String) throws -> [PortRecord] {
+    struct PartialFile {
+        var family: AddressFamily?
+        var name: String?
+        var protocolName: String?
+    }
+    struct PartialProcess {
+        var pid: pid_t?
+        var command: String = ""
+        var files: [PartialFile] = []
+    }
+
+    var partials: [PartialProcess] = []
+    var currentProcess: PartialProcess? = nil
+    var currentFile: PartialFile? = nil
+
+    func flushFile() {
+        if let file = currentFile, currentProcess != nil {
+            currentProcess!.files.append(file)
+        }
+        currentFile = nil
+    }
+    func flushProcess() {
+        flushFile()
+        if let proc = currentProcess { partials.append(proc) }
+        currentProcess = nil
+    }
+
+    for rawLine in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+        guard let first = rawLine.first else { continue }
+        let value = String(rawLine.dropFirst())
+
+        switch first {
+        case "p":
+            flushProcess()
+            currentProcess = PartialProcess(pid: pid_t(value), command: "", files: [])
+        case "c":
+            if currentProcess != nil { currentProcess!.command = decodeLsofEscapes(value) }
+        case "L":
+            break // login name unused
+        case "f":
+            flushFile()
+            currentFile = PartialFile()
+        case "P":
+            if currentFile != nil { currentFile!.protocolName = value }
+        case "t":
+            if currentFile != nil { currentFile!.family = AddressFamily(rawValue: value) }
+        case "n":
+            if currentFile != nil { currentFile!.name = value }
+        default:
+            break // unknown field — ignore for forward-compat
+        }
+    }
+    flushProcess()
+
+    // Group by (pid, port). Within a group, accumulate distinct binds.
+    struct Key: Hashable { let pid: pid_t; let port: UInt16 }
+    var groups: [Key: (processName: String, binds: [PortBind])] = [:]
+    var keyOrder: [Key] = []
+
+    for proc in partials {
+        guard let pid = proc.pid else { continue }
+        for file in proc.files {
+            guard let name = file.name,
+                  let (address, port) = parseAddressPort(name),
+                  let family = file.family else { continue }
+            let key = Key(pid: pid, port: port)
+            let bind = PortBind(address: address, family: family)
+            if var existing = groups[key] {
+                if !existing.binds.contains(bind) { existing.binds.append(bind) }
+                groups[key] = existing
+            } else {
+                groups[key] = (proc.command, [bind])
+                keyOrder.append(key)
+            }
+        }
+    }
+
+    return keyOrder.map { key in
+        let g = groups[key]!
+        let sortedBinds = g.binds.sorted { $0.family.rawValue < $1.family.rawValue }
+        return PortRecord(
+            port: key.port,
+            pid: key.pid,
+            processName: g.processName,
+            executablePath: nil,
+            commandLine: nil,
+            binds: sortedBinds
+        )
+    }
+}
+
+/// Parses the `n` field's `addr:port` value. Handles three forms:
+///   `*:3000`, `127.0.0.1:5000`, `[::1]:8080`, `[fe80::1%en0]:1234`.
+private func parseAddressPort(_ raw: String) -> (address: String, port: UInt16)? {
+    // IPv6 bracketed form
+    if raw.hasPrefix("[") {
+        guard let close = raw.firstIndex(of: "]") else { return nil }
+        let address = String(raw[raw.index(after: raw.startIndex)..<close])
+        let after = raw.index(after: close)
+        guard after < raw.endIndex, raw[after] == ":" else { return nil }
+        let portStr = raw[raw.index(after: after)...]
+        guard let port = UInt16(portStr) else { return nil }
+        return (address, port)
+    }
+    // Plain "address:port"
+    guard let lastColon = raw.lastIndex(of: ":") else { return nil }
+    let address = String(raw[raw.startIndex..<lastColon])
+    let portStr = raw[raw.index(after: lastColon)...]
+    guard let port = UInt16(portStr) else { return nil }
+    return (address, port)
+}
+
+/// lsof escapes non-printable bytes in command names as `\xHH`. Decode them back
+/// to UTF-8 bytes when possible. Spaces and printable ASCII pass through.
+private func decodeLsofEscapes(_ raw: String) -> String {
+    guard raw.contains("\\x") else { return raw }
+    var bytes: [UInt8] = []
+    let scalars = Array(raw.unicodeScalars)
+    var i = 0
+    while i < scalars.count {
+        if scalars[i] == "\\", i + 3 < scalars.count, scalars[i + 1] == "x",
+           let hi = hexNibble(scalars[i + 2]), let lo = hexNibble(scalars[i + 3]) {
+            bytes.append(UInt8(hi << 4 | lo))
+            i += 4
+        } else {
+            // Append the scalar's UTF-8 bytes
+            for byte in String(scalars[i]).utf8 { bytes.append(byte) }
+            i += 1
+        }
+    }
+    return String(decoding: bytes, as: UTF8.self)
+}
+
+private func hexNibble(_ s: Unicode.Scalar) -> UInt8? {
+    switch s {
+    case "0"..."9": return UInt8(s.value - Unicode.Scalar("0").value)
+    case "a"..."f": return UInt8(s.value - Unicode.Scalar("a").value + 10)
+    case "A"..."F": return UInt8(s.value - Unicode.Scalar("A").value + 10)
+    default: return nil
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `swift test --filter PortScannerTests/testParseSingleIPv4Listener`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortScanner.swift Tests/AnyDoorTests/PortScannerTests.swift Tests/AnyDoorTests/Fixtures/lsof-single-ipv4.txt
+git commit -m "feat(scanner): parse lsof -F output for single IPv4 listener"
+```
+
+---
+
+## Task 6: Extend parser — multi-port, dual-stack, multi-bind, IPv6 zone, command spaces, escape
+
+**Files:**
+- Create: 6 fixture files under `Tests/AnyDoorTests/Fixtures/`
+- Modify: `Tests/AnyDoorTests/PortScannerTests.swift`
+
+- [ ] **Step 1: Add the multi-port fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-multi-port.txt`:
+
+```
+p898
+cOrbStack Helper
+LZinger
+f17
+PTCP
+tIPv4
+n*:80
+f18
+PTCP
+tIPv4
+n*:443
+f19
+PTCP
+tIPv4
+n*:5432
+```
+
+- [ ] **Step 2: Add the dual-stack fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-dual-stack.txt`:
+
+```
+p75837
+cControlCenter
+LZinger
+f17
+PTCP
+tIPv4
+n*:5000
+f18
+PTCP
+tIPv6
+n*:5000
+```
+
+- [ ] **Step 3: Add the multi-bind fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-multi-bind.txt`:
+
+```
+p4242
+cmyserver
+LZinger
+f10
+PTCP
+tIPv4
+n127.0.0.1:5000
+f11
+PTCP
+tIPv4
+n0.0.0.0:5000
+```
+
+- [ ] **Step 4: Add the IPv6 zone fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-ipv6-zone.txt`:
+
+```
+p999
+clinkservice
+LZinger
+f7
+PTCP
+tIPv6
+n[fe80::1%en0]:1234
+```
+
+- [ ] **Step 5: Add the command-name-with-spaces fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-command-spaces.txt`:
+
+```
+p1234
+cGoogle Chrome Helper
+LZinger
+f99
+PTCP
+tIPv4
+n*:9222
+```
+
+- [ ] **Step 6: Add the escape-sequence fixture**
+
+Create `Tests/AnyDoorTests/Fixtures/lsof-escape.txt`:
+
+```
+p5555
+cweird\x20name
+LZinger
+f1
+PTCP
+tIPv4
+n*:7777
+```
+
+(After decoding `\x20`, the command name should become `weird name`.)
+
+- [ ] **Step 7: Add the tests**
+
+Append to `Tests/AnyDoorTests/PortScannerTests.swift` (inside the same class):
+
+```swift
+    func testParseMultiPort() throws {
+        let raw = try fixture("lsof-multi-port")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 3)
+        XCTAssertEqual(records.map(\.port), [80, 443, 5432])
+        for r in records { XCTAssertEqual(r.pid, 898); XCTAssertEqual(r.processName, "OrbStack Helper") }
+    }
+
+    func testParseDualStackMergesBinds() throws {
+        let raw = try fixture("lsof-dual-stack")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.pid, 75837)
+        XCTAssertEqual(r.port, 5000)
+        XCTAssertEqual(r.binds.count, 2)
+        XCTAssertEqual(Set(r.binds.map(\.family)), Set([.ipv4, .ipv6]))
+        // Ordering: IPv4 first then IPv6 (sorted by rawValue).
+        XCTAssertEqual(r.binds.map(\.family), [.ipv4, .ipv6])
+    }
+
+    func testParseMultiBindSamePort() throws {
+        let raw = try fixture("lsof-multi-bind")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.binds.count, 2)
+        XCTAssertEqual(Set(r.binds.map(\.address)), Set(["127.0.0.1", "0.0.0.0"]))
+    }
+
+    func testParseIPv6ZoneId() throws {
+        let raw = try fixture("lsof-ipv6-zone")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        let r = records[0]
+        XCTAssertEqual(r.port, 1234)
+        XCTAssertEqual(r.binds, [PortBind(address: "fe80::1%en0", family: .ipv6)])
+    }
+
+    func testParseCommandWithSpaces() throws {
+        let raw = try fixture("lsof-command-spaces")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].processName, "Google Chrome Helper")
+    }
+
+    func testParseEscapeSequence() throws {
+        let raw = try fixture("lsof-escape")
+        let records = try parseLsofOutput(raw)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].processName, "weird name")
+    }
+```
+
+- [ ] **Step 8: Run all parser tests**
+
+Run: `swift test --filter PortScannerTests`
+Expected: all 7 tests pass (the original `testParseSingleIPv4Listener` + 6 new).
+
+If any fails, the parser needs adjustment — re-read the failing test's expectations and fix in `parseLsofOutput` / `parseAddressPort` / `decodeLsofEscapes`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Tests/AnyDoorTests/Fixtures/lsof-multi-port.txt Tests/AnyDoorTests/Fixtures/lsof-dual-stack.txt Tests/AnyDoorTests/Fixtures/lsof-multi-bind.txt Tests/AnyDoorTests/Fixtures/lsof-ipv6-zone.txt Tests/AnyDoorTests/Fixtures/lsof-command-spaces.txt Tests/AnyDoorTests/Fixtures/lsof-escape.txt Tests/AnyDoorTests/PortScannerTests.swift
+git commit -m "test(scanner): cover multi-port, dual-stack, multi-bind, IPv6 zone, escapes"
+```
+
+---
+
+## Task 7: Implement `scanTCPListening` with stub runner + empty-result / timeout / failure rules
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortScanner.swift`
+- Modify: `Tests/AnyDoorTests/PortScannerTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnyDoorTests/PortScannerTests.swift`:
+
+```swift
+    // Stub runner used to exercise scanner branches without spawning lsof.
+    private struct StubRunner: SubprocessRunning {
+        let result: SubprocessResult
+        func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
+            result
+        }
+    }
+
+    func testScanEmptyResultExit1BothStreamsEmpty() async throws {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "", stderr: "", exit: 1, timedOut: false)
+        ))
+        let records = try await scanner.scanTCPListening()
+        XCTAssertEqual(records, [])
+    }
+
+    func testScanExit1WithStderrIsFailure() async {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "", stderr: "lsof: permission denied\n", exit: 1, timedOut: false)
+        ))
+        do {
+            _ = try await scanner.scanTCPListening()
+            XCTFail("expected lsofFailed")
+        } catch let PortScanError.lsofFailed(code, stderr) {
+            XCTAssertEqual(code, 1)
+            XCTAssertTrue(stderr.contains("permission denied"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testScanTimeoutThrowsRegardlessOfExit() async {
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: "anything", stderr: "", exit: 0, timedOut: true)
+        ))
+        do {
+            _ = try await scanner.scanTCPListening()
+            XCTFail("expected lsofTimeout")
+        } catch PortScanError.lsofTimeout {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testScanSuccessfulParse() async throws {
+        let raw = try fixture("lsof-single-ipv4")
+        let scanner = PortScanner(runner: StubRunner(
+            result: SubprocessResult(stdout: raw, stderr: "", exit: 0, timedOut: false)
+        ))
+        let records = try await scanner.scanTCPListening()
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].port, 3000)
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortScannerTests/testScanEmptyResultExit1BothStreamsEmpty`
+Expected: fails because `scanTCPListening` returns `[]` for everything.
+
+- [ ] **Step 3: Implement scan branching**
+
+Replace the body of `scanTCPListening()` in `Sources/AnyDoor/Services/PortScanner.swift`:
+
+```swift
+    func scanTCPListening() async throws -> [PortRecord] {
+        let result = try await runner.run(
+            path: "/usr/sbin/lsof",
+            args: ["-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pPcntL", "+c", "0"],
+            timeout: .seconds(3)
+        )
+
+        if result.timedOut { throw PortScanError.lsofTimeout }
+
+        // lsof returns exit 1 with empty stdout AND empty stderr when there is
+        // no matching open file. Treat that as a successful empty scan.
+        if result.exit == 1 && result.stdout.isEmpty && result.stderr.isEmpty {
+            return []
+        }
+        // Non-zero exit with any output on stderr (or stdout) is a real failure.
+        if result.exit != 0 {
+            throw PortScanError.lsofFailed(exitCode: result.exit, stderr: result.stderr)
+        }
+
+        var records = try parseLsofOutput(result.stdout)
+        records = enrichWithProcArgs(records)
+        return records
+    }
+
+    /// Enriches each record's `executablePath` and `commandLine` via sysctl.
+    /// One sysctl call per unique pid; failures are silent (record keeps lsof's data).
+    private func enrichWithProcArgs(_ records: [PortRecord]) -> [PortRecord] {
+        var cache: [pid_t: (path: String?, command: String?)] = [:]
+        return records.map { r in
+            if cache[r.pid] == nil {
+                cache[r.pid] = parseProcArgs(forPid: r.pid)
+            }
+            let info = cache[r.pid] ?? (nil, nil)
+            return PortRecord(
+                port: r.port,
+                pid: r.pid,
+                processName: r.processName,
+                executablePath: info.path,
+                commandLine: info.command,
+                binds: r.binds
+            )
+        }
+    }
+```
+
+Also add a placeholder `parseProcArgs` helper that returns `(nil, nil)` for now (it gets fleshed out in Task 8). Append:
+
+```swift
+// MARK: - sysctl KERN_PROCARGS2 helper (filled in Task 8)
+
+func parseProcArgs(forPid pid: pid_t) -> (path: String?, command: String?) {
+    // Task 8 replaces this stub with the real sysctl-based implementation.
+    return (nil, nil)
+}
+```
+
+- [ ] **Step 4: Run all scanner tests**
+
+Run: `swift test --filter PortScannerTests`
+Expected: all 11 tests pass (7 parser + 4 scanner-branch tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortScanner.swift Tests/AnyDoorTests/PortScannerTests.swift
+git commit -m "feat(scanner): scanTCPListening with timeout/empty/failure branches"
+```
+
+---
+
+## Task 8: Replace `LsofRunner` and `parseProcArgs` with real implementations
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortScanner.swift`
+
+- [ ] **Step 1: Replace the `LsofRunner` placeholder**
+
+In `Sources/AnyDoor/Services/PortScanner.swift`, replace the placeholder `LsofRunner` struct with:
+
+```swift
+struct LsofRunner: SubprocessRunning {
+    func run(path: String, args: [String], timeout: Duration) async throws -> SubprocessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = args
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        do { try process.run() }
+        catch { throw SubprocessError.spawnFailed("\(error)") }
+
+        // OSAllocatedUnfairLock<Bool> — no new dependency, watchdog and
+        // result-builder both read/write through .withLock.
+        let timedOut = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+        return await withTaskCancellationHandler {
+            // Drain pipes concurrently so the kernel buffer never fills.
+            async let outData: Data = readAll(outPipe.fileHandleForReading)
+            async let errData: Data = readAll(errPipe.fileHandleForReading)
+
+            let watchdog = Task {
+                try? await Task.sleep(for: timeout)
+                if process.isRunning {
+                    timedOut.withLock { $0 = true }
+                    process.terminate()
+                }
+            }
+
+            let out = await outData
+            let err = await errData
+            watchdog.cancel()
+            process.waitUntilExit()
+
+            return SubprocessResult(
+                stdout: String(data: out, encoding: .utf8) ?? "",
+                stderr: String(data: err, encoding: .utf8) ?? "",
+                exit: process.terminationStatus,
+                timedOut: timedOut.withLock { $0 }
+            )
+        } onCancel: {
+            if process.isRunning { process.terminate() }
+        }
+    }
+}
+
+private func readAll(_ handle: FileHandle) async -> Data {
+    await withCheckedContinuation { (cont: CheckedContinuation<Data, Never>) in
+        DispatchQueue.global().async {
+            let data = (try? handle.readToEnd()) ?? Data()
+            cont.resume(returning: data)
+        }
+    }
+}
+```
+
+Add `import os` at the top of the file if missing (the existing import line is already `import os`; verify).
+
+- [ ] **Step 2: Replace the `parseProcArgs` stub**
+
+In the same file, replace the `parseProcArgs` placeholder with:
+
+```swift
+/// Reads `KERN_PROCARGS2` for a pid and extracts the executable path and the
+/// space-joined argv. Returns `(nil, nil)` on any failure (permission, race,
+/// pid no longer alive). Silent by design — caller falls back to lsof's command.
+func parseProcArgs(forPid pid: pid_t) -> (path: String?, command: String?) {
+    var size: Int = 0
+    var name: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+    // First call: ask for size.
+    if sysctl(&name, 3, nil, &size, nil, 0) != 0 || size == 0 {
+        return (nil, nil)
+    }
+    var buffer = [UInt8](repeating: 0, count: size)
+    if sysctl(&name, 3, &buffer, &size, nil, 0) != 0 {
+        return (nil, nil)
+    }
+
+    // Layout: <argc:Int32><executable path NUL>[padding NULs]<argv[0] NUL><argv[1] NUL>...
+    guard size >= MemoryLayout<Int32>.size else { return (nil, nil) }
+    let argc = buffer.withUnsafeBytes { $0.load(as: Int32.self) }
+    if argc < 0 { return (nil, nil) }
+
+    var cursor = MemoryLayout<Int32>.size
+    // Read NUL-terminated executable path.
+    let pathStart = cursor
+    while cursor < buffer.count && buffer[cursor] != 0 { cursor += 1 }
+    let pathBytes = buffer[pathStart..<cursor]
+    let path = String(decoding: pathBytes, as: UTF8.self)
+    // Skip padding NULs.
+    while cursor < buffer.count && buffer[cursor] == 0 { cursor += 1 }
+
+    // Read argc NUL-terminated argv entries.
+    var argv: [String] = []
+    var collected = 0
+    while collected < Int(argc) && cursor < buffer.count {
+        let start = cursor
+        while cursor < buffer.count && buffer[cursor] != 0 { cursor += 1 }
+        argv.append(String(decoding: buffer[start..<cursor], as: UTF8.self))
+        if cursor < buffer.count { cursor += 1 } // skip NUL
+        collected += 1
+    }
+    let command = argv.joined(separator: " ")
+    return (path.isEmpty ? nil : path, command.isEmpty ? nil : command)
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: clean build.
+
+- [ ] **Step 4: Run all existing tests (regression check)**
+
+Run: `swift test --filter PortScannerTests`
+Expected: all 11 still pass (the real runner is not exercised; tests still inject `StubRunner`).
+
+- [ ] **Step 5: Dev-only smoke test (manual)**
+
+Open a terminal in this repo and run a one-off Swift snippet (do NOT add to CI):
+
+```bash
+cat > /tmp/scan-smoke.swift <<'SWIFT'
+@testable import AnyDoor
+import Foundation
+Task {
+    let s = PortScanner()
+    do {
+        let records = try await s.scanTCPListening()
+        print("found \(records.count) listeners")
+        for r in records.prefix(5) { print(":\(r.port) \(r.processName) (pid \(r.pid))") }
+    } catch { print("error: \(error)") }
+    exit(0)
+}
+RunLoop.main.run()
+SWIFT
+echo "(snippet at /tmp/scan-smoke.swift — manual run is optional)"
+```
+
+This is a documentation step only. The next agent doesn't need to execute it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortScanner.swift
+git commit -m "feat(scanner): real LsofRunner with concurrent drain + KERN_PROCARGS2"
+```
+
+---
+
+## Task 9: Skeleton `PortInventory` with viewMode persistence
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/PortInventory.swift`
+- Modify: `Tests/AnyDoorTests/PortInventoryTests.swift`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+    @MainActor
+    func testViewModeDefaultsToList() {
+        let defaults = isolatedDefaults()
+        let inventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        XCTAssertEqual(inventory.viewMode, .list)
+    }
+
+    @MainActor
+    func testViewModePersistsToDefaults() {
+        let defaults = isolatedDefaults()
+        let inventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        inventory.viewMode = .tree
+
+        // New instance reads back the persisted value.
+        let inventory2 = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: defaults
+        )
+        XCTAssertEqual(inventory2.viewMode, .tree)
+    }
+
+    // Test helpers
+    private struct StubScanner: PortScanning {
+        let records: [PortRecord]
+        var killBehavior: @Sendable (pid_t, Int32) -> SignalResult = { _, _ in .success }
+        func scanTCPListening() async throws -> [PortRecord] { records }
+        func kill(pid: pid_t, signal: Int32) -> SignalResult { killBehavior(pid, signal) }
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suite = "PortInventoryTests-\(UUID().uuidString)"
+        return UserDefaults(suiteName: suite)!
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests/testViewModeDefaultsToList`
+Expected: build error — `PortInventory` undefined.
+
+- [ ] **Step 3: Create the inventory file**
+
+Create `Sources/AnyDoor/Services/PortInventory.swift`:
+
+```swift
+import Foundation
+import Darwin
+import os
+
+@MainActor
+@Observable
+final class PortInventory {
+    // MARK: - Public state
+
+    private(set) var records: [PortRecord] = []
+    private(set) var isRefreshing: Bool = false
+    private(set) var lastError: PortInventoryError? = nil
+    private(set) var killingPIDs: Set<pid_t> = []
+    private(set) var failedKillPIDs: [pid_t: KillFailure] = [:]
+
+    var searchText: String = ""
+
+    var viewMode: ViewMode {
+        didSet {
+            defaults.set(viewMode.rawValue, forKey: Self.viewModeKey)
+        }
+    }
+
+    // MARK: - Dependencies
+
+    private let scanner: any PortScanning
+    private let defaults: UserDefaults
+    private static let viewModeKey = "PortInventory.viewMode"
+    private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")
+
+    // MARK: - Internal refresh state (Task 10)
+
+    private var refreshGeneration: UInt64 = 0
+    private var inflightCount: Int = 0
+
+    // MARK: - Lifecycle
+
+    nonisolated static let shared = PortInventory()
+
+    init(
+        scanner: any PortScanning = PortScanner(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.scanner = scanner
+        self.defaults = defaults
+        let raw = defaults.string(forKey: Self.viewModeKey)
+        self.viewMode = raw.flatMap(ViewMode.init(rawValue:)) ?? .list
+    }
+
+    // Placeholder methods — real implementations land in Task 10 and Task 11.
+
+    func refresh() async {
+        // Implemented in Task 10.
+    }
+
+    func kill(pid: pid_t) async {
+        // Implemented in Task 11.
+    }
+
+    func dismissError(for pid: pid_t) {
+        failedKillPIDs.removeValue(forKey: pid)
+    }
+}
+
+enum ViewMode: String, Sendable, Equatable {
+    case list, tree
+}
+
+enum PortInventoryError: Equatable, Sendable {
+    case scanFailed(String)
+}
+
+struct KillFailure: Equatable, Sendable {
+    enum Reason: Equatable, Sendable {
+        case permissionDenied
+        case processGone
+        case other(Int32)
+    }
+    let reason: Reason
+    let timestamp: Date
+}
+```
+
+Note: `nonisolated static let shared = PortInventory()` requires that `PortInventory.init` is callable from a nonisolated context. Since the class is `@MainActor`, the no-arg init needs to be marked accordingly. Adjust if Swift rejects: change to `static let shared: PortInventory = MainActor.assumeIsolated { PortInventory() }`.
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: at minimum the two viewMode tests pass alongside earlier ones.
+
+If `shared` causes a Swift 6 actor-isolation error, switch to:
+
+```swift
+static let shared: PortInventory = MainActor.assumeIsolated { PortInventory() }
+```
+
+Re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortInventory.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(inventory): PortInventory skeleton with viewMode persistence"
+```
+
+---
+
+## Task 10: Implement `refresh()` with generation token + inflightCount
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortInventory.swift`
+- Modify: `Tests/AnyDoorTests/PortInventoryTests.swift`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`. First, a controllable async scanner:
+
+```swift
+    /// Scanner that lets the test resolve `scanTCPListening()` on demand.
+    private actor BlockingScanner: PortScanning {
+        struct Pending {
+            let continuation: CheckedContinuation<[PortRecord], Error>
+        }
+        private var queue: [Pending] = []
+        private(set) var calls = 0
+        func resolve(with records: [PortRecord]) async {
+            calls += 1
+            if let next = queue.first {
+                queue.removeFirst()
+                next.continuation.resume(returning: records)
+            }
+        }
+        func fail(with error: Error) async {
+            if let next = queue.first {
+                queue.removeFirst()
+                next.continuation.resume(throwing: error)
+            }
+        }
+        func scanTCPListening() async throws -> [PortRecord] {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<[PortRecord], Error>) in
+                queue.append(Pending(continuation: cont))
+            }
+        }
+        nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
+    }
+
+    @MainActor
+    func testRefreshPopulatesRecords() async {
+        let stub = StubScanner(records: [
+            PortRecord(port: 3000, pid: 1, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        let inv = PortInventory(scanner: stub, defaults: isolatedDefaults())
+        await inv.refresh()
+        XCTAssertEqual(inv.records.count, 1)
+        XCTAssertEqual(inv.records[0].port, 3000)
+        XCTAssertFalse(inv.isRefreshing)
+        XCTAssertNil(inv.lastError)
+    }
+
+    @MainActor
+    func testRefreshFailurePreservesRecordsAndSetsError() async {
+        struct ThrowingScanner: PortScanning {
+            func scanTCPListening() async throws -> [PortRecord] {
+                throw PortScanError.lsofFailed(exitCode: 2, stderr: "boom")
+            }
+            func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
+        }
+        let inv = PortInventory(scanner: ThrowingScanner(), defaults: isolatedDefaults())
+        // Seed records via a stub first refresh would be ideal; here we just verify error path.
+        await inv.refresh()
+        XCTAssertNotNil(inv.lastError)
+        XCTAssertFalse(inv.isRefreshing)
+    }
+
+    @MainActor
+    func testIsRefreshingClearsOnlyWhenAllInflightFinish() async throws {
+        let scanner = BlockingScanner()
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+
+        // Start refresh #1 — it blocks awaiting the scanner.
+        let t1: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "first refresh should mark isRefreshing")
+
+        // Start refresh #2 — also blocked.
+        let t2: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "still refreshing with two in flight")
+
+        // Resolve the older one (refresh #1) first.
+        await scanner.resolve(with: [])
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(inv.isRefreshing, "stale completion must NOT clear isRefreshing while #2 is still running")
+
+        // Resolve the newer one.
+        await scanner.resolve(with: [
+            PortRecord(port: 9, pid: 2, processName: "x",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        await t1.value
+        await t2.value
+        XCTAssertFalse(inv.isRefreshing)
+        XCTAssertEqual(inv.records.count, 1)
+        XCTAssertEqual(inv.records[0].port, 9)
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests/testRefreshPopulatesRecords`
+Expected: fail — `refresh()` is empty.
+
+- [ ] **Step 3: Implement `refresh()`**
+
+In `Sources/AnyDoor/Services/PortInventory.swift`, replace the `refresh()` placeholder:
+
+```swift
+    func refresh() async {
+        refreshGeneration &+= 1
+        let myGen = refreshGeneration
+        inflightCount += 1
+        isRefreshing = true
+
+        do {
+            let scanned = try await scanner.scanTCPListening()
+            inflightCount -= 1
+            if myGen == refreshGeneration {
+                records = scanned
+                lastError = nil
+            } else {
+                Self.logger.debug("dropping stale scan result (gen \(myGen), now \(self.refreshGeneration))")
+            }
+            isRefreshing = inflightCount > 0
+        } catch {
+            inflightCount -= 1
+            if myGen == refreshGeneration {
+                lastError = .scanFailed(String(describing: error))
+                // records intentionally preserved
+            }
+            isRefreshing = inflightCount > 0
+        }
+    }
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortInventory.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(inventory): refresh() with generation token + inflight count"
+```
+
+---
+
+## Task 11: Implement `kill(pid:)` state machine
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortInventory.swift`
+- Modify: `Tests/AnyDoorTests/PortInventoryTests.swift`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+    /// Records every kill call and lets the test choose what `SignalResult` to return.
+    private final class RecordingKillScanner: PortScanning, @unchecked Sendable {
+        var records: [PortRecord]
+        let killHandler: (pid_t, Int32) -> SignalResult
+        private(set) var killCalls: [(pid: pid_t, sig: Int32)] = []
+        init(records: [PortRecord], killHandler: @escaping (pid_t, Int32) -> SignalResult) {
+            self.records = records
+            self.killHandler = killHandler
+        }
+        func scanTCPListening() async throws -> [PortRecord] { records }
+        func kill(pid: pid_t, signal: Int32) -> SignalResult {
+            killCalls.append((pid, signal))
+            return killHandler(pid, signal)
+        }
+    }
+
+    @MainActor
+    func testKillEPERMRecordsPermissionDenied() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "root-thing",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .failure(.EPERM) }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        await inv.kill(pid: 99)
+        XCTAssertEqual(inv.failedKillPIDs[99]?.reason, .permissionDenied)
+        XCTAssertFalse(inv.killingPIDs.contains(99))
+    }
+
+    @MainActor
+    func testKillESRCHIsNotRecordedAsFailure() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "x",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .failure(.ESRCH) }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        scanner.records = [] // pretend the process is already gone
+        await inv.kill(pid: 99)
+        XCTAssertNil(inv.failedKillPIDs[99])
+        XCTAssertFalse(inv.killingPIDs.contains(99))
+    }
+
+    @MainActor
+    func testKillSuccessEscalatesToSIGKILLWhenProcessSurvives() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "stubborn",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .success }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        // Pid still present after SIGTERM, so SIGKILL should be sent.
+        await inv.kill(pid: 99)
+        let sigs = scanner.killCalls.map(\.sig)
+        XCTAssertTrue(sigs.contains(SIGTERM))
+        XCTAssertTrue(sigs.contains(SIGKILL))
+    }
+
+    @MainActor
+    func testKillSuccessNoEscalateWhenProcessExits() async {
+        let r = PortRecord(port: 80, pid: 99, processName: "fast-exit",
+                           executablePath: nil, commandLine: nil,
+                           binds: [PortBind(address: "*", family: .ipv4)])
+        let scanner = RecordingKillScanner(records: [r]) { _, _ in .success }
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+        await inv.refresh()
+        // After SIGTERM, simulate the process being gone before refresh checks.
+        scanner.records = []
+        await inv.kill(pid: 99)
+        let sigs = scanner.killCalls.map(\.sig)
+        XCTAssertEqual(sigs, [SIGTERM])
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests/testKillEPERMRecordsPermissionDenied`
+Expected: fail — `kill(pid:)` is empty.
+
+- [ ] **Step 3: Implement `kill(pid:)`**
+
+In `Sources/AnyDoor/Services/PortInventory.swift`, replace the `kill(pid:)` placeholder:
+
+```swift
+    func kill(pid: pid_t) async {
+        killingPIDs.insert(pid)
+
+        // Step 1: SIGTERM
+        switch scanner.kill(pid: pid, signal: SIGTERM) {
+        case .failure(.ESRCH):
+            // Process already gone — treat as success.
+            await refresh()
+            killingPIDs.remove(pid)
+            return
+        case .failure(let code):
+            let reason: KillFailure.Reason =
+                (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+            failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+            scheduleAutoDismiss(for: pid)
+            killingPIDs.remove(pid)
+            return
+        case .success:
+            break
+        }
+
+        // Step 2: give the process time to handle SIGTERM, then re-scan.
+        try? await Task.sleep(for: .milliseconds(500))
+        await refresh()
+
+        // Step 3: if still alive, escalate.
+        if records.contains(where: { $0.pid == pid }) {
+            switch scanner.kill(pid: pid, signal: SIGKILL) {
+            case .success:
+                try? await Task.sleep(for: .milliseconds(200))
+                await refresh()
+            case .failure(.ESRCH):
+                await refresh()
+            case .failure(let code):
+                let reason: KillFailure.Reason =
+                    (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+                failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+                scheduleAutoDismiss(for: pid)
+            }
+        }
+
+        killingPIDs.remove(pid)
+    }
+
+    private func scheduleAutoDismiss(for pid: pid_t) {
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            await MainActor.run {
+                self?.failedKillPIDs.removeValue(forKey: pid)
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run the kill tests**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortInventory.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(inventory): pid-level kill with SIGTERM→SIGKILL fallback"
+```
+
+---
+
+## Task 12: Add derived views — `filteredRecords` + `groupedByProcess`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PortInventory.swift`
+- Modify: `Tests/AnyDoorTests/PortInventoryTests.swift`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `Tests/AnyDoorTests/PortInventoryTests.swift`:
+
+```swift
+    @MainActor
+    func testFilteredEmptyQueryReturnsPortAscending() async {
+        let recs = [
+            PortRecord(port: 5000, pid: 1, processName: "a", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 80, pid: 2, processName: "b", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 3000, pid: 3, processName: "c", executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        XCTAssertEqual(inv.filteredRecords.map(\.port), [80, 3000, 5000])
+    }
+
+    @MainActor
+    func testSearchPriorityPortBeforeNameBeforePid() async {
+        let recs = [
+            PortRecord(port: 3000, pid: 99, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 8080, pid: 30,  processName: "java",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        inv.searchText = "30"
+        // Port :3000 matches the "30" substring; pid 30 also matches. Port should come first.
+        XCTAssertEqual(inv.filteredRecords.map(\.port), [3000, 8080])
+    }
+
+    @MainActor
+    func testSearchIsCaseInsensitive() async {
+        let recs = [
+            PortRecord(port: 1, pid: 1, processName: "NodeProcess",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        inv.searchText = "node"
+        XCTAssertEqual(inv.filteredRecords.count, 1)
+    }
+
+    @MainActor
+    func testGroupedByProcessSortsByNameThenPort() async {
+        let recs = [
+            PortRecord(port: 5000, pid: 10, processName: "bravo",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 80, pid: 10, processName: "bravo",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+            PortRecord(port: 22, pid: 20, processName: "alpha",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)]),
+        ]
+        let inv = PortInventory(scanner: StubScanner(records: recs), defaults: isolatedDefaults())
+        await inv.refresh()
+        let groups = inv.groupedByProcess
+        XCTAssertEqual(groups.map(\.processName), ["alpha", "bravo"])
+        XCTAssertEqual(groups[1].ports.map(\.port), [80, 5000])
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter PortInventoryTests/testFilteredEmptyQueryReturnsPortAscending`
+Expected: build error — `filteredRecords` / `groupedByProcess` undefined.
+
+- [ ] **Step 3: Implement the derived views**
+
+Append inside the `PortInventory` class (before the closing brace) in `Sources/AnyDoor/Services/PortInventory.swift`:
+
+```swift
+    // MARK: - Derived views
+
+    var filteredRecords: [PortRecord] {
+        guard !searchText.isEmpty else {
+            return records.sorted { $0.port < $1.port }
+        }
+        let q = searchText.lowercased()
+        var seen = Set<PortRecord.ID>()
+        var ordered: [PortRecord] = []
+        func add(_ bucket: [PortRecord]) {
+            for r in bucket where !seen.contains(r.id) {
+                seen.insert(r.id)
+                ordered.append(r)
+            }
+        }
+        add(records.filter { String($0.port).contains(q) })
+        add(records.filter { $0.processName.lowercased().contains(q) })
+        add(records.filter { String($0.pid).contains(q) })
+        return ordered
+    }
+
+    var groupedByProcess: [ProcessGroup] {
+        let grouped = Dictionary(grouping: filteredRecords, by: \.pid)
+        return grouped.map { (pid, recs) in
+            ProcessGroup(
+                pid: pid,
+                processName: recs.first?.processName ?? "",
+                ports: recs.sorted { $0.port < $1.port }
+            )
+        }
+        .sorted {
+            $0.processName.localizedCaseInsensitiveCompare($1.processName) == .orderedAscending
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter PortInventoryTests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PortInventory.swift Tests/AnyDoorTests/PortInventoryTests.swift
+git commit -m "feat(inventory): filteredRecords (priority search) + groupedByProcess"
+```
+
+---
+
+## Task 13: Make `HoverPopover` key-focus-capable
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/HoverPopover.swift`
+
+This is a UI infrastructure change. No new tests; verified via the manual QA gate in Task 21.
+
+- [ ] **Step 1: Replace the `NSWindow` with a key-capable `NSPanel`**
+
+Edit `Sources/AnyDoor/Views/HoverPopover.swift`. Replace the contents with:
+
+```swift
+import SwiftUI
+import AppKit
+import Observation
+
+/// Hover-triggered NSPanel popover.
+///
+/// Used by both App Shortcuts (`needsKeyFocus = false`, read-only) and Port Manager
+/// (`needsKeyFocus = true`, needs to receive text input and local key events).
+///
+/// Lifecycle:
+/// - Trigger view installs `onHover` that arms the gate after 400ms.
+/// - Popover stays open while either trigger or popover is hovered (gate manages).
+/// - Closes 300ms after both lose hover, OR immediately via `hide()`.
+@MainActor
+@Observable
+final class HoverPopover {
+    /// True while the underlying panel is keyWindow. Read by MenuBarView.onDisappear
+    /// to avoid hiding the popover when the menu bar panel collapses because we just
+    /// took key focus.
+    private(set) var isHoldingFocus: Bool = false
+
+    private let panel: KeyableHoverPanel
+    private let hostingController: NSHostingController<AnyView>
+    private var hideTask: Task<Void, Never>?
+    private var keyObserver: NSObjectProtocol?
+    private var resignObserver: NSObjectProtocol?
+
+    /// Set to `true` for popovers whose SwiftUI content needs first-responder focus
+    /// (e.g. TextField). Leave `false` for read-only popovers — they keep the
+    /// historical "never becomes key" behaviour.
+    var needsKeyFocus: Bool = false {
+        didSet { panel.allowKey = needsKeyFocus }
+    }
+
+    init<Content: View>(@ViewBuilder content: () -> Content) {
+        let controller = NSHostingController(rootView: AnyView(content()))
+        controller.sizingOptions = [.preferredContentSize]
+        self.hostingController = controller
+
+        let panel = KeyableHoverPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 200),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+        panel.contentViewController = controller
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.hidesOnDeactivate = false
+        self.panel = panel
+
+        // Track key state so MenuBarView can guard onDisappear.
+        keyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isHoldingFocus = true }
+        }
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isHoldingFocus = false }
+        }
+    }
+
+    deinit {
+        if let keyObserver { NotificationCenter.default.removeObserver(keyObserver) }
+        if let resignObserver { NotificationCenter.default.removeObserver(resignObserver) }
+    }
+
+    func updateContent<Content: View>(@ViewBuilder content: () -> Content) {
+        hostingController.rootView = AnyView(content())
+        hostingController.view.layoutSubtreeIfNeeded()
+        let fitting = hostingController.view.fittingSize
+        if fitting.width > 0 && fitting.height > 0 {
+            panel.setContentSize(fitting)
+        }
+    }
+
+    /// Show the popover anchored to the right side of `referenceFrame` (screen coordinates).
+    func show(anchoredTo referenceFrame: NSRect) {
+        hideTask?.cancel()
+        hideTask = nil
+
+        let screen = NSScreen.screens.first(where: { $0.frame.intersects(referenceFrame) }) ?? NSScreen.main
+        let screenFrame = screen?.visibleFrame ?? .zero
+
+        let size = panel.frame.size
+        let rightX = referenceFrame.maxX + 4
+        let leftX = referenceFrame.minX - 4 - size.width
+        let originX = (rightX + size.width <= screenFrame.maxX) ? rightX : leftX
+        let originY = max(screenFrame.minY,
+                          min(referenceFrame.midY - size.height / 2,
+                              screenFrame.maxY - size.height))
+
+        panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+        panel.orderFrontRegardless()
+        if needsKeyFocus {
+            panel.makeKey()
+        }
+    }
+
+    func scheduleHide(after delay: TimeInterval = 0.3) {
+        hideTask?.cancel()
+        hideTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            self.panel.orderOut(nil)
+        }
+    }
+
+    func keepOpen() {
+        hideTask?.cancel()
+        hideTask = nil
+    }
+
+    func hide() {
+        hideTask?.cancel()
+        hideTask = nil
+        panel.orderOut(nil)
+    }
+}
+
+/// NSPanel subclass whose key-eligibility is controlled by an opt-in flag.
+/// App Shortcuts uses `allowKey = false` (read-only), Port Manager uses `true`.
+final class KeyableHoverPanel: NSPanel {
+    var allowKey: Bool = false
+    override var canBecomeKey: Bool { allowKey }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - HoverGate (unchanged plus new reset())
+
+@MainActor
+@Observable
+final class HoverGate {
+    private(set) var isShown = false
+    private var triggerHovered = false
+    private var popoverHovered = false
+    private var showTask: Task<Void, Never>?
+    private var hideTask: Task<Void, Never>?
+
+    var onShow: () -> Void = {}
+    var onHide: () -> Void = {}
+
+    func triggerHover(_ hovered: Bool) {
+        triggerHovered = hovered
+        if hovered { scheduleShow() } else { scheduleHide() }
+    }
+
+    func popoverHover(_ hovered: Bool) {
+        popoverHovered = hovered
+        if hovered { showTask?.cancel(); hideTask?.cancel() }
+        else { scheduleHide() }
+    }
+
+    func showImmediately() {
+        showTask?.cancel()
+        if !isShown {
+            isShown = true
+            onShow()
+        }
+    }
+
+    /// Forcibly reset all tracked hover state. Used by the port-manager ESC
+    /// path to clear the gate before the popover is dismissed programmatically.
+    func reset() {
+        showTask?.cancel()
+        hideTask?.cancel()
+        showTask = nil
+        hideTask = nil
+        triggerHovered = false
+        popoverHovered = false
+        if isShown {
+            isShown = false
+            onHide()
+        }
+    }
+
+    private func scheduleShow() {
+        guard !isShown else { return }
+        hideTask?.cancel()
+        showTask?.cancel()
+        showTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard let self, !Task.isCancelled, self.triggerHovered else { return }
+            self.isShown = true
+            self.onShow()
+        }
+    }
+
+    private func scheduleHide() {
+        guard isShown else { return }
+        hideTask?.cancel()
+        hideTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard let self, !Task.isCancelled else { return }
+            guard !self.triggerHovered && !self.popoverHovered else { return }
+            self.isShown = false
+            self.onHide()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build and run existing tests**
+
+Run: `swift build`
+Expected: clean build.
+
+Run: `swift test`
+Expected: all existing tests still pass (App Shortcuts behaviour preserved because `needsKeyFocus` defaults to `false`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/HoverPopover.swift
+git commit -m "refactor(hover): opt-in key-focus via NSPanel + reset gate helper"
+```
+
+---
+
+## Task 14: Generalise `PanelSettingsView` hotkey filter for any submenu
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/PanelSettingsView.swift`
+
+- [ ] **Step 1: Read the current code**
+
+Open `Sources/AnyDoor/Views/PanelSettingsView.swift`. The function around line 90 is:
+
+```swift
+    @ViewBuilder
+    private func hotkeyField(for entry: PanelEntry) -> some View {
+        if case .builtin(.appShortcuts) = entry.source {
+            // The submenu itself has no hotkey (children do); reserve column width
+            // for alignment without showing a meaningless placeholder.
+            Color.clear.frame(width: 130)
+        } else {
+            HotkeyRecorder(hotkey: .constant(entry.hotkey)) { newValue in
+                handleHotkeyChange(entry: entry, newValue: newValue)
+            }
+            .frame(width: 130, alignment: .trailing)
+        }
+    }
+```
+
+- [ ] **Step 2: Replace with the generalised filter**
+
+Replace the function body with:
+
+```swift
+    @ViewBuilder
+    private func hotkeyField(for entry: PanelEntry) -> some View {
+        // Any submenu-kind builtin has no hotkey (children carry their own, or
+        // the submenu is opened by hovering). Reserve the column width so the
+        // grid stays aligned.
+        if case let .builtin(item) = entry.source, item.kind == .submenu {
+            Color.clear.frame(width: 130)
+        } else {
+            HotkeyRecorder(hotkey: .constant(entry.hotkey)) { newValue in
+                handleHotkeyChange(entry: entry, newValue: newValue)
+            }
+            .frame(width: 130, alignment: .trailing)
+        }
+    }
+```
+
+- [ ] **Step 3: Build and run tests**
+
+Run: `swift build`
+Run: `swift test`
+Expected: all pass; no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PanelSettingsView.swift
+git commit -m "fix(settings): hide hotkey recorder for any submenu-kind builtin"
+```
+
+---
+
+## Task 15: Build `PortListView` with `PortRowView` and `PortStatusDot`
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/PortListView.swift`
+
+UI tasks are validated by the build (no unit tests for SwiftUI views).
+
+- [ ] **Step 1: Create the file**
+
+Create `Sources/AnyDoor/Views/PortListView.swift`:
+
+```swift
+import SwiftUI
+
+struct PortListView: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(inventory.filteredRecords) { record in
+                    PortRowView(record: record, inventory: inventory)
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+struct PortRowView: View {
+    let record: PortRecord
+    @Bindable var inventory: PortInventory
+    @State private var isHovered = false
+
+    private var rowState: PortStatusDot.State {
+        if inventory.failedKillPIDs[record.pid] != nil { return .failed }
+        if inventory.killingPIDs.contains(record.pid)  { return .killing }
+        return .listening
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            PortStatusDot(state: rowState).frame(width: 10)
+            Text(":\(record.port)")
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .frame(minWidth: 60, alignment: .leading)
+            Text(record.processName)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("PID \(record.pid)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            trailingControl
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(isHovered ? Color.white.opacity(0.04) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .help(tooltipText)
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch rowState {
+        case .killing:
+            ProgressView().controlSize(.small)
+        case .failed:
+            Button {
+                inventory.dismissError(for: record.pid)
+            } label: {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+        case .listening:
+            if isHovered {
+                Button {
+                    Task { await inventory.kill(pid: record.pid) }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("kill PID \(record.pid)")
+            } else {
+                Color.clear.frame(width: 16, height: 16)
+            }
+        }
+    }
+
+    private var tooltipText: String {
+        var lines: [String] = [record.processName]
+        if let cmd = record.commandLine, !cmd.isEmpty, cmd != record.processName {
+            lines.append(cmd)
+        }
+        if let path = record.executablePath, !path.isEmpty { lines.append(path) }
+        lines.append("")
+        lines.append("Binds:")
+        for bind in record.binds {
+            lines.append("  \(bind.address) (\(bind.family.rawValue))")
+        }
+        if let failure = inventory.failedKillPIDs[record.pid] {
+            lines.append("")
+            switch failure.reason {
+            case .permissionDenied:
+                lines.append("kill 失败：权限不足（系统/其他用户进程）")
+            case .processGone:
+                lines.append("kill 失败：进程已退出")
+            case .other(let code):
+                lines.append("kill 失败 (errno: \(code))")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct PortStatusDot: View {
+    enum State { case listening, killing, failed }
+    let state: State
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+    }
+
+    private var color: Color {
+        switch state {
+        case .listening: return .green
+        case .killing:   return .gray
+        case .failed:    return .red
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PortListView.swift
+git commit -m "feat(ui): PortListView with hover-revealed kill icon"
+```
+
+---
+
+## Task 16: Build `PortTreeView` with bind summary
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/PortTreeView.swift`
+
+- [ ] **Step 1: Create the file**
+
+Create `Sources/AnyDoor/Views/PortTreeView.swift`:
+
+```swift
+import SwiftUI
+
+struct PortTreeView: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(inventory.groupedByProcess) { group in
+                    PortProcessGroupRow(group: group, inventory: inventory)
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+private struct PortProcessGroupRow: View {
+    let group: ProcessGroup
+    @Bindable var inventory: PortInventory
+    @State private var isExpanded: Bool = false
+    @State private var isHeaderHovered: Bool = false
+
+    private var rowState: PortStatusDot.State {
+        if inventory.failedKillPIDs[group.pid] != nil { return .failed }
+        if inventory.killingPIDs.contains(group.pid)  { return .killing }
+        return .listening
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if isExpanded {
+                ForEach(group.ports) { record in
+                    leaf(record)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 8) {
+            Button {
+                isExpanded.toggle()
+            } label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .frame(width: 12)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+            PortStatusDot(state: rowState).frame(width: 10)
+            Text(group.processName)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("PID \(group.pid)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if !isExpanded {
+                Text("\(group.ports.count)")
+                    .font(.caption)
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Capsule().fill(Color.secondary.opacity(0.15)))
+            }
+            trailingControl
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(isHeaderHovered ? Color.white.opacity(0.04) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { isHeaderHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch rowState {
+        case .killing:
+            ProgressView().controlSize(.small)
+        case .failed:
+            Button {
+                inventory.dismissError(for: group.pid)
+            } label: {
+                Image(systemName: "exclamationmark.circle.fill").foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+        case .listening:
+            if isHeaderHovered {
+                Button {
+                    Task { await inventory.kill(pid: group.pid) }
+                } label: {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("kill PID \(group.pid)")
+            } else {
+                Color.clear.frame(width: 16, height: 16)
+            }
+        }
+    }
+
+    private func leaf(_ record: PortRecord) -> some View {
+        HStack(spacing: 12) {
+            Spacer().frame(width: 28)
+            Text(":\(record.port)")
+                .font(.system(.body, design: .monospaced))
+                .frame(minWidth: 60, alignment: .leading)
+            Text(bindSummary(for: record))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .help(record.binds.map { "\($0.address) (\($0.family.rawValue))" }.joined(separator: "\n"))
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    private func bindSummary(for record: PortRecord) -> String {
+        let binds = record.binds
+        switch binds.count {
+        case 0:
+            return ""
+        case 1:
+            return binds[0].address
+        case 2:
+            if Set(binds.map(\.family)) == Set([.ipv4, .ipv6]) {
+                let v4 = binds.first(where: { $0.family == .ipv4 })?.address ?? ""
+                let v6 = binds.first(where: { $0.family == .ipv6 })?.address ?? ""
+                return "\(v4) · \(v6)"
+            }
+            return binds.map(\.address).joined(separator: " · ")
+        default:
+            return "\(binds.count) binds"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PortTreeView.swift
+git commit -m "feat(ui): PortTreeView with collapsible process groups + bind summary"
+```
+
+---
+
+## Task 17: Assemble `PortManagerPopoverView` + header + toolbar + banner + keyboard monitor
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/PortManagerPopoverView.swift`
+
+- [ ] **Step 1: Create the file**
+
+Create `Sources/AnyDoor/Views/PortManagerPopoverView.swift`:
+
+```swift
+import SwiftUI
+import AppKit
+
+struct PortManagerPopoverView: View {
+    @Bindable var inventory: PortInventory
+    var onHoverChange: (Bool) -> Void
+    var onClose: () -> Void
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PortManagerHeader(
+                inventory: inventory,
+                searchFocused: $searchFocused
+            )
+            if let err = inventory.lastError {
+                PortScanErrorBanner(error: err) {
+                    Task { await inventory.refresh() }
+                }
+            }
+            content
+            Divider()
+            PortManagerToolbar(inventory: inventory)
+        }
+        .frame(width: 340)
+        .frame(minHeight: 280, maxHeight: 560)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .task {
+            await inventory.refresh()
+            searchFocused = true
+        }
+        .onHover(perform: onHoverChange)
+        .background(KeyboardMonitor(inventory: inventory, onClose: onClose))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if inventory.isRefreshing && inventory.records.isEmpty {
+            VStack {
+                Spacer()
+                ProgressView("扫描中...")
+                Spacer()
+            }
+        } else if inventory.filteredRecords.isEmpty {
+            VStack {
+                Spacer()
+                Text("无匹配的端口").foregroundStyle(.secondary)
+                Spacer()
+            }
+        } else {
+            switch inventory.viewMode {
+            case .list: PortListView(inventory: inventory)
+            case .tree: PortTreeView(inventory: inventory)
+            }
+        }
+    }
+}
+
+private struct PortManagerHeader: View {
+    @Bindable var inventory: PortInventory
+    var searchFocused: FocusState<Bool>.Binding
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "globe").foregroundStyle(.secondary)
+            TextField("Search...", text: $inventory.searchText)
+                .textFieldStyle(.plain)
+                .focused(searchFocused)
+            ZStack {
+                if inventory.isRefreshing {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("\(inventory.filteredRecords.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 8).padding(.vertical, 2)
+            .background(Capsule().fill(Color.secondary.opacity(0.15)))
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+    }
+}
+
+private struct PortManagerToolbar: View {
+    @Bindable var inventory: PortInventory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                Task { await inventory.refresh() }
+            } label: {
+                HStack {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                    Spacer()
+                    Text("⌘R").foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12).padding(.vertical, 8)
+
+            Button {
+                inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list
+            } label: {
+                HStack {
+                    Label(
+                        inventory.viewMode == .list ? "Tree View" : "List View",
+                        systemImage: "list.bullet.indent"
+                    )
+                    Spacer()
+                    Text("⌘T").foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12).padding(.vertical, 8)
+        }
+    }
+}
+
+private struct PortScanErrorBanner: View {
+    let error: PortInventoryError
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+            Text(message).font(.caption)
+            Spacer()
+            Button(action: retry) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+        .background(Color.yellow.opacity(0.15))
+    }
+
+    private var message: String {
+        switch error {
+        case .scanFailed(let detail):
+            return "刷新失败：\(detail)"
+        }
+    }
+}
+
+/// Installs a local NSEvent key-down monitor while mounted. Handles ⌘R, ⌘T, ESC.
+private struct KeyboardMonitor: NSViewRepresentable {
+    @Bindable var inventory: PortInventory
+    var onClose: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(inventory: inventory, onClose: onClose)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.install()
+        return NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onClose = onClose
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    final class Coordinator {
+        let inventory: PortInventory
+        var onClose: () -> Void
+        private var monitor: Any?
+
+        init(inventory: PortInventory, onClose: @escaping () -> Void) {
+            self.inventory = inventory
+            self.onClose = onClose
+        }
+
+        func install() {
+            uninstall()
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                let cmd = event.modifierFlags.contains(.command)
+                let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
+                if cmd && chars == "r" {
+                    Task { @MainActor in await self.inventory.refresh() }
+                    return nil
+                }
+                if cmd && chars == "t" {
+                    Task { @MainActor in
+                        self.inventory.viewMode = (self.inventory.viewMode == .list) ? .tree : .list
+                    }
+                    return nil
+                }
+                if event.keyCode == 53 { // ESC
+                    Task { @MainActor in
+                        if self.inventory.searchText.isEmpty {
+                            self.onClose()
+                        } else {
+                            self.inventory.searchText = ""
+                        }
+                    }
+                    return nil
+                }
+                return event
+            }
+        }
+
+        func uninstall() {
+            if let m = monitor { NSEvent.removeMonitor(m) }
+            monitor = nil
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PortManagerPopoverView.swift
+git commit -m "feat(ui): PortManagerPopoverView assembly with header, toolbar, keyboard monitor"
+```
+
+---
+
+## Task 18: Wire `PortManagerPopoverView` into `MenuBarView`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift`
+
+- [ ] **Step 1: Update MenuBarView**
+
+Open `Sources/AnyDoor/Views/MenuBarView.swift`. We need to:
+
+1. Replace the single `triggerFrame: NSRect` state with a dictionary `triggerFrames: [BuiltinItem: NSRect]` keyed by submenu item.
+2. Extend `rowView(for:)` to handle any `.submenu`-kind builtin (currently special-cases `.appShortcuts`).
+3. Track which submenu is "active" so `gate.onShow` can mount the right popover.
+4. Add `mountPopoverContent(for:)` switch on `BuiltinItem` (App Shortcuts keeps current behaviour with `AppSwitcher.toggle` calls; Port Manager mounts `PortManagerPopoverView` with `needsKeyFocus = true`).
+5. Make `onDisappear` guard on `popover.isHoldingFocus`.
+
+Replace the file contents with:
+
+```swift
+import SwiftUI
+import AppKit
+
+struct MenuBarView: View {
+    @State private var panel = PanelStore.shared
+    @State private var popover = HoverPopover { EmptyView() }
+    @State private var gate = HoverGate()
+    @State private var triggerFrames: [BuiltinItem: NSRect] = [:]
+    @State private var activeSubmenu: BuiltinItem? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("AnyDoor").font(.headline)
+                Spacer()
+                let count = panel.topLevelEntries.filter(\.isVisible).count
+                Text("\(count) 个已启用").font(.caption).foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12).padding(.top, 4)
+
+            GlassEffectContainer(spacing: 2) {
+                VStack(spacing: 2) {
+                    ForEach(panel.topLevelEntries.filter(\.isVisible)) { entry in
+                        rowView(for: entry)
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+
+            HStack(spacing: 8) {
+                SettingsLink { Label("设置", systemImage: "gear") }
+                    .buttonStyle(.glass)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        NSApplication.shared.activate()
+                    })
+                Button { NSApplication.shared.terminate(nil) } label: {
+                    Label("退出", systemImage: "power")
+                }.buttonStyle(.glass)
+                Spacer()
+            }
+            .focusEffectDisabled()
+            .padding(.horizontal, 8).padding(.bottom, 4)
+        }
+        .padding(.vertical, 8).padding(.horizontal, 4)
+        .frame(width: 260)
+        .fixedSize(horizontal: false, vertical: true)
+        .task {
+            await panel.refreshAll()
+        }
+        .onAppear { wireGate() }
+        .onDisappear {
+            // Don't hide if the popover took key focus deliberately (port-manager
+            // search field). Otherwise hide as before.
+            if !popover.isHoldingFocus { popover.hide() }
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(for entry: PanelEntry) -> some View {
+        if case let .builtin(item) = entry.source, item.kind == .submenu {
+            PanelRowView(
+                entry: entry,
+                onToggle: {},
+                onAction: {},
+                onSubmenu: { triggerSubmenu(item) },
+                onPermission: openPermissionsSettings
+            )
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.onAppear {
+                        triggerFrames[item] = proxy.frame(in: .global)
+                    }.onChange(of: proxy.frame(in: .global)) { _, new in
+                        triggerFrames[item] = new
+                    }
+                }
+            )
+            .onHover { hovered in
+                if hovered { activeSubmenu = item }
+                gate.triggerHover(hovered)
+            }
+        } else {
+            PanelRowView(
+                entry: entry,
+                onToggle: {
+                    if case let .builtin(builtin) = entry.source {
+                        Task { await panel.toggle(builtin) }
+                    }
+                },
+                onAction: {
+                    if case let .builtin(builtin) = entry.source {
+                        Task { await panel.run(builtin) }
+                    }
+                },
+                onSubmenu: {},
+                onPermission: openPermissionsSettings
+            )
+        }
+    }
+
+    private func wireGate() {
+        gate.onShow = {
+            guard let item = activeSubmenu else { return }
+            mountPopoverContent(for: item)
+            popover.show(anchoredTo: convertedTriggerFrame(for: item))
+        }
+        gate.onHide = {
+            popover.scheduleHide()
+            popover.needsKeyFocus = false
+        }
+    }
+
+    private func mountPopoverContent(for item: BuiltinItem) {
+        switch item {
+        case .appShortcuts:
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                AppShortcutsPopoverView(
+                    entries: panel.appShortcutChildren,
+                    onHoverChange: { gate.popoverHover($0) },
+                    onSelect: { entry in
+                        if case let .appShortcut(id) = entry.source,
+                           let binding = panel.binding(id: id) {
+                            AppSwitcher.toggle(
+                                bundleID: binding.appBundleID,
+                                appPath: binding.appPath
+                            )
+                        }
+                    },
+                    appPath: { entry in
+                        guard case let .appShortcut(id) = entry.source,
+                              let binding = panel.binding(id: id) else { return nil }
+                        return binding.appPath
+                    }
+                )
+            }
+        case .portManager:
+            popover.needsKeyFocus = true
+            popover.updateContent {
+                PortManagerPopoverView(
+                    inventory: PortInventory.shared,
+                    onHoverChange: { gate.popoverHover($0) },
+                    onClose: {
+                        PortInventory.shared.searchText = ""
+                        gate.reset()
+                        popover.hide()
+                    }
+                )
+            }
+        default:
+            break
+        }
+    }
+
+    /// Convert the panel-local rect to screen coordinates by adding the menu bar
+    /// window's origin. Same approach as the previous single-trigger implementation.
+    private func convertedTriggerFrame(for item: BuiltinItem) -> NSRect {
+        let local = triggerFrames[item] ?? .zero
+        guard let window = NSApp.windows.first(where: { $0.isVisible }) else { return local }
+        return window.convertToScreen(local)
+    }
+
+    private func triggerSubmenu(_ item: BuiltinItem) {
+        activeSubmenu = item
+        gate.showImmediately()
+    }
+
+    private func openPermissionsSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+```
+
+Notes for the implementer:
+
+- The existing file imports may include only `SwiftUI` and `AppKit`. Match the existing import list rather than adding others.
+- `AppShortcutsPopoverView`'s initializer surface (`entries:`/`onHoverChange:`/`onSelect:`/`appPath:`) is exactly what the current code uses — do not change it. The replacement preserves the App Shortcuts behaviour 1:1; only the data plumbing through `triggerFrames` and `activeSubmenu` is new.
+- `AppSwitcher.toggle(bundleID:appPath:)` is the existing call used for App Shortcuts taps. Keep it.
+- `PortInventory.shared` is accessed from the closure. If Swift 6 actor isolation flags this as an issue, change the closure to wrap the body in `Task { @MainActor in ... }` or import the singleton through a captured local.
+
+- [ ] **Step 2: Verify `PanelStore` API surface is unchanged**
+
+Sanity-check that the helpers used by the App Shortcuts branch still exist:
+
+```bash
+grep -n 'func binding\|appShortcutChildren' Sources/AnyDoor/Services/PanelStore.swift
+```
+
+Expected: both are present (`binding(id:)` at ~line 218; `appShortcutChildren` declared near the top).
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: clean build.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `swift test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/MenuBarView.swift
+git commit -m "feat(ui): wire port manager popover through hover dispatch"
+```
+
+---
+
+## Task 19: Manual QA pass
+
+This task is a checklist, not a code change. Mark each item as done after performing it.
+
+- [ ] **Step 1: Build and launch the app**
+
+Run: `swift run AnyDoor`
+
+The app should appear in the menu bar with the existing door icon. macOS may prompt for accessibility permission — grant it.
+
+- [ ] **Step 2: Verify port-manager entry is present in the menu**
+
+Click the menu bar icon. The panel should list all existing entries plus a new "端口管理" row near the bottom.
+
+- [ ] **Step 3: Verify Settings shows no hotkey recorder for the new row**
+
+Open Settings → Panel tab. The "端口管理" row should display the type badge "系统 · 子菜单" and have no hotkey input field (the same alignment column reserved for App Shortcuts).
+
+- [ ] **Step 4: Hover the port-manager row**
+
+After ~400ms, a popover should appear to the right of the menu bar panel. It should show:
+
+- Globe icon, search field (with cursor), count capsule.
+- A scrolling list of `:port  process  PID xxxxx` rows.
+- Bottom toolbar with "Refresh ⌘R" and "Tree View ⌘T" entries.
+
+- [ ] **Step 5: Verify search**
+
+Type "node" (or any process name visible in the list). The list should filter live and the count capsule updates.
+
+Type a port number (e.g. `30`) — port-matching rows appear before name-matching ones.
+
+Press ESC. The search clears; press ESC again — the popover closes and reopens cleanly on the next hover.
+
+- [ ] **Step 6: Verify view toggle**
+
+Press ⌘T. View flips to tree mode with collapsed process groups. Click a chevron to expand; verify leaf rows show `:port` plus a bind summary like `*` or `127.0.0.1 · ::1`.
+
+Press ⌘T again to flip back. Quit the app and relaunch — the last-used view should persist.
+
+- [ ] **Step 7: Verify kill (user process)**
+
+Start a test listener in another terminal:
+
+```bash
+python3 -m http.server 9999 &
+```
+
+Wait a few seconds, press ⌘R in the popover. Find the `:9999` row, hover it, click the `xmark.circle.fill`. Within ~1 second the row should disappear.
+
+`ps aux | grep 9999` should show no remaining process.
+
+- [ ] **Step 8: Verify kill (root process)**
+
+Find a row owned by a system process (e.g. `ControlCenter`). Hover and click kill. The row should show a red error icon with a tooltip saying "kill 失败：权限不足（系统/其他用户进程）". The indicator should disappear after ~3 seconds. The process keeps running.
+
+- [ ] **Step 9: Verify the menu bar panel doesn't auto-close**
+
+While typing in the search field, look at the menu bar panel — it should remain visible behind the popover. If the menu bar panel collapses when the popover takes focus, **the key-focus implementation needs the fallback path** (local NSEvent monitor without taking key focus). Document the observation, then switch the popover to `needsKeyFocus = false` in `MenuBarView.mountPopoverContent(for: .portManager)` and reroute printable keys via the existing `KeyboardMonitor`. (This contingency is also in the design spec under "Fallback if MenuBarExtra still collapses".)
+
+- [ ] **Step 10: Verify App Shortcuts is unaffected**
+
+Hover App Shortcuts; the existing popover should appear with no typing cursor, no app activation steal, and behave exactly as before.
+
+- [ ] **Step 11: Commit any tweaks**
+
+If the QA pass required spec-fallback tweaks (e.g. dropping `needsKeyFocus`), commit them as a follow-up:
+
+```bash
+git add Sources/AnyDoor/Views/MenuBarView.swift
+git commit -m "fix(ui): use no-key-focus fallback for port manager popover"
+```
+
+Otherwise mark this task complete with no commit.
+
+---
+
+## Self-Review Checklist (for the planning agent only)
+
+Before handing off to executing-plans:
+
+- [ ] Every spec section has a corresponding task (BuiltinItem, HotkeyAction-deferred, PortScanner, PortInventory, UI layer, error handling, testing, manual QA).
+- [ ] No placeholders, no "TBD"s in the plan body.
+- [ ] All type names match across tasks: `PortRecord`, `PortBind`, `AddressFamily`, `SignalResult`, `PortScanning`, `SubprocessRunning`, `SubprocessResult`, `SubprocessError`, `PortScanError`, `PortInventory`, `ViewMode`, `KillFailure`, `PortInventoryError`, `ProcessGroup`, `LsofRunner`, `KeyableHoverPanel`, `HoverGate`, `HoverPopover`, `PortListView`, `PortRowView`, `PortStatusDot`, `PortTreeView`, `PortManagerPopoverView`, `KeyboardMonitor`.
+- [ ] Method names consistent: `parseLsofOutput`, `parseProcArgs`, `parseAddressPort`, `decodeLsofEscapes`, `scanTCPListening`, `kill(pid:signal:)`, `refresh()`, `kill(pid:)`, `dismissError(for:)`, `filteredRecords`, `groupedByProcess`, `gate.reset()`, `needsKeyFocus`, `isHoldingFocus`.
+- [ ] Generation token + inflightCount semantics covered by `testIsRefreshingClearsOnlyWhenAllInflightFinish`.
+- [ ] ESRCH success semantics covered at both SIGTERM and SIGKILL sites by tests.
+- [ ] No new dependencies (only `OSAllocatedUnfairLock` from `os`, already available).
+- [ ] All commits use Conventional Commits in English.
+
+---
+
+## Execution Note
+
+Tasks 1–18 modify code with tests; Task 19 is a manual QA gate. The plan assumes the agent has macOS available to run `swift test` (XCTest on macOS). Tests cannot run in a sandbox without a working macOS toolchain.

--- a/docs/superpowers/specs/2026-05-21-port-management-design.md
+++ b/docs/superpowers/specs/2026-05-21-port-management-design.md
@@ -87,6 +87,24 @@ New case in `Sources/AnyDoor/Models/BuiltinItem.swift`:
 
 No changes to `HotkeyAction`, `PanelStore.rebuildHotkeySnapshots`, or `HotkeyService` in this iteration. `PanelStore` already skips snapshot generation for items whose `kind == .submenu` (see `PanelStore.swift:202`), and the menu bar only resolves the popover anchor for the App Shortcuts row (`MenuBarView.swift:62`). Designing a "global hotkey opens menu bar then mounts a submenu popover" flow requires its own design pass and is intentionally out of scope.
 
+**Settings UI must also hide the hotkey recorder for every submenu, not just App Shortcuts.** `PanelSettingsView.swift:92` currently special-cases `.builtin(.appShortcuts)`:
+
+```swift
+if case .builtin(.appShortcuts) = entry.source {
+    Color.clear.frame(width: 130)   // reserve column width
+}
+```
+
+Generalise this to all submenu-kind items so `.portManager` (and any future submenu) does not render a recorder the user can fill in but the system silently ignores:
+
+```swift
+if case let .builtin(item) = entry.source, item.kind == .submenu {
+    Color.clear.frame(width: 130)
+}
+```
+
+This is a one-line change and ships in the same iteration.
+
 ### 3. `PortScanner` (actor)
 
 Files:
@@ -149,44 +167,84 @@ Capturing `errno` **immediately after** the `Darwin.kill` call (before any other
 
 The existing `ShellRunner` calls `pipe.fileHandleForReading.readToEnd()` after the process has already exited, which deadlocks once stdout exceeds the pipe buffer (~16 KiB). `lsof` listing 50–200 open TCP files reliably exceeds that.
 
-`PortScanner` ships its own private runner that drains pipes concurrently with the running process. Sketch:
+`PortScanner` defines a `SubprocessRunning` protocol so the runner can be stubbed in tests (the "lsof exit 1 with empty stdout/stderr" case lives at the runner layer, not the parser layer):
 
 ```swift
-private func runProcess(
-    path: String, args: [String], timeout: Duration
-) async throws -> (stdout: String, stderr: String, exit: Int32) {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: path)
-    process.arguments = args
-    let outPipe = Pipe(), errPipe = Pipe()
-    process.standardOutput = outPipe
-    process.standardError = errPipe
-    try process.run()
+protocol SubprocessRunning: Sendable {
+    func run(
+        path: String, args: [String], timeout: Duration
+    ) async throws -> SubprocessResult
+}
 
-    // Drain pipes on detached tasks so the kernel buffer never fills.
-    async let outData = readAll(outPipe.fileHandleForReading)
-    async let errData = readAll(errPipe.fileHandleForReading)
+struct SubprocessResult: Sendable, Equatable {
+    let stdout: String
+    let stderr: String
+    let exit: Int32
+    let timedOut: Bool
+}
 
-    // Timeout watchdog terminates the process. The read tasks then finish
-    // naturally because the file handles hit EOF.
-    let watchdog = Task {
-        try? await Task.sleep(for: timeout)
-        if process.isRunning { process.terminate() }
-    }
-
-    let (out, err) = await (outData, errData)
-    watchdog.cancel()
-    process.waitUntilExit()  // already returned, but ensures status is set
-
-    return (
-        stdout: String(data: out, encoding: .utf8) ?? "",
-        stderr: String(data: err, encoding: .utf8) ?? "",
-        exit: process.terminationStatus
-    )
+enum SubprocessError: Error, Equatable {
+    case spawnFailed(String)
 }
 ```
 
-The runner is private to `PortScanner` — other features keep using `ShellRunner` for short outputs.
+`PortScanner.init(runner:)` accepts any `any SubprocessRunning` (defaulting to the real one). Tests inject a stub that returns canned `SubprocessResult` values.
+
+The real implementation drains pipes concurrently with the running process and honors both timeout and Task cancellation:
+
+```swift
+struct LsofRunner: SubprocessRunning {
+    func run(
+        path: String, args: [String], timeout: Duration
+    ) async throws -> SubprocessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = args
+        let outPipe = Pipe(), errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        do { try process.run() }
+        catch { throw SubprocessError.spawnFailed("\(error)") }
+
+        // Honor cancellation: if the awaiting Task is cancelled, terminate
+        // the child. The read async-lets then hit EOF and unblock.
+        return try await withTaskCancellationHandler {
+            // Drain pipes concurrently so the kernel buffer never fills.
+            async let outData: Data = readAll(outPipe.fileHandleForReading)
+            async let errData: Data = readAll(errPipe.fileHandleForReading)
+
+            // Timeout watchdog terminates the child on deadline.
+            let timedOut = ManagedAtomic(false)   // or actor-isolated Bool
+            let watchdog = Task {
+                try? await Task.sleep(for: timeout)
+                if process.isRunning {
+                    timedOut.store(true, ordering: .relaxed)
+                    process.terminate()
+                }
+            }
+
+            let (out, err) = await (outData, errData)
+            watchdog.cancel()
+            process.waitUntilExit()   // already returned; ensures status set
+
+            return SubprocessResult(
+                stdout: String(data: out, encoding: .utf8) ?? "",
+                stderr: String(data: err, encoding: .utf8) ?? "",
+                exit: process.terminationStatus,
+                timedOut: timedOut.load(ordering: .relaxed)
+            )
+        } onCancel: {
+            // Called when the *outer* Task is cancelled. Process.terminate()
+            // is thread-safe.
+            if process.isRunning { process.terminate() }
+        }
+    }
+}
+```
+
+`scanTCPListening()` inspects `SubprocessResult.timedOut` first; when true it throws `PortScanError.lsofTimeout` regardless of exit status. When false, it applies the empty-result rule (exit 1 + empty stdout/stderr → `[]`) and otherwise the failure rule.
+
+`LsofRunner` lives in `PortScanner.swift` alongside the actor; other features keep using `ShellRunner` for their short outputs. `Bool`-flag implementation detail can use `os_unfair_lock` or actor isolation if `ManagedAtomic` is overkill — the point is "the runner returns whether it timed out, the scanner branches on it."
 
 #### Scanning pipeline
 
@@ -229,7 +287,7 @@ final class PortInventory {
     }
     var searchText: String = ""
 
-    init(scanner: PortScanning = PortScanner()) { ... }
+    init(scanner: any PortScanning = PortScanner()) { ... }
 
     func refresh() async
     func kill(pid: pid_t) async
@@ -256,12 +314,15 @@ struct KillFailure: Equatable, Sendable {
 #### Refresh
 
 - Entry points: popover `.task`, ⌘R, automatic after a kill.
-- Concurrency model: a monotonically incrementing `refreshGeneration: UInt64` token. Each `refresh()` call:
-  1. Increments the generation and captures `let myGen = refreshGeneration`.
-  2. Awaits the scanner. The scanner's subprocess runner is responsible for terminating the lsof child when its enclosing Task is cancelled or hits the timeout (see the runner sketch above) — Swift's `Task.cancel` alone does not kill a running `Process`.
-  3. After awaiting, checks `guard myGen == refreshGeneration else { return }`. A stale completion is discarded; only the latest scan can overwrite `records`.
-- On failure, `lastError` is set and `records` is preserved. (Staleness check still applies — a stale failure does not overwrite a fresh success.)
-- A single in-flight scan is the steady state; overlapping refreshes are tolerated but only the newest result lands. We do **not** try to cancel the old subprocess on a new request — lsof is fast enough that the simple "newest wins" rule is sufficient.
+- Concurrency model: a monotonically incrementing `refreshGeneration: UInt64` token plus an `inflightCount: Int` counter:
+  1. Each `refresh()` call increments `refreshGeneration`, captures `let myGen = refreshGeneration`, increments `inflightCount`, and sets `isRefreshing = true`.
+  2. Awaits the scanner. The scanner's subprocess runner is responsible for terminating the lsof child on cancellation or timeout (see the runner sketch above) — Swift's `Task.cancel` alone does not kill a running `Process`.
+  3. After awaiting: decrement `inflightCount`. Then:
+     - `guard myGen == refreshGeneration else { isRefreshing = (inflightCount > 0); return }` — stale completion is discarded but the spinner remains on if a newer scan is still running.
+     - On the latest generation, write `records` / `lastError` and set `isRefreshing = (inflightCount > 0)`.
+- The rule that matters: **`isRefreshing = false` happens only when no scans are in flight**, regardless of whether the resolved one was the latest. This prevents a stale early completion from clearing the spinner while the newest scan is still running.
+- On failure, `lastError` is set and `records` is preserved. A stale failure does not overwrite a fresh success (same generation-token gate).
+- We do **not** try to cancel the old subprocess on a new request — lsof is fast enough (~tens of ms) that the simple "newest wins" rule is sufficient. The runner's task-cancellation handler exists for the harder case (popover dismissed mid-scan) where the parent Task itself gets cancelled.
 
 #### Kill policy (two-phase)
 
@@ -347,47 +408,64 @@ File: `Sources/AnyDoor/Views/PortManagerPopoverView.swift`
 
 Structure:
 
-```
-VStack(spacing: 0) {
-    PortManagerHeader(inventory: ...)        // globe icon + search + count
-    if let err = inventory.lastError {
-        ScanErrorBanner(error: err, retry: { await inventory.refresh() })
-    }
-    Group {
-        if inventory.isRefreshing && inventory.records.isEmpty {
-            ProgressView("扫描中...")
-        } else if inventory.filteredRecords.isEmpty {
-            Text("无匹配的端口").foregroundStyle(.secondary)
-        } else {
-            switch inventory.viewMode {
-            case .list: PortListView()
-            case .tree: PortTreeView()
+```swift
+struct PortManagerPopoverView: View {
+    @Bindable var inventory: PortInventory   // the singleton
+    var onHoverChange: (Bool) -> Void        // callback to HoverGate.popoverHover
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PortManagerHeader(inventory: inventory)
+            if let err = inventory.lastError {
+                ScanErrorBanner(error: err, retry: { await inventory.refresh() })
             }
+            Group {
+                if inventory.isRefreshing && inventory.records.isEmpty {
+                    ProgressView("扫描中...")
+                } else if inventory.filteredRecords.isEmpty {
+                    Text("无匹配的端口").foregroundStyle(.secondary)
+                } else {
+                    switch inventory.viewMode {
+                    case .list: PortListView(inventory: inventory)
+                    case .tree: PortTreeView(inventory: inventory)
+                    }
+                }
+            }
+            Divider()
+            PortManagerToolbar(inventory: inventory)
         }
+        .frame(width: 340)
+        .frame(minHeight: 280, maxHeight: 560)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .task { await inventory.refresh() }
+        .onHover(perform: onHoverChange)   // critical: keeps popover open while hovered
+        .background(KeyboardMonitor(inventory: inventory))
     }
-    Divider()
-    PortManagerToolbar(inventory: ...)       // Refresh ⌘R / Toggle View ⌘T
 }
-.frame(width: 340)
-.frame(minHeight: 280, maxHeight: 560)
-.task { await inventory.refresh() }
-.background(KeyboardMonitor(inventory: ...)) // local NSEvent monitor
 ```
+
+The `onHoverChange` callback mirrors `AppShortcutsPopoverView.swift:51` and feeds into `HoverGate.popoverHover(_:)`. Without it, the gate only tracks the trigger row's hover state, and the popover closes 300ms after the cursor leaves the menu bar row even though the cursor is inside the popover. `MenuBarView` is responsible for wiring this callback when it constructs the view (just like it does for App Shortcuts today).
 
 #### `PortListView` / `PortRowView`
 
 - One row per `PortRecord`, sorted by port ascending.
 - Layout: `[status dot] [:port monospaced] [process name] [PID xxxxx] [kill icon on hover]`
+- Bind addresses (`record.binds`) are surfaced via tooltip on hover (`help(...)` modifier). The tooltip string format: `"\(processName)\n\(commandLine ?? "")\n\nBinds:\n\(binds.map { "\($0.address) (\($0.family.rawValue))" }.joined(separator: "\n"))"`. The list row stays compact (matches the mockup) — binds are surfaced on demand, not in the primary visual.
 - Status dot: green (default), gray + spinner (killing), red (failed).
-- Process name truncates tail; tooltip shows `commandLine ?? processName`.
+- Process name truncates tail.
 - Kill icon: `xmark.circle.fill`, hidden until row hover; replaced by spinner while `killingPIDs` contains the pid; replaced by `exclamationmark.circle.fill` (red) while `failedKillPIDs` contains the pid.
 - Tap kill → `Task { await inventory.kill(pid: record.pid) }`.
 
-#### `PortTreeView` / `PortProcessGroupView`
+#### `PortTreeView` / process group rendering
 
 - One `DisclosureGroup` per `ProcessGroup`, all collapsed by default.
 - Group header: `[chevron] [status dot] [process name] [PID xxxxx] [collapsed-only: port count capsule] [kill icon on hover]`.
-- Leaf rows: `:port` + bind-address subtitle (`* · :5000` or `127.0.0.1 · :3000`); no kill icon on leaves.
+- Leaf rows: `[:port monospaced] [bind summary]`. The bind summary is computed from `record.binds`:
+  - 1 bind → `"\(bind.address)"` (e.g. `*`, `127.0.0.1`, `[::1]`).
+  - 2 binds, exactly one IPv4 and one IPv6 → `"\(ipv4.address) · \(ipv6.address)"` (typical dual-stack case; matches the mockup's "* · :5000" intent except now driven by real data).
+  - More than 2 → `"\(binds.count) binds"` with tooltip listing them in full.
+- Leaf rows still have **no** kill icon (per earlier decision).
 - Tap group's kill icon → `Task { await inventory.kill(pid: group.pid) }`.
 - Expansion state in `@State` only; not persisted.
 
@@ -396,6 +474,15 @@ VStack(spacing: 0) {
 - Left: SF Symbol `globe` (matches mockups).
 - Middle: search field, auto-focused on appear; `@FocusState` binding.
 - Right: count capsule showing `filteredRecords.count`, accompanied by a small spinner when `isRefreshing` is true.
+
+**Window key-focus contract.** The existing `HoverPopover` (`HoverPopover.swift:14`) hosts content in a borderless, `level = .floating` `NSWindow` that is shown with `orderFrontRegardless()`. A bare `NSWindow` like that returns `false` from `canBecomeKey` and therefore swallows text input and local key events — fine for App Shortcuts (read-only rows with tap gestures), broken for port-manager (search field + ⌘R / ⌘T / ESC). Two changes are required and **must land in the same iteration as this feature**:
+
+1. Subclass `NSWindow` (or set `setIsVisible(false)` and reconfigure) so `canBecomeKey` and `canBecomeMain` return `true`. Add `becomesKeyOnlyIfNeeded = true` and `styleMask` includes `.nonactivatingPanel`-style behavior (use `NSPanel` if simpler) so opening the popover does not steal app activation from the foreground app — this matches the existing "menu bar accessory" feel.
+2. In `HoverPopover.show(...)`, call `window.makeKey()` (or `makeKeyAndOrderFront(nil)` followed by `NSApp.activate(ignoringOtherApps: false)`) so the SwiftUI `@FocusState` binding can claim first responder.
+
+App Shortcuts is unaffected: it has no focusable controls, so gaining key status is harmless. Add a manual QA check that hovering App Shortcuts still doesn't show a typing cursor and doesn't steal focus from other apps.
+
+If subclassing turns out fragile, the fallback is a second, port-manager-specific popover host that owns an `NSPanel` configured for key acceptance, and `HoverPopover` stays read-only. The spec leaves room for either path during implementation; the contract that must hold is "the search field is focused on appear and receives keystrokes without forcing AnyDoor to the foreground."
 
 #### `PortManagerToolbar`
 
@@ -411,13 +498,15 @@ A local `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` mounted while the
 
 ### 6. `HoverPopover` integration
 
-`MenuBarView` already dispatches hover for `.appShortcuts`. Extend the switch:
+`MenuBarView` already dispatches hover for `.appShortcuts`. Extend the dispatch (real API: `entry.source` is the `PanelEntrySource` enum, not `entry.builtin`):
 
 ```swift
-switch entry.builtin {
-case .appShortcuts: present(AppShortcutsPopoverView())
-case .portManager:  present(PortManagerPopoverView())
-default: break
+if case let .builtin(item) = entry.source {
+    switch item {
+    case .appShortcuts: popover.updateContent { AppShortcutsPopoverView(...) }
+    case .portManager:  popover.updateContent { PortManagerPopoverView(...) }
+    default: break
+    }
 }
 ```
 
@@ -516,18 +605,27 @@ Fixtures live under `Tests/AnyDoorTests/Fixtures/`. Tests load them with `Bundle
 - Refresh generation token: consecutive `refresh()` calls where the older one resolves later → records reflect only the newer scan's data (stub controls resolution order via `CheckedContinuation`).
 - `groupedByProcess` returns groups sorted by name with ports sorted ascending.
 - Submenu hotkey filtering remains unchanged: `PanelStore.rebuildHotkeySnapshots()` produces zero snapshots for `.portManager` regardless of whether the preference has a keycode set (regression guard since `.portManager` is the first new submenu item).
+- `isRefreshing` semantics with concurrent refreshes: stub runner exposes two `CheckedContinuation`s. Trigger `refresh()` twice; resolve the older one first; assert `isRefreshing == true` (newer scan still in flight); resolve the newer; assert `isRefreshing == false`. Reverse order also covered.
+- Subprocess runner timeout: stub runner returns `SubprocessResult(timedOut: true, ...)`; scanner throws `.lsofTimeout` regardless of exit code.
+- Subprocess runner cancellation: real `LsofRunner` test (best-effort; skip if CI cannot spawn `/usr/bin/yes`) — spawn `/usr/bin/yes`, wrap in a Task, cancel after 100ms, assert the process is no longer running shortly after.
 
 ### Manual QA checklist
 
 - Hover the App Shortcuts row → port-manager popover does **not** appear.
 - Hover the port-manager row → popover appears after ~400ms.
+- Search field receives focus on appear and accepts typing **without** bringing AnyDoor to the foreground (verify by hovering with another app key — the other app's title bar should not lose key state).
+- Move cursor from the menu bar row into the popover → popover stays open (no flicker, no close after 300ms).
+- Move cursor out of the popover entirely → popover closes after ~300ms.
 - Toggle list/tree → preference persists after app restart.
 - Type in search → count updates instantly; ordering matches priority spec.
+- Tooltip on a list row shows the bind addresses; for a dual-stack listener, both IPv4 and IPv6 entries are listed.
+- Tree view leaf row shows a sensible bind summary (single, dual, or "N binds") matching `record.binds`.
 - Click kill on a user-owned process → row turns gray, process disappears after 0.5–1s, list refreshes.
 - Click kill on a root-owned process (e.g. `ControlCenter`) → red icon + tooltip, auto-dismisses after 3s.
 - ESC clears search when non-empty; ESC closes popover when search is empty.
 - ⌘R triggers refresh; banner appears and disappears on transient failures.
 - ⌘T toggles list/tree view.
+- Open Settings → port-manager row shows no hotkey recorder (column reserved blank, matching App Shortcuts).
 
 ### Out of scope for tests
 
@@ -553,6 +651,8 @@ Fixtures live under `Tests/AnyDoorTests/Fixtures/`. Tests load them with `Bundle
 - `Sources/AnyDoor/Models/BuiltinItem.swift` — add `.portManager` case with `.submenu` kind, title, symbol, default ordering.
 - `Sources/AnyDoor/Services/PanelStore.swift` — no behavioural change required for hotkey path; verify the existing submenu filter still applies (regression test in `PortInventoryTests`).
 - `Sources/AnyDoor/Views/MenuBarView.swift` — generalise the single `triggerFrame` into per-submenu-item frames; extend the hover dispatch to mount `PortManagerPopoverView` for `.portManager`.
+- `Sources/AnyDoor/Views/HoverPopover.swift` — allow the underlying `NSWindow` to accept key focus (subclass override / `NSPanel` swap / opt-in flag) so the SwiftUI `@FocusState` on the search field can become first responder. Existing `AppShortcutsPopoverView` is unaffected because it has no focusable controls.
+- `Sources/AnyDoor/Views/PanelSettingsView.swift` — generalise the hotkey-column filter at `:92` from `case .builtin(.appShortcuts)` to "any `.submenu`-kind builtin" so the new port-manager row does not present a recorder that the system ignores.
 - `Package.swift` — augment the existing `AnyDoorTests` target with `resources: [.process("Fixtures")]`.
 
 **Not modified (despite earlier draft saying otherwise)**
@@ -576,7 +676,18 @@ None. All clarifications captured above.
 
 ## Revisions
 
-**2026-05-21 — post-review revisions**
+**2026-05-21 — second-round revisions**
+
+- Documented that `HoverPopover`'s current `NSWindow` is not key-eligible. The port-manager popover requires text input + local hotkeys, so the popover host must be modified (subclass / `NSPanel` / opt-in flag) to accept key focus without stealing app activation. Bundled in the same iteration.
+- Generalised the hotkey-column filter in `PanelSettingsView` from `case .builtin(.appShortcuts)` to "any submenu-kind builtin" so the port-manager row does not display a recorder the system silently ignores.
+- Added the `onHoverChange` callback wiring on `PortManagerPopoverView` (mirroring `AppShortcutsPopoverView.swift:51`) so the popover keeps the `HoverGate` aware of cursor presence and does not close after 300ms when the cursor moves from the menu row into the popover.
+- Subprocess runner: introduced `SubprocessRunning` protocol + `SubprocessResult.timedOut` flag; the scanner now branches on `timedOut` to throw `.lsofTimeout` deterministically. Added `withTaskCancellationHandler` so the lsof child is terminated when the awaiting Task is cancelled.
+- Made the runner injection-friendly: `PortScanner.init(runner: any SubprocessRunning = LsofRunner())`. Lets the tests cover the "exit 1 + empty" rule and the timeout rule with a stub runner instead of spawning lsof.
+- UI bind display: list row tooltip lists every bind with its family; tree leaf row renders a deterministic bind summary (1 / 2 / >2 cases) drawn from `record.binds` instead of a single string.
+- Refresh concurrency: explicit `inflightCount` companion to the generation token so a stale early completion does not clear `isRefreshing` while a newer scan is still running.
+- Swift 6 / API correctness: `any PortScanning` for the existential; `MenuBarView` switch keys on `entry.source` (the real API) via `if case let .builtin(item) = entry.source`.
+
+**2026-05-21 — post-review revisions (first round)**
 
 - Replaced `ShellRunner` usage in `PortScanner` with a dedicated subprocess runner that drains stdout/stderr concurrently with `process.run()`. `ShellRunner` reads the pipe only after `waitUntilExit`, which deadlocks once lsof's output exceeds the kernel pipe buffer (~16 KiB).
 - Corrected the lsof field characters: `-F pPcntL` (the `t` field carries IPv4/IPv6; `P` is the protocol name, not the family).

--- a/docs/superpowers/specs/2026-05-21-port-management-design.md
+++ b/docs/superpowers/specs/2026-05-21-port-management-design.md
@@ -1,7 +1,7 @@
 # Port Management — Design
 
 **Date**: 2026-05-21
-**Status**: Approved (design phase)
+**Status**: Revised after review (design phase)
 **Author**: Brainstorming session
 
 ## Summary
@@ -10,11 +10,11 @@ Add a "port management" entry to the AnyDoor menu bar panel that, on hover, surf
 
 ## Goals
 
-- Show all TCP listening ports with port number, process name, pid, bind address.
+- Show all TCP listening ports with port number, process name, pid, bind address(es).
 - Provide search across port / process name / pid with priority ordering.
 - Provide list and tree views; remember the chosen view across sessions.
 - Provide one-click kill (SIGTERM → 500ms → SIGKILL fallback) with inline failure feedback when the kernel rejects the signal (typically root-owned processes).
-- Reuse `BuiltinItem` infrastructure so the entry can be reordered, hidden, and bound to a global hotkey from the panel settings.
+- Reuse `BuiltinItem` infrastructure so the entry can be reordered and hidden from the panel settings (same as the App Shortcuts entry).
 
 ## Non-Goals
 
@@ -23,23 +23,26 @@ Add a "port management" entry to the AnyDoor menu bar panel that, on hover, surf
 - No continuous background scanning; data refreshes when the popover opens or on user request.
 - No persistence of search text or tree expansion state across sessions.
 - No keyboard navigation inside the list (up/down arrows, enter-to-kill).
+- **No global hotkey for opening the port-manager popover in this iteration.** The existing menu-bar architecture only resolves submenu popovers when the menu bar panel is already open (it tracks a single trigger frame for the App Shortcuts row). Wiring a hotkey to open the menu bar, then mount the popover, then focus the search field is a separate piece of work that is explicitly deferred to a follow-up. Per-row hotkeys for `.submenu` items remain skipped in `PanelStore.rebuildHotkeySnapshots` as they are today.
 
 ## Clarifications Captured
 
 | Topic | Decision |
 |-------|----------|
 | Port scope | TCP listening only (`lsof -nP -iTCP -sTCP:LISTEN`) |
-| IPv4/IPv6 dual-stack | Merge into one row (one entry per pid+port) |
+| IPv4/IPv6 dual-stack | One row per `(pid, port)`; both bind addresses retained as a `binds: [PortBind]` array on the record |
 | Kill mechanism | Darwin `kill(2)` direct syscall, SIGTERM → 500ms wait → SIGKILL fallback |
 | Kill failure handling | Inline red icon + tooltip, auto-dismiss after 3s; no escalation prompt |
 | Refresh strategy | Scan on popover open + manual ⌘R + auto-refresh after kill |
 | Menu integration | New `BuiltinItem.portManager` with `kind = .submenu` |
-| Hotkey action | New `HotkeyAction.showSubmenu(BuiltinItem)` (semantically distinct from `toggleBuiltin`) |
+| Hotkey support | **Deferred.** Existing infrastructure already filters out submenu hotkeys; no change in this iteration. |
 | Persistence | Only the list/tree toggle (`UserDefaults`); search text and tree expansion are session-only |
 | Tree default state | All groups collapsed by default |
 | Kill icon on tree leaf rows | Not shown; killing the process row kills the pid (and consequently all its ports) |
 | Scanning state UI | Centered `ProgressView` with label, no skeleton |
 | Scan failure UI | Inline banner above the list, keeps last results visible, has a retry button |
+| Subprocess runtime | Dedicated `SubprocessRunner` in `PortScanner` that drains stdout/stderr concurrently with `process.run()` (the existing `ShellRunner` reads the pipe only after `waitUntilExit()` and would deadlock on lsof's volume). |
+| lsof empty result | Exit code 1 with empty stdout/stderr is treated as `[]`, not as failure. |
 
 ## Architecture
 
@@ -59,7 +62,7 @@ Three new units, each isolated and individually testable:
 │                                                           │ │
 │  actor PortScanner (conforms to PortScanning protocol)    │ │
 │    ├─ scanTCPListening() async throws -> [PortRecord]     │ │
-│    └─ kill(pid:signal:) -> Bool   (nonisolated)           │ │
+│    └─ kill(pid:signal:) -> SignalResult (nonisolated)     │ │
 └───────────────────────────────────────────────────────────┴─┘
 ```
 
@@ -80,70 +83,128 @@ New case in `Sources/AnyDoor/Models/BuiltinItem.swift`:
 
 `BuiltinPreferenceSeeder` automatically creates the SwiftData preference row on first launch (existing logic). No SwiftData schema changes.
 
-### 2. `HotkeyAction.showSubmenu(BuiltinItem)`
+### 2. Hotkey action (deferred)
 
-New case in `Sources/AnyDoor/Models/HotkeyAction.swift`:
-
-- Encoded as `"showSubmenu:<itemKey>"` for `HotkeySnapshot` serialization.
-- `BuiltinItem.hotkeyAction()` returns `.showSubmenu(.portManager)` for items where `kind == .submenu`, and the existing `.toggleBuiltin` / `.runBuiltin` for the other kinds.
-- `PanelStore.dispatch` gains a new case:
-  ```
-  case .showSubmenu(let item):
-      // broadcast to the menu bar to open the popover for `item`
-  ```
-- The menu bar listens to a published `submenuOpenRequest: BuiltinItem?` (or equivalent SwiftUI binding) on `PanelStore` and responds by mounting the corresponding `HoverPopover`.
+No changes to `HotkeyAction`, `PanelStore.rebuildHotkeySnapshots`, or `HotkeyService` in this iteration. `PanelStore` already skips snapshot generation for items whose `kind == .submenu` (see `PanelStore.swift:202`), and the menu bar only resolves the popover anchor for the App Shortcuts row (`MenuBarView.swift:62`). Designing a "global hotkey opens menu bar then mounts a submenu popover" flow requires its own design pass and is intentionally out of scope.
 
 ### 3. `PortScanner` (actor)
 
-File: `Sources/AnyDoor/Services/PortScanner.swift`
+Files:
+- `Sources/AnyDoor/Models/PortRecord.swift` — shared domain types.
+- `Sources/AnyDoor/Services/PortScanner.swift` — actor + subprocess runner + parser.
+
+#### Domain types (in `Models/PortRecord.swift`)
 
 ```swift
-protocol PortScanning: Sendable {
-    func scanTCPListening() async throws -> [PortRecord]
-    func kill(pid: pid_t, signal: Int32) -> Bool
-}
-
-actor PortScanner: PortScanning {
-    func scanTCPListening() async throws -> [PortRecord]
-    nonisolated func kill(pid: pid_t, signal: Int32) -> Bool
-}
-
 struct PortRecord: Sendable, Hashable, Identifiable {
     let port: UInt16
     let pid: pid_t
     let processName: String
     let executablePath: String?
     let commandLine: String?
-    let bindAddress: String      // "*", "127.0.0.1", "::1", ...
-    let families: Set<AddressFamily>
+    let binds: [PortBind]        // never empty; ordered ipv4 first then ipv6
     var id: String { "\(pid)-\(port)" }
 }
 
-enum AddressFamily: Sendable, Hashable { case ipv4, ipv6 }
+struct PortBind: Sendable, Hashable {
+    let address: String          // "*", "127.0.0.1", "::1", "fe80::1%en0", ...
+    let family: AddressFamily
+}
 
-enum PortScanError: Error {
+enum AddressFamily: String, Sendable, Hashable { case ipv4 = "IPv4", ipv6 = "IPv6" }
+
+enum SignalResult: Sendable, Equatable {
+    case success
+    case failure(POSIXErrorCode)
+}
+```
+
+#### Service surface (in `Services/PortScanner.swift`)
+
+```swift
+protocol PortScanning: Sendable {
+    func scanTCPListening() async throws -> [PortRecord]
+    func kill(pid: pid_t, signal: Int32) -> SignalResult
+}
+
+actor PortScanner: PortScanning {
+    func scanTCPListening() async throws -> [PortRecord]
+    nonisolated func kill(pid: pid_t, signal: Int32) -> SignalResult {
+        if Darwin.kill(pid, signal) == 0 { return .success }
+        let code = POSIXErrorCode(rawValue: errno) ?? .EINVAL
+        return .failure(code)
+    }
+}
+
+enum PortScanError: Error, Equatable {
     case lsofTimeout
     case lsofFailed(exitCode: Int32, stderr: String)
     case parseFailed(line: String)
 }
 ```
 
+Capturing `errno` **immediately after** the `Darwin.kill` call (before any other syscall can clobber it) is the entire reason the result type carries the code.
+
+#### Subprocess runner
+
+The existing `ShellRunner` calls `pipe.fileHandleForReading.readToEnd()` after the process has already exited, which deadlocks once stdout exceeds the pipe buffer (~16 KiB). `lsof` listing 50–200 open TCP files reliably exceeds that.
+
+`PortScanner` ships its own private runner that drains pipes concurrently with the running process. Sketch:
+
+```swift
+private func runProcess(
+    path: String, args: [String], timeout: Duration
+) async throws -> (stdout: String, stderr: String, exit: Int32) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: path)
+    process.arguments = args
+    let outPipe = Pipe(), errPipe = Pipe()
+    process.standardOutput = outPipe
+    process.standardError = errPipe
+    try process.run()
+
+    // Drain pipes on detached tasks so the kernel buffer never fills.
+    async let outData = readAll(outPipe.fileHandleForReading)
+    async let errData = readAll(errPipe.fileHandleForReading)
+
+    // Timeout watchdog terminates the process. The read tasks then finish
+    // naturally because the file handles hit EOF.
+    let watchdog = Task {
+        try? await Task.sleep(for: timeout)
+        if process.isRunning { process.terminate() }
+    }
+
+    let (out, err) = await (outData, errData)
+    watchdog.cancel()
+    process.waitUntilExit()  // already returned, but ensures status is set
+
+    return (
+        stdout: String(data: out, encoding: .utf8) ?? "",
+        stderr: String(data: err, encoding: .utf8) ?? "",
+        exit: process.terminationStatus
+    )
+}
+```
+
+The runner is private to `PortScanner` — other features keep using `ShellRunner` for short outputs.
+
 #### Scanning pipeline
 
-1. Run `/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -F pPcnL +c 0` via the existing `ShellRunner` with a 3-second timeout.
-   - `-F pPcnL` requests fielded output: `p` = pid, `P` = protocol, `c` = command, `n` = name (`addr:port`), `L` = login user.
-   - `-n -P` skips DNS / service-name resolution for performance.
+1. Run `/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -F pPcntL +c 0` with a 3-second timeout via the private runner.
+   - `-F pPcntL` requests fielded output: `p` = process id, `P` = protocol name, `c` = command name, `n` = name (`addr:port`), `t` = file type (`IPv4` / `IPv6`), `L` = login user. **`t` is the address family field — `P` is the protocol (`TCP`), not the family.**
+   - `-n -P` skips DNS / service-name resolution.
    - `+c 0` disables command-name truncation.
-2. Parse the fielded output by process group → file group, extract `(pid, command, addr:port, family)`.
-3. Merge entries with identical `(pid, port)` and different address families into a single `PortRecord` whose `families` is a set.
-4. Optionally enrich with `sysctl(KERN_PROCARGS2)` for each unique pid to obtain `executablePath` and full `commandLine`. Failures (permission, race) are silent — the record falls back to lsof's command name.
-5. Return `[PortRecord]` unsorted; the inventory sorts at the view layer.
+2. **Handle empty-result exit code.** lsof returns exit code 1 with empty stdout and (typically) empty stderr when no matching open files exist. Treat `(exit == 1 && stdout.isEmpty)` as a successful empty scan, not a failure. Any other non-zero exit with non-empty stderr is a real error → `PortScanError.lsofFailed`.
+3. Parse the fielded output by process record (`p`-prefixed line starts a new process) → file record (`f`-prefixed line starts a new file within a process). Extract `(pid, command, addr:port, family)`. Address parsing handles three forms: `*:5000`, `127.0.0.1:3000`, `[::1]:8080` (and zone-id variants like `[fe80::1%en0]:1234`).
+4. Group entries by `(pid, port)`. Each group becomes a single `PortRecord` whose `binds` array preserves every distinct `(address, family)` pair. **No information is lost when both IPv4 `127.0.0.1` and IPv6 `[::1]` listen on the same port.**
+5. Enrich with `sysctl(KERN_PROCARGS2)` once per unique pid (deduplicated across multi-port processes) to obtain `executablePath` and `commandLine`. Failures (permission denied, process gone) are silent — the record keeps lsof's short command name.
+6. Return `[PortRecord]` unsorted; the inventory sorts at the view layer.
 
-The parser is exposed as a `static func parseLsofOutput(_ raw: String) throws -> [PortRecord]` to enable fixture-based unit tests.
+The parser is exposed as a free function `parseLsofOutput(_ raw: String) throws -> [PortRecord]` to enable fixture-based unit tests without spawning lsof.
 
 #### Kill
 
-`Darwin.kill(pid, signal) == 0` returns success. The actor does **not** implement the SIGTERM → SIGKILL fallback — that lives in `PortInventory` as a policy decision.
+`scanner.kill(pid, signal)` returns `SignalResult.success` on `Darwin.kill == 0`, otherwise `.failure(POSIXErrorCode)` with `errno` captured immediately. The actor does **not** implement the SIGTERM → SIGKILL fallback — that lives in `PortInventory` as a policy decision.
 
 ### 4. `PortInventory` (`@MainActor @Observable`)
 
@@ -195,8 +256,12 @@ struct KillFailure: Equatable, Sendable {
 #### Refresh
 
 - Entry points: popover `.task`, ⌘R, automatic after a kill.
-- Holds a `currentTask: Task<Void, Never>?`; a new refresh cancels the previous.
-- On failure, `lastError` is set and `records` is preserved.
+- Concurrency model: a monotonically incrementing `refreshGeneration: UInt64` token. Each `refresh()` call:
+  1. Increments the generation and captures `let myGen = refreshGeneration`.
+  2. Awaits the scanner. The scanner's subprocess runner is responsible for terminating the lsof child when its enclosing Task is cancelled or hits the timeout (see the runner sketch above) — Swift's `Task.cancel` alone does not kill a running `Process`.
+  3. After awaiting, checks `guard myGen == refreshGeneration else { return }`. A stale completion is discarded; only the latest scan can overwrite `records`.
+- On failure, `lastError` is set and `records` is preserved. (Staleness check still applies — a stale failure does not overwrite a fresh success.)
+- A single in-flight scan is the steady state; overlapping refreshes are tolerated but only the newest result lands. We do **not** try to cancel the old subprocess on a new request — lsof is fast enough that the simple "newest wins" rule is sufficient.
 
 #### Kill policy (two-phase)
 
@@ -204,22 +269,38 @@ Kill is **pid-level by design**. When the user clicks the kill icon on a port ro
 
 ```
 1. killingPIDs.insert(pid)
-2. ok = scanner.kill(pid, SIGTERM)
-3. if !ok:
-     classify errno → failedKillPIDs[pid] = KillFailure(reason: ...)
-     start a 3-second detached Task to remove the entry
-     killingPIDs.remove(pid)
-     return
-4. sleep 500ms
+2. let result = scanner.kill(pid, SIGTERM)
+3. switch result:
+   case .failure(.ESRCH):
+       // Process already gone — treat as success.
+       await refresh()
+       killingPIDs.remove(pid)
+       return
+   case .failure(let code):
+       let reason: KillFailure.Reason =
+           (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+       failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+       schedule3sDismiss(for: pid)
+       killingPIDs.remove(pid)
+       return
+   case .success:
+       break  // continue to step 4
+4. try? await Task.sleep(for: .milliseconds(500))
 5. await refresh()
 6. if records still contains pid:
-     scanner.kill(pid, SIGKILL)
-     sleep 200ms
-     await refresh()
+       let escalate = scanner.kill(pid, SIGKILL)
+       switch escalate:
+         case .success: try? await Task.sleep(for: .milliseconds(200)); await refresh()
+         case .failure(.ESRCH): await refresh()
+         case .failure(let code):
+             let reason: KillFailure.Reason =
+                 (code == .EPERM) ? .permissionDenied : .other(code.rawValue)
+             failedKillPIDs[pid] = KillFailure(reason: reason, timestamp: .now)
+             schedule3sDismiss(for: pid)
 7. killingPIDs.remove(pid)
 ```
 
-`errno` classification: `EPERM` → `.permissionDenied`, `ESRCH` → `.processGone` (treated as success, no error surfaced), anything else → `.other(errno)`. Because failure is recorded by pid, every row of the affected process shows the red indicator until the auto-dismiss timer fires (3s) or the user dismisses it.
+`errno` is captured by `SignalResult.failure(POSIXErrorCode)`, then mapped to `KillFailure.Reason`. **`ESRCH` is never recorded as a failure** — at any stage where it occurs (either initial SIGTERM or SIGKILL escalation) the inventory treats it as the process having already exited and just refreshes. Because failure is recorded by pid, every row of the affected process shows the red indicator until the auto-dismiss timer fires (3s) or the user dismisses it.
 
 #### Derived views
 
@@ -342,7 +423,7 @@ default: break
 
 Reuse `HoverGate` timing (400ms enter, 300ms leave) and `HoverPopover` placement (right-anchored, flips left on screen edges).
 
-When the global hotkey for `.portManager` fires, `PanelStore.dispatch(.showSubmenu(.portManager))` publishes the submenu open request, the menu bar opens its panel, then mounts the popover for that item with search focused.
+The existing `MenuBarView` already maintains a single `triggerFrame` for the App Shortcuts row (`MenuBarView.swift:62`). To support a second hoverable row, that state is generalised into a small dictionary `[BuiltinItem: CGRect]` (or two named optionals — judgement call during implementation) so each submenu row can record its own anchor. `HoverGate` is also parametrised by the currently-hovered item so the popover can mount the right content. This is the only structural change to `MenuBarView`; no new windows, no new gestures.
 
 ## Data Flow
 
@@ -352,9 +433,11 @@ User hover on port-manager row
        └─> HoverPopover.present(PortManagerPopoverView)
             └─> .task { await PortInventory.shared.refresh() }
                  └─> PortScanner.scanTCPListening()
-                      ├─> ShellRunner: lsof ...
-                      ├─> parseLsofOutput
-                      └─> sysctl(KERN_PROCARGS2) per pid
+                      ├─> private subprocess runner: lsof -nP -iTCP -sTCP:LISTEN -F pPcntL +c 0
+                      │     (drains stdout/stderr concurrently with run; 3s timeout)
+                      ├─> handle (exit==1 && stdout.isEmpty) → return []
+                      ├─> parseLsofOutput → [(pid,port,binds[],family)]
+                      └─> sysctl(KERN_PROCARGS2) per unique pid
                  └─> PortInventory.records = ...
                       └─> SwiftUI re-renders PortListView / PortTreeView
 
@@ -373,13 +456,17 @@ User clicks kill on a row
 
 | Error | Surface | Recovery |
 |-------|---------|----------|
-| `lsof` timeout / non-zero exit / parse failure | Inline yellow banner above the list ("刷新失败: ..."), retry button. Last records preserved. | Manual ⌘R or banner retry button. |
-| Kill returns `EPERM` | Red `exclamationmark.circle.fill` on the row, tooltip "权限不足（系统/其他用户进程）", auto-dismiss after 3s. | None (no privilege escalation). |
-| Kill returns `ESRCH` | Treated as success, no UI error. Refresh removes the row. | Automatic. |
-| Kill returns other errno | Same red indicator, tooltip "kill 失败 (errno: N)". | Manual retry. |
+| `lsof` exit 1 with empty stdout/stderr | Treated as a successful empty scan: `records = []`, no banner. | N/A (expected when no TCP listeners exist). |
+| `lsof` timeout / other non-zero exit / parse failure | Inline yellow banner above the list ("刷新失败: ..."), retry button. Last records preserved. | Manual ⌘R or banner retry button. |
+| `lsof` subprocess hangs past timeout | Subprocess runner terminates the child and surfaces `.lsofTimeout`. | Manual ⌘R. |
+| Stale scan completion arrives after a newer one | Generation token discards the stale result. | Automatic. |
+| Kill returns `.failure(.EPERM)` | Red `exclamationmark.circle.fill` on every row of that pid, tooltip "权限不足（系统/其他用户进程）", auto-dismiss after 3s. | None (no privilege escalation). |
+| Kill returns `.failure(.ESRCH)` | Treated as success, no UI error. Refresh removes the row(s). | Automatic. |
+| Kill returns other `.failure(code)` | Same red indicator, tooltip "kill 失败 (errno: <code>)". | Manual retry. |
+| SIGKILL escalation fails | Red indicator with the escalation errno; row remains in the list until next manual action. | Manual retry. |
 | Popover opens with empty records | Centered `ProgressView("扫描中...")`. | Automatic on scan completion. |
 | Filtered records empty | Centered "无匹配的端口" text. | Adjust search. |
-| Duplicate kill clicks on same pid | Kill icon disabled (row gray) while `killingPIDs` contains pid. | N/A. |
+| Duplicate kill clicks on same pid | Kill icon disabled (rows gray) while `killingPIDs` contains pid. | N/A. |
 
 Logging: `os.Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")` records scan start/end/failure and kill calls (pid, signal, errno). Process names and command lines are not logged to avoid leaking user activity.
 
@@ -387,37 +474,48 @@ Logging: `os.Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")` 
 
 ### Package change
 
-Add a test target to `Package.swift`:
+`Package.swift` already declares an `AnyDoorTests` target. The change required is **modifying** that target to enable bundling fixture files:
 
 ```swift
 .testTarget(
     name: "AnyDoorTests",
     dependencies: ["AnyDoor"],
-    path: "Tests/AnyDoorTests",
-    resources: [.process("Fixtures")]
+    resources: [.process("Fixtures")],            // ← add this line
+    swiftSettings: [.swiftLanguageMode(.v6)]
 )
 ```
 
+Fixtures live under `Tests/AnyDoorTests/Fixtures/`. Tests load them with `Bundle.module.url(forResource:...)`. Short fixtures can also live inline as multiline string literals when the file would be only a handful of lines.
+
 ### `PortScannerTests` (unit, no system dependency)
 
-- `parseLsofOutput` fixtures:
-  - single process, single IPv4 port
-  - single process, multiple ports
-  - same pid+port across IPv4/IPv6 → merged into one record with both families
-  - long command name preserved (no truncation)
-  - malformed input → throws `.parseFailed`
-- `parseProcArgs` fixture: simulated KERN_PROCARGS2 byte buffer.
+`parseLsofOutput` fixtures (one assertion per fixture):
+
+- Single process, single IPv4 listener (`tIPv4` field present).
+- Single process, multiple ports (verifies file-record grouping under one process record).
+- Same `(pid, port)` listening on both IPv4 and IPv6 → one `PortRecord` whose `binds` contains both families with their respective addresses (`127.0.0.1` and `::1`).
+- Multiple distinct bind addresses on the same port (e.g. a server binding both `127.0.0.1:5000` and `0.0.0.0:5000`) → one record with multiple binds.
+- IPv6 zone-id parsing (`[fe80::1%en0]:1234`).
+- Command name containing a space (e.g. `Google Chrome Helper`) preserved verbatim with `+c 0`.
+- Command name containing lsof's `\xHH` escape sequences (lsof escapes non-printable bytes); spec'd behaviour: decode escapes back to the original byte before constructing the string.
+- `exit == 1, stdout.isEmpty, stderr.isEmpty` → parser returns `[]` (this is tested at the scanner-runner layer with a stubbed runner).
+- Malformed input (truncated record, missing required field) → throws `PortScanError.parseFailed`.
+
+`parseProcArgs` fixture: simulated `KERN_PROCARGS2` byte buffer; verify executable path and argv extraction.
 
 ### `PortInventoryTests` (`@MainActor`, stub `PortScanning`)
 
-- Search priority: records covering port `:3000`, process `node`, PID `67035`; query `"30"` returns the port-match first.
+- Search priority: records covering port `:3000`, process `node`, PID `67035`; query `"30"` returns the port-match first, then the PID match.
 - Search is case-insensitive.
-- `viewMode` round-trips through UserDefaults (isolated suite).
-- Successful kill clears `killingPIDs` and refreshes records.
-- `EPERM` populates `failedKillPIDs` with `.permissionDenied`.
-- `ESRCH` does **not** populate `failedKillPIDs`.
-- Consecutive `refresh()` calls cancel the previous task.
+- `viewMode` round-trips through `UserDefaults` (isolated suite name per test).
+- Successful kill: stub returns `.success` → `killingPIDs` cleared after refresh; records updated.
+- SIGTERM `.failure(.EPERM)` → `failedKillPIDs[pid].reason == .permissionDenied`; auto-dismiss timer removes it.
+- SIGTERM `.failure(.ESRCH)` → **not** in `failedKillPIDs`; refresh is still triggered.
+- SIGTERM `.success` but process persists in next scan → stub records a second kill call with `SIGKILL`.
+- SIGKILL escalation `.failure(.EPERM)` → records `failedKillPIDs` with that errno.
+- Refresh generation token: consecutive `refresh()` calls where the older one resolves later → records reflect only the newer scan's data (stub controls resolution order via `CheckedContinuation`).
 - `groupedByProcess` returns groups sorted by name with ports sorted ascending.
+- Submenu hotkey filtering remains unchanged: `PanelStore.rebuildHotkeySnapshots()` produces zero snapshots for `.portManager` regardless of whether the preference has a keycode set (regression guard since `.portManager` is the first new submenu item).
 
 ### Manual QA checklist
 
@@ -441,23 +539,24 @@ Add a test target to `Package.swift`:
 ## Files Touched / Created
 
 **Created**
-- `Sources/AnyDoor/Services/PortScanner.swift`
-- `Sources/AnyDoor/Services/PortInventory.swift`
+- `Sources/AnyDoor/Models/PortRecord.swift` — `PortRecord`, `PortBind`, `AddressFamily`, `SignalResult`.
+- `Sources/AnyDoor/Services/PortScanner.swift` — actor, `PortScanning` protocol, private subprocess runner, free function `parseLsofOutput`.
+- `Sources/AnyDoor/Services/PortInventory.swift` — `@MainActor @Observable` store, refresh generation token, kill policy.
 - `Sources/AnyDoor/Views/PortManagerPopoverView.swift`
-- `Sources/AnyDoor/Views/PortListView.swift`
-- `Sources/AnyDoor/Views/PortTreeView.swift`
-- `Sources/AnyDoor/Views/PortRowView.swift` (shared row + status dot + kill icon)
-- `Sources/AnyDoor/Views/PortProcessGroupView.swift`
+- `Sources/AnyDoor/Views/PortListView.swift` + `PortRowView.swift` (shared row visuals).
+- `Sources/AnyDoor/Views/PortTreeView.swift` (group-header rendering may live inline if it stays small; promote to a separate `PortProcessGroupView.swift` if it grows past ~40 lines).
 - `Tests/AnyDoorTests/PortScannerTests.swift`
 - `Tests/AnyDoorTests/PortInventoryTests.swift`
-- `Tests/AnyDoorTests/Fixtures/lsof-*.txt` (fixture files)
+- `Tests/AnyDoorTests/Fixtures/lsof-*.txt`
 
 **Modified**
 - `Sources/AnyDoor/Models/BuiltinItem.swift` — add `.portManager` case with `.submenu` kind, title, symbol, default ordering.
-- `Sources/AnyDoor/Models/HotkeyAction.swift` — add `.showSubmenu(BuiltinItem)` case and its `HotkeySnapshot` encoding.
-- `Sources/AnyDoor/Services/PanelStore.swift` — add submenu open-request publisher; dispatch `.showSubmenu` accordingly.
-- `Sources/AnyDoor/Views/MenuBarView.swift` — extend hover dispatch to mount `PortManagerPopoverView` for `.portManager`.
-- `Package.swift` — add `.testTarget(name: "AnyDoorTests", ...)`.
+- `Sources/AnyDoor/Services/PanelStore.swift` — no behavioural change required for hotkey path; verify the existing submenu filter still applies (regression test in `PortInventoryTests`).
+- `Sources/AnyDoor/Views/MenuBarView.swift` — generalise the single `triggerFrame` into per-submenu-item frames; extend the hover dispatch to mount `PortManagerPopoverView` for `.portManager`.
+- `Package.swift` — augment the existing `AnyDoorTests` target with `resources: [.process("Fixtures")]`.
+
+**Not modified (despite earlier draft saying otherwise)**
+- `Sources/AnyDoor/Models/HotkeyAction.swift` — no new case; global hotkey deferred.
 
 No SwiftData schema changes (preference for `.portManager` is auto-seeded by the existing seeder).
 
@@ -467,9 +566,25 @@ None. All clarifications captured above.
 
 ## Future Extensions (not in this design)
 
+- Global hotkey that opens the menu bar + mounts the port-manager popover with search focused. Requires a new presenter path because the current architecture only resolves submenu popovers when the menu bar panel is already on screen.
 - Copy port / PID / command line to clipboard via context menu.
 - Pin specific ports as favorites for quick access.
 - Show CPU / memory next to each process.
 - Background polling with delta animations.
 - UDP / established connections via a view-mode segmented control.
 - Keyboard navigation inside the list.
+
+## Revisions
+
+**2026-05-21 — post-review revisions**
+
+- Replaced `ShellRunner` usage in `PortScanner` with a dedicated subprocess runner that drains stdout/stderr concurrently with `process.run()`. `ShellRunner` reads the pipe only after `waitUntilExit`, which deadlocks once lsof's output exceeds the kernel pipe buffer (~16 KiB).
+- Corrected the lsof field characters: `-F pPcntL` (the `t` field carries IPv4/IPv6; `P` is the protocol name, not the family).
+- Replaced `(bindAddress: String, families: Set<AddressFamily>)` with `binds: [PortBind]` so dual-stack and multi-bind listeners do not lose addresses.
+- Changed `kill(pid:signal:)` return type from `Bool` to `SignalResult` carrying a `POSIXErrorCode`. `errno` is captured immediately after the syscall. The kill pseudocode now branches on the result enum, and `ESRCH` is handled as success at every stage (no longer routed through the failure branch).
+- Removed `HotkeyAction.showSubmenu` and the global-hotkey flow from the current scope. Listed it under Future Extensions.
+- Generalised the single `triggerFrame` in `MenuBarView` into per-submenu frames so the App Shortcuts and port-manager rows can both anchor a popover.
+- Refresh concurrency: replaced "new refresh cancels the previous" with a generation-token model. Documented that Swift `Task.cancel()` does not terminate a child subprocess and pushed responsibility for that into the subprocess runner.
+- Error handling: `lsof exit 1 + empty stdout/stderr` is now defined as a successful empty scan.
+- Tests: corrected the Package.swift instruction (the test target already exists; only `resources` are added). Added fixtures for multi-bind, IPv6 zone-id, command-name spaces, lsof's `\xHH` escape, the exit-1-empty case, SIGKILL fallback paths, and a regression test that submenu hotkey snapshots remain filtered out.
+- Added `Sources/AnyDoor/Models/PortRecord.swift` as a dedicated domain-model file so `PortScanner.swift` does not own shared types.

--- a/docs/superpowers/specs/2026-05-21-port-management-design.md
+++ b/docs/superpowers/specs/2026-05-21-port-management-design.md
@@ -1,0 +1,475 @@
+# Port Management — Design
+
+**Date**: 2026-05-21
+**Status**: Approved (design phase)
+**Author**: Brainstorming session
+
+## Summary
+
+Add a "port management" entry to the AnyDoor menu bar panel that, on hover, surfaces a popover listing all TCP listening ports on the machine. Users can search by port / process name / pid, switch between a list view (sorted by port) and a tree view (grouped by process), and kill processes inline. The feature reuses the existing hover-popover infrastructure (`HoverPopover` + `HoverGate`) used by the "App Shortcuts" entry.
+
+## Goals
+
+- Show all TCP listening ports with port number, process name, pid, bind address.
+- Provide search across port / process name / pid with priority ordering.
+- Provide list and tree views; remember the chosen view across sessions.
+- Provide one-click kill (SIGTERM → 500ms → SIGKILL fallback) with inline failure feedback when the kernel rejects the signal (typically root-owned processes).
+- Reuse `BuiltinItem` infrastructure so the entry can be reordered, hidden, and bound to a global hotkey from the panel settings.
+
+## Non-Goals
+
+- No UDP, established TCP, or per-connection inspection.
+- No privilege escalation (no `sudo`, no `osascript with administrator privileges`, no privileged helper). System processes that the kernel refuses to signal stay visible with a permission-denied indicator.
+- No continuous background scanning; data refreshes when the popover opens or on user request.
+- No persistence of search text or tree expansion state across sessions.
+- No keyboard navigation inside the list (up/down arrows, enter-to-kill).
+
+## Clarifications Captured
+
+| Topic | Decision |
+|-------|----------|
+| Port scope | TCP listening only (`lsof -nP -iTCP -sTCP:LISTEN`) |
+| IPv4/IPv6 dual-stack | Merge into one row (one entry per pid+port) |
+| Kill mechanism | Darwin `kill(2)` direct syscall, SIGTERM → 500ms wait → SIGKILL fallback |
+| Kill failure handling | Inline red icon + tooltip, auto-dismiss after 3s; no escalation prompt |
+| Refresh strategy | Scan on popover open + manual ⌘R + auto-refresh after kill |
+| Menu integration | New `BuiltinItem.portManager` with `kind = .submenu` |
+| Hotkey action | New `HotkeyAction.showSubmenu(BuiltinItem)` (semantically distinct from `toggleBuiltin`) |
+| Persistence | Only the list/tree toggle (`UserDefaults`); search text and tree expansion are session-only |
+| Tree default state | All groups collapsed by default |
+| Kill icon on tree leaf rows | Not shown; killing the process row kills the pid (and consequently all its ports) |
+| Scanning state UI | Centered `ProgressView` with label, no skeleton |
+| Scan failure UI | Inline banner above the list, keeps last results visible, has a retry button |
+
+## Architecture
+
+Three new units, each isolated and individually testable:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  MenuBarView → PanelRowView (.portManager row)              │
+│    └─ HoverGate → HoverPopover → PortManagerPopoverView     │
+│                                       ▲                     │
+│                                       │ reads               │
+│                                       ▼                     │
+│  @MainActor @Observable PortInventory.shared                │
+│    ├─ state: records / viewMode / searchText / isRefreshing │
+│    │         killingPIDs / failedKillPIDs / lastError       │
+│    └─ uses ───────────────────────────────────────────────┐ │
+│                                                           │ │
+│  actor PortScanner (conforms to PortScanning protocol)    │ │
+│    ├─ scanTCPListening() async throws -> [PortRecord]     │ │
+│    └─ kill(pid:signal:) -> Bool   (nonisolated)           │ │
+└───────────────────────────────────────────────────────────┴─┘
+```
+
+- `PanelStore` does **not** own port data. It only carries the `BuiltinItem.portManager` entry through its existing pipeline.
+- `PortInventory` is the single source of UI truth for port-related state. Single-instance, MainActor-isolated, Observable.
+- `PortScanner` is a stateless actor wrapping `lsof` parsing, optional `sysctl(KERN_PROCARGS2)` enrichment, and the `kill(2)` syscall. Its surface is captured by the `PortScanning` protocol for test injection.
+
+## Components
+
+### 1. `BuiltinItem.portManager`
+
+New case in `Sources/AnyDoor/Models/BuiltinItem.swift`:
+
+- `kind = .submenu`
+- `title = "端口管理"`
+- `symbol = "network"`
+- Appended to `BuiltinItem.allCases` default ordering (tail).
+
+`BuiltinPreferenceSeeder` automatically creates the SwiftData preference row on first launch (existing logic). No SwiftData schema changes.
+
+### 2. `HotkeyAction.showSubmenu(BuiltinItem)`
+
+New case in `Sources/AnyDoor/Models/HotkeyAction.swift`:
+
+- Encoded as `"showSubmenu:<itemKey>"` for `HotkeySnapshot` serialization.
+- `BuiltinItem.hotkeyAction()` returns `.showSubmenu(.portManager)` for items where `kind == .submenu`, and the existing `.toggleBuiltin` / `.runBuiltin` for the other kinds.
+- `PanelStore.dispatch` gains a new case:
+  ```
+  case .showSubmenu(let item):
+      // broadcast to the menu bar to open the popover for `item`
+  ```
+- The menu bar listens to a published `submenuOpenRequest: BuiltinItem?` (or equivalent SwiftUI binding) on `PanelStore` and responds by mounting the corresponding `HoverPopover`.
+
+### 3. `PortScanner` (actor)
+
+File: `Sources/AnyDoor/Services/PortScanner.swift`
+
+```swift
+protocol PortScanning: Sendable {
+    func scanTCPListening() async throws -> [PortRecord]
+    func kill(pid: pid_t, signal: Int32) -> Bool
+}
+
+actor PortScanner: PortScanning {
+    func scanTCPListening() async throws -> [PortRecord]
+    nonisolated func kill(pid: pid_t, signal: Int32) -> Bool
+}
+
+struct PortRecord: Sendable, Hashable, Identifiable {
+    let port: UInt16
+    let pid: pid_t
+    let processName: String
+    let executablePath: String?
+    let commandLine: String?
+    let bindAddress: String      // "*", "127.0.0.1", "::1", ...
+    let families: Set<AddressFamily>
+    var id: String { "\(pid)-\(port)" }
+}
+
+enum AddressFamily: Sendable, Hashable { case ipv4, ipv6 }
+
+enum PortScanError: Error {
+    case lsofTimeout
+    case lsofFailed(exitCode: Int32, stderr: String)
+    case parseFailed(line: String)
+}
+```
+
+#### Scanning pipeline
+
+1. Run `/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -F pPcnL +c 0` via the existing `ShellRunner` with a 3-second timeout.
+   - `-F pPcnL` requests fielded output: `p` = pid, `P` = protocol, `c` = command, `n` = name (`addr:port`), `L` = login user.
+   - `-n -P` skips DNS / service-name resolution for performance.
+   - `+c 0` disables command-name truncation.
+2. Parse the fielded output by process group → file group, extract `(pid, command, addr:port, family)`.
+3. Merge entries with identical `(pid, port)` and different address families into a single `PortRecord` whose `families` is a set.
+4. Optionally enrich with `sysctl(KERN_PROCARGS2)` for each unique pid to obtain `executablePath` and full `commandLine`. Failures (permission, race) are silent — the record falls back to lsof's command name.
+5. Return `[PortRecord]` unsorted; the inventory sorts at the view layer.
+
+The parser is exposed as a `static func parseLsofOutput(_ raw: String) throws -> [PortRecord]` to enable fixture-based unit tests.
+
+#### Kill
+
+`Darwin.kill(pid, signal) == 0` returns success. The actor does **not** implement the SIGTERM → SIGKILL fallback — that lives in `PortInventory` as a policy decision.
+
+### 4. `PortInventory` (`@MainActor @Observable`)
+
+File: `Sources/AnyDoor/Services/PortInventory.swift`
+
+```swift
+@MainActor
+@Observable
+final class PortInventory {
+    static let shared = PortInventory()
+
+    private(set) var records: [PortRecord] = []
+    private(set) var isRefreshing = false
+    private(set) var lastError: PortInventoryError? = nil
+    private(set) var killingPIDs: Set<pid_t> = []
+    private(set) var failedKillPIDs: [pid_t: KillFailure] = [:]
+
+    var viewMode: ViewMode {
+        didSet {
+            UserDefaults.standard.set(viewMode.rawValue, forKey: Self.viewModeKey)
+        }
+    }
+    var searchText: String = ""
+
+    init(scanner: PortScanning = PortScanner()) { ... }
+
+    func refresh() async
+    func kill(pid: pid_t) async
+    func dismissError(for pid: pid_t)
+}
+
+enum ViewMode: String { case list, tree }
+
+enum PortInventoryError: Equatable, Sendable {
+    case scanFailed(String)
+}
+
+struct KillFailure: Equatable, Sendable {
+    enum Reason: Equatable, Sendable {
+        case permissionDenied
+        case processGone
+        case other(Int32)
+    }
+    let reason: Reason
+    let timestamp: Date
+}
+```
+
+#### Refresh
+
+- Entry points: popover `.task`, ⌘R, automatic after a kill.
+- Holds a `currentTask: Task<Void, Never>?`; a new refresh cancels the previous.
+- On failure, `lastError` is set and `records` is preserved.
+
+#### Kill policy (two-phase)
+
+Kill is **pid-level by design**. When the user clicks the kill icon on a port row, the inventory looks up the pid for that port and signals the entire process. Consequently, if a process listens on multiple ports, killing one row removes all of them on the next refresh. This is intentional — the UI never partially signals a process — and surfaces consistently in both list and tree views.
+
+```
+1. killingPIDs.insert(pid)
+2. ok = scanner.kill(pid, SIGTERM)
+3. if !ok:
+     classify errno → failedKillPIDs[pid] = KillFailure(reason: ...)
+     start a 3-second detached Task to remove the entry
+     killingPIDs.remove(pid)
+     return
+4. sleep 500ms
+5. await refresh()
+6. if records still contains pid:
+     scanner.kill(pid, SIGKILL)
+     sleep 200ms
+     await refresh()
+7. killingPIDs.remove(pid)
+```
+
+`errno` classification: `EPERM` → `.permissionDenied`, `ESRCH` → `.processGone` (treated as success, no error surfaced), anything else → `.other(errno)`. Because failure is recorded by pid, every row of the affected process shows the red indicator until the auto-dismiss timer fires (3s) or the user dismisses it.
+
+#### Derived views
+
+```swift
+var filteredRecords: [PortRecord] {
+    guard !searchText.isEmpty else {
+        return records.sorted { $0.port < $1.port }
+    }
+    let q = searchText.lowercased()
+    var seen = Set<PortRecord.ID>()
+    var ordered: [PortRecord] = []
+    func append(_ bucket: [PortRecord]) {
+        for r in bucket where !seen.contains(r.id) {
+            seen.insert(r.id); ordered.append(r)
+        }
+    }
+    append(records.filter { String($0.port).contains(q) })
+    append(records.filter { $0.processName.lowercased().contains(q) })
+    append(records.filter { String($0.pid).contains(q) })
+    return ordered
+}
+
+var groupedByProcess: [ProcessGroup] {
+    Dictionary(grouping: filteredRecords, by: \.pid)
+        .map { ProcessGroup(pid: $0.key,
+                            processName: $0.value.first!.processName,
+                            ports: $0.value.sorted { $0.port < $1.port }) }
+        .sorted { $0.processName.localizedCaseInsensitiveCompare($1.processName) == .orderedAscending }
+}
+
+struct ProcessGroup: Identifiable {
+    var id: pid_t { pid }
+    let pid: pid_t
+    let processName: String
+    let ports: [PortRecord]
+}
+```
+
+### 5. UI layer
+
+#### `PortManagerPopoverView`
+
+File: `Sources/AnyDoor/Views/PortManagerPopoverView.swift`
+
+Structure:
+
+```
+VStack(spacing: 0) {
+    PortManagerHeader(inventory: ...)        // globe icon + search + count
+    if let err = inventory.lastError {
+        ScanErrorBanner(error: err, retry: { await inventory.refresh() })
+    }
+    Group {
+        if inventory.isRefreshing && inventory.records.isEmpty {
+            ProgressView("扫描中...")
+        } else if inventory.filteredRecords.isEmpty {
+            Text("无匹配的端口").foregroundStyle(.secondary)
+        } else {
+            switch inventory.viewMode {
+            case .list: PortListView()
+            case .tree: PortTreeView()
+            }
+        }
+    }
+    Divider()
+    PortManagerToolbar(inventory: ...)       // Refresh ⌘R / Toggle View ⌘T
+}
+.frame(width: 340)
+.frame(minHeight: 280, maxHeight: 560)
+.task { await inventory.refresh() }
+.background(KeyboardMonitor(inventory: ...)) // local NSEvent monitor
+```
+
+#### `PortListView` / `PortRowView`
+
+- One row per `PortRecord`, sorted by port ascending.
+- Layout: `[status dot] [:port monospaced] [process name] [PID xxxxx] [kill icon on hover]`
+- Status dot: green (default), gray + spinner (killing), red (failed).
+- Process name truncates tail; tooltip shows `commandLine ?? processName`.
+- Kill icon: `xmark.circle.fill`, hidden until row hover; replaced by spinner while `killingPIDs` contains the pid; replaced by `exclamationmark.circle.fill` (red) while `failedKillPIDs` contains the pid.
+- Tap kill → `Task { await inventory.kill(pid: record.pid) }`.
+
+#### `PortTreeView` / `PortProcessGroupView`
+
+- One `DisclosureGroup` per `ProcessGroup`, all collapsed by default.
+- Group header: `[chevron] [status dot] [process name] [PID xxxxx] [collapsed-only: port count capsule] [kill icon on hover]`.
+- Leaf rows: `:port` + bind-address subtitle (`* · :5000` or `127.0.0.1 · :3000`); no kill icon on leaves.
+- Tap group's kill icon → `Task { await inventory.kill(pid: group.pid) }`.
+- Expansion state in `@State` only; not persisted.
+
+#### `PortManagerHeader`
+
+- Left: SF Symbol `globe` (matches mockups).
+- Middle: search field, auto-focused on appear; `@FocusState` binding.
+- Right: count capsule showing `filteredRecords.count`, accompanied by a small spinner when `isRefreshing` is true.
+
+#### `PortManagerToolbar`
+
+- Two horizontal rows or a single divided footer matching the mockups: `Refresh ⌘R` and `Tree View ⌘T` (label flips to `List View ⌘T` when in tree mode).
+
+#### Keyboard handling
+
+A local `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` mounted while the popover is visible:
+
+- `⌘R` → `Task { await inventory.refresh() }`
+- `⌘T` → `inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list`
+- `ESC`: if `searchText` is non-empty, clear it; otherwise close the popover via the `HoverPopover` handle.
+
+### 6. `HoverPopover` integration
+
+`MenuBarView` already dispatches hover for `.appShortcuts`. Extend the switch:
+
+```swift
+switch entry.builtin {
+case .appShortcuts: present(AppShortcutsPopoverView())
+case .portManager:  present(PortManagerPopoverView())
+default: break
+}
+```
+
+Reuse `HoverGate` timing (400ms enter, 300ms leave) and `HoverPopover` placement (right-anchored, flips left on screen edges).
+
+When the global hotkey for `.portManager` fires, `PanelStore.dispatch(.showSubmenu(.portManager))` publishes the submenu open request, the menu bar opens its panel, then mounts the popover for that item with search focused.
+
+## Data Flow
+
+```
+User hover on port-manager row
+  └─> HoverGate.shouldShow = true after 400ms
+       └─> HoverPopover.present(PortManagerPopoverView)
+            └─> .task { await PortInventory.shared.refresh() }
+                 └─> PortScanner.scanTCPListening()
+                      ├─> ShellRunner: lsof ...
+                      ├─> parseLsofOutput
+                      └─> sysctl(KERN_PROCARGS2) per pid
+                 └─> PortInventory.records = ...
+                      └─> SwiftUI re-renders PortListView / PortTreeView
+
+User clicks kill on a row
+  └─> PortInventory.kill(pid:)
+       ├─> killingPIDs.insert(pid)  → all rows of that pid turn gray + spinner
+       ├─> scanner.kill(pid, SIGTERM)
+       │    └─ failure → failedKillPIDs[pid] = ...  → all rows of that pid turn red
+       ├─> sleep 500ms
+       ├─> refresh()
+       ├─> if still alive: scanner.kill(pid, SIGKILL) → refresh()
+       └─> killingPIDs.remove(pid)
+```
+
+## Error Handling
+
+| Error | Surface | Recovery |
+|-------|---------|----------|
+| `lsof` timeout / non-zero exit / parse failure | Inline yellow banner above the list ("刷新失败: ..."), retry button. Last records preserved. | Manual ⌘R or banner retry button. |
+| Kill returns `EPERM` | Red `exclamationmark.circle.fill` on the row, tooltip "权限不足（系统/其他用户进程）", auto-dismiss after 3s. | None (no privilege escalation). |
+| Kill returns `ESRCH` | Treated as success, no UI error. Refresh removes the row. | Automatic. |
+| Kill returns other errno | Same red indicator, tooltip "kill 失败 (errno: N)". | Manual retry. |
+| Popover opens with empty records | Centered `ProgressView("扫描中...")`. | Automatic on scan completion. |
+| Filtered records empty | Centered "无匹配的端口" text. | Adjust search. |
+| Duplicate kill clicks on same pid | Kill icon disabled (row gray) while `killingPIDs` contains pid. | N/A. |
+
+Logging: `os.Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")` records scan start/end/failure and kill calls (pid, signal, errno). Process names and command lines are not logged to avoid leaking user activity.
+
+## Testing
+
+### Package change
+
+Add a test target to `Package.swift`:
+
+```swift
+.testTarget(
+    name: "AnyDoorTests",
+    dependencies: ["AnyDoor"],
+    path: "Tests/AnyDoorTests",
+    resources: [.process("Fixtures")]
+)
+```
+
+### `PortScannerTests` (unit, no system dependency)
+
+- `parseLsofOutput` fixtures:
+  - single process, single IPv4 port
+  - single process, multiple ports
+  - same pid+port across IPv4/IPv6 → merged into one record with both families
+  - long command name preserved (no truncation)
+  - malformed input → throws `.parseFailed`
+- `parseProcArgs` fixture: simulated KERN_PROCARGS2 byte buffer.
+
+### `PortInventoryTests` (`@MainActor`, stub `PortScanning`)
+
+- Search priority: records covering port `:3000`, process `node`, PID `67035`; query `"30"` returns the port-match first.
+- Search is case-insensitive.
+- `viewMode` round-trips through UserDefaults (isolated suite).
+- Successful kill clears `killingPIDs` and refreshes records.
+- `EPERM` populates `failedKillPIDs` with `.permissionDenied`.
+- `ESRCH` does **not** populate `failedKillPIDs`.
+- Consecutive `refresh()` calls cancel the previous task.
+- `groupedByProcess` returns groups sorted by name with ports sorted ascending.
+
+### Manual QA checklist
+
+- Hover the App Shortcuts row → port-manager popover does **not** appear.
+- Hover the port-manager row → popover appears after ~400ms.
+- Toggle list/tree → preference persists after app restart.
+- Type in search → count updates instantly; ordering matches priority spec.
+- Click kill on a user-owned process → row turns gray, process disappears after 0.5–1s, list refreshes.
+- Click kill on a root-owned process (e.g. `ControlCenter`) → red icon + tooltip, auto-dismisses after 3s.
+- ESC clears search when non-empty; ESC closes popover when search is empty.
+- ⌘R triggers refresh; banner appears and disappears on transient failures.
+- ⌘T toggles list/tree view.
+
+### Out of scope for tests
+
+- `lsof` integration (treated as trusted system tool).
+- SwiftUI rendering (no snapshot library).
+- `HoverPopover` plumbing (already validated in App Shortcuts).
+- UI automation.
+
+## Files Touched / Created
+
+**Created**
+- `Sources/AnyDoor/Services/PortScanner.swift`
+- `Sources/AnyDoor/Services/PortInventory.swift`
+- `Sources/AnyDoor/Views/PortManagerPopoverView.swift`
+- `Sources/AnyDoor/Views/PortListView.swift`
+- `Sources/AnyDoor/Views/PortTreeView.swift`
+- `Sources/AnyDoor/Views/PortRowView.swift` (shared row + status dot + kill icon)
+- `Sources/AnyDoor/Views/PortProcessGroupView.swift`
+- `Tests/AnyDoorTests/PortScannerTests.swift`
+- `Tests/AnyDoorTests/PortInventoryTests.swift`
+- `Tests/AnyDoorTests/Fixtures/lsof-*.txt` (fixture files)
+
+**Modified**
+- `Sources/AnyDoor/Models/BuiltinItem.swift` — add `.portManager` case with `.submenu` kind, title, symbol, default ordering.
+- `Sources/AnyDoor/Models/HotkeyAction.swift` — add `.showSubmenu(BuiltinItem)` case and its `HotkeySnapshot` encoding.
+- `Sources/AnyDoor/Services/PanelStore.swift` — add submenu open-request publisher; dispatch `.showSubmenu` accordingly.
+- `Sources/AnyDoor/Views/MenuBarView.swift` — extend hover dispatch to mount `PortManagerPopoverView` for `.portManager`.
+- `Package.swift` — add `.testTarget(name: "AnyDoorTests", ...)`.
+
+No SwiftData schema changes (preference for `.portManager` is auto-seeded by the existing seeder).
+
+## Open Questions
+
+None. All clarifications captured above.
+
+## Future Extensions (not in this design)
+
+- Copy port / PID / command line to clipboard via context menu.
+- Pin specific ports as favorites for quick access.
+- Show CPU / memory next to each process.
+- Background polling with delta animations.
+- UDP / established connections via a view-mode segmented control.
+- Keyboard navigation inside the list.

--- a/docs/superpowers/specs/2026-05-21-port-management-design.md
+++ b/docs/superpowers/specs/2026-05-21-port-management-design.md
@@ -190,7 +190,7 @@ enum SubprocessError: Error, Equatable {
 
 `PortScanner.init(runner:)` accepts any `any SubprocessRunning` (defaulting to the real one). Tests inject a stub that returns canned `SubprocessResult` values.
 
-The real implementation drains pipes concurrently with the running process and honors both timeout and Task cancellation:
+The real implementation drains pipes concurrently with the running process and honors both timeout and Task cancellation. The `timedOut` flag uses `OSAllocatedUnfairLock<Bool>` from `os` — **no new package dependency**; Swift Atomics is intentionally *not* added to `Package.swift` for this feature. A simple `NSLock`-guarded `Bool` or an actor-wrapped value are interchangeable; the only requirement is that the watchdog and the result-builder see consistent state.
 
 ```swift
 struct LsofRunner: SubprocessRunning {
@@ -214,11 +214,11 @@ struct LsofRunner: SubprocessRunning {
             async let errData: Data = readAll(errPipe.fileHandleForReading)
 
             // Timeout watchdog terminates the child on deadline.
-            let timedOut = ManagedAtomic(false)   // or actor-isolated Bool
+            let timedOut = OSAllocatedUnfairLock<Bool>(initialState: false)
             let watchdog = Task {
                 try? await Task.sleep(for: timeout)
                 if process.isRunning {
-                    timedOut.store(true, ordering: .relaxed)
+                    timedOut.withLock { $0 = true }
                     process.terminate()
                 }
             }
@@ -231,7 +231,7 @@ struct LsofRunner: SubprocessRunning {
                 stdout: String(data: out, encoding: .utf8) ?? "",
                 stderr: String(data: err, encoding: .utf8) ?? "",
                 exit: process.terminationStatus,
-                timedOut: timedOut.load(ordering: .relaxed)
+                timedOut: timedOut.withLock { $0 }
             )
         } onCancel: {
             // Called when the *outer* Task is cancelled. Process.terminate()
@@ -242,9 +242,9 @@ struct LsofRunner: SubprocessRunning {
 }
 ```
 
-`scanTCPListening()` inspects `SubprocessResult.timedOut` first; when true it throws `PortScanError.lsofTimeout` regardless of exit status. When false, it applies the empty-result rule (exit 1 + empty stdout/stderr → `[]`) and otherwise the failure rule.
+`scanTCPListening()` inspects `SubprocessResult.timedOut` first; when true it throws `PortScanError.lsofTimeout` regardless of exit status. When false, it applies the empty-result rule (`exit == 1 && stdout.isEmpty && stderr.isEmpty` → `[]`) and otherwise the failure rule. **Both stdout and stderr must be empty** for the empty-result shortcut — exit 1 with diagnostics on stderr is a real failure.
 
-`LsofRunner` lives in `PortScanner.swift` alongside the actor; other features keep using `ShellRunner` for their short outputs. `Bool`-flag implementation detail can use `os_unfair_lock` or actor isolation if `ManagedAtomic` is overkill — the point is "the runner returns whether it timed out, the scanner branches on it."
+`LsofRunner` lives in `PortScanner.swift` alongside the actor; other features keep using `ShellRunner` for their short outputs.
 
 #### Scanning pipeline
 
@@ -252,7 +252,7 @@ struct LsofRunner: SubprocessRunning {
    - `-F pPcntL` requests fielded output: `p` = process id, `P` = protocol name, `c` = command name, `n` = name (`addr:port`), `t` = file type (`IPv4` / `IPv6`), `L` = login user. **`t` is the address family field — `P` is the protocol (`TCP`), not the family.**
    - `-n -P` skips DNS / service-name resolution.
    - `+c 0` disables command-name truncation.
-2. **Handle empty-result exit code.** lsof returns exit code 1 with empty stdout and (typically) empty stderr when no matching open files exist. Treat `(exit == 1 && stdout.isEmpty)` as a successful empty scan, not a failure. Any other non-zero exit with non-empty stderr is a real error → `PortScanError.lsofFailed`.
+2. **Handle empty-result exit code.** lsof returns exit code 1 with empty stdout *and* empty stderr when no matching open files exist. Treat **`(exit == 1 && stdout.isEmpty && stderr.isEmpty)`** as a successful empty scan. **Stderr must also be empty** — exit code 1 with non-empty stderr means lsof actually failed (permissions, syntax, etc.) and stderr carries the diagnostic. That case throws `PortScanError.lsofFailed`. Any other non-zero exit also throws `.lsofFailed`.
 3. Parse the fielded output by process record (`p`-prefixed line starts a new process) → file record (`f`-prefixed line starts a new file within a process). Extract `(pid, command, addr:port, family)`. Address parsing handles three forms: `*:5000`, `127.0.0.1:3000`, `[::1]:8080` (and zone-id variants like `[fe80::1%en0]:1234`).
 4. Group entries by `(pid, port)`. Each group becomes a single `PortRecord` whose `binds` array preserves every distinct `(address, family)` pair. **No information is lost when both IPv4 `127.0.0.1` and IPv6 `[::1]` listen on the same port.**
 5. Enrich with `sysctl(KERN_PROCARGS2)` once per unique pid (deduplicated across multi-port processes) to obtain `executablePath` and `commandLine`. Failures (permission denied, process gone) are silent — the record keeps lsof's short command name.
@@ -412,6 +412,7 @@ Structure:
 struct PortManagerPopoverView: View {
     @Bindable var inventory: PortInventory   // the singleton
     var onHoverChange: (Bool) -> Void        // callback to HoverGate.popoverHover
+    var onClose: () -> Void                  // invoked by ESC (when search is empty)
 
     var body: some View {
         VStack(spacing: 0) {
@@ -440,12 +441,20 @@ struct PortManagerPopoverView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .task { await inventory.refresh() }
         .onHover(perform: onHoverChange)   // critical: keeps popover open while hovered
-        .background(KeyboardMonitor(inventory: inventory))
+        .background(KeyboardMonitor(inventory: inventory, onClose: onClose))
     }
 }
 ```
 
-The `onHoverChange` callback mirrors `AppShortcutsPopoverView.swift:51` and feeds into `HoverGate.popoverHover(_:)`. Without it, the gate only tracks the trigger row's hover state, and the popover closes 300ms after the cursor leaves the menu bar row even though the cursor is inside the popover. `MenuBarView` is responsible for wiring this callback when it constructs the view (just like it does for App Shortcuts today).
+The `onHoverChange` callback mirrors `AppShortcutsPopoverView.swift:51` and feeds into `HoverGate.popoverHover(_:)`. Without it, the gate only tracks the trigger row's hover state, and the popover closes 300ms after the cursor leaves the menu bar row even though the cursor is inside the popover.
+
+The `onClose` callback is the ESC-when-search-is-empty path. `MenuBarView` wires it to a closure that:
+
+1. Calls `inventory.searchText = ""` (no-op if already empty; keeps state tidy).
+2. Calls `gate.reset()` — a new helper on `HoverGate` that clears both `triggerHovered` and `popoverHovered`, cancels any pending show/hide tasks, and sets `isShown = false`. Without this reset the gate can keep believing `popoverHovered == true` (last seen during an `.onHover(false)` that never fired because the popover was force-closed first), which jams the next hover open or closed depending on which task wins.
+3. Calls `popover.hide()`.
+
+`MenuBarView` is responsible for passing all three closures (`inventory`, `onHoverChange`, `onClose`) when it constructs the view — same wiring pattern as App Shortcuts today.
 
 #### `PortListView` / `PortRowView`
 
@@ -475,14 +484,38 @@ The `onHoverChange` callback mirrors `AppShortcutsPopoverView.swift:51` and feed
 - Middle: search field, auto-focused on appear; `@FocusState` binding.
 - Right: count capsule showing `filteredRecords.count`, accompanied by a small spinner when `isRefreshing` is true.
 
-**Window key-focus contract.** The existing `HoverPopover` (`HoverPopover.swift:14`) hosts content in a borderless, `level = .floating` `NSWindow` that is shown with `orderFrontRegardless()`. A bare `NSWindow` like that returns `false` from `canBecomeKey` and therefore swallows text input and local key events — fine for App Shortcuts (read-only rows with tap gestures), broken for port-manager (search field + ⌘R / ⌘T / ESC). Two changes are required and **must land in the same iteration as this feature**:
+**Window key-focus contract.** The existing `HoverPopover` (`HoverPopover.swift:14`) hosts content in a borderless, `level = .floating` `NSWindow` that is shown with `orderFrontRegardless()`. A bare `NSWindow` like that returns `false` from `canBecomeKey` and therefore swallows text input and local key events — fine for App Shortcuts (read-only rows with tap gestures), broken for port-manager (search field + ⌘R / ⌘T / ESC).
 
-1. Subclass `NSWindow` (or set `setIsVisible(false)` and reconfigure) so `canBecomeKey` and `canBecomeMain` return `true`. Add `becomesKeyOnlyIfNeeded = true` and `styleMask` includes `.nonactivatingPanel`-style behavior (use `NSPanel` if simpler) so opening the popover does not steal app activation from the foreground app — this matches the existing "menu bar accessory" feel.
-2. In `HoverPopover.show(...)`, call `window.makeKey()` (or `makeKeyAndOrderFront(nil)` followed by `NSApp.activate(ignoringOtherApps: false)`) so the SwiftUI `@FocusState` binding can claim first responder.
+The complication unique to AnyDoor is the parent: `AnyDoorApp` uses `MenuBarExtra(...).menuBarExtraStyle(.window)` (`AnyDoor.swift:13`), which means the menu bar panel itself is an `NSPanel` that auto-dismisses when key is taken away from it. And `MenuBarView.swift:57` runs `popover.hide()` from `onDisappear`. If the popover naively calls `makeKey()`, the menu bar panel will lose key, collapse, and trigger `onDisappear`, which hides the very popover that just took focus.
 
-App Shortcuts is unaffected: it has no focusable controls, so gaining key status is harmless. Add a manual QA check that hovering App Shortcuts still doesn't show a typing cursor and doesn't steal focus from other apps.
+The design therefore has three layered requirements that **all ship together with this feature**:
 
-If subclassing turns out fragile, the fallback is a second, port-manager-specific popover host that owns an `NSPanel` configured for key acceptance, and `HoverPopover` stays read-only. The spec leaves room for either path during implementation; the contract that must hold is "the search field is focused on appear and receives keystrokes without forcing AnyDoor to the foreground."
+1. **Popover host is an `NSPanel` with `.nonactivatingPanel`** (replace or subclass the current `NSWindow`). Override `canBecomeKey` to return `true` only when the content actually needs first responder (a `needsKeyFocus: Bool` flag on `HoverPopover` set by the caller — `AppShortcutsPopoverView` leaves it `false`, `PortManagerPopoverView` sets it `true`). Non-activating panels do not activate the app, but they still take key when explicitly asked.
+
+2. **`HoverPopover.isHoldingFocus`** — a published flag flipped to `true` while the popover panel has key status (observe via `NSWindow.didBecomeKeyNotification` / `didResignKeyNotification`). When `true`, `HoverGate` and `MenuBarView` treat the popover as "stuck" and do not run dismissal timers.
+
+3. **`MenuBarView.onDisappear` guards on `isHoldingFocus`**:
+   ```swift
+   .onDisappear {
+       if !popover.isHoldingFocus { popover.hide() }
+   }
+   ```
+   The contract: if the popover is the reason the menu bar panel lost key, leave it alive. The popover takes responsibility for hiding itself when its own focus session ends (next finding's `onClose`).
+
+**Fallback if MenuBarExtra still collapses despite a non-activating panel.** The risk that `.menuBarExtraStyle(.window)` collapses on any key transition — even to a non-activating panel — cannot be dismissed without testing on the target macOS. If the primary path fails, the fallback is:
+
+- The popover panel does **not** become key. Instead, the popover installs a local `NSEvent.addLocalMonitorForEvents(matching: [.keyDown])` while it is visible. The monitor intercepts every key event delivered to any of AnyDoor's windows, routes ⌘R / ⌘T / ESC to inventory commands, and appends/removes characters from `inventory.searchText` directly (treating the search field as a presentation-only mirror with `@Bindable` two-way binding back to the inventory string). The TextField is rendered but never becomes first responder.
+- This is less polished (no cursor blinking inside the field) but completely sidesteps the focus-transfer problem.
+
+The implementation order is: try (1)+(2)+(3) first, validate with the QA gate below, and only fall back if it visibly misbehaves. Either way the spec's external contract is unchanged: typing works, ⌘R/⌘T/ESC work, hovering away closes the popover, hovering App Shortcuts is unaffected.
+
+**QA gate** (must all pass before the feature ships):
+
+- Hover port-manager → popover appears, search field shows a cursor (or, in fallback mode, typing visibly updates the field via the bound string).
+- Type a query → menu bar panel is still visible, popover is still visible, list filters.
+- Move cursor away from popover and trigger row → popover closes after 300ms, menu bar panel remains open (or closes naturally on outside click), and a subsequent hover on port-manager re-opens the popover cleanly (no stuck gate state).
+- Switch focus to another app (Cmd-Tab) → menu bar panel and popover both dismiss; reopening the menu bar shows a fresh state.
+- Hover App Shortcuts → still works exactly as before; popover content has no typing cursor; no app activation occurs.
 
 #### `PortManagerToolbar`
 
@@ -490,11 +523,14 @@ If subclassing turns out fragile, the fallback is a second, port-manager-specifi
 
 #### Keyboard handling
 
-A local `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` mounted while the popover is visible:
+`KeyboardMonitor` is an `NSViewRepresentable` that installs a local `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` when its hosting view appears and removes it on disappear. While the popover is visible:
 
-- `⌘R` → `Task { await inventory.refresh() }`
-- `⌘T` → `inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list`
-- `ESC`: if `searchText` is non-empty, clear it; otherwise close the popover via the `HoverPopover` handle.
+- `⌘R` → `Task { await inventory.refresh() }`. Return `nil` to swallow the event.
+- `⌘T` → `inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list`. Return `nil`.
+- `ESC`: if `inventory.searchText.isEmpty`, call `onClose()` (passed in from `PortManagerPopoverView`). Otherwise clear `inventory.searchText` and return `nil`.
+- All other events pass through (return the event unchanged) so the search field receives input normally.
+
+The monitor is local (not global), so it sees only events delivered to AnyDoor's own windows. When the fallback "no-key-focus" mode is in use (see Window key-focus contract above), the same monitor also handles printable keys to update `inventory.searchText` directly.
 
 ### 6. `HoverPopover` integration
 
@@ -524,7 +560,7 @@ User hover on port-manager row
                  └─> PortScanner.scanTCPListening()
                       ├─> private subprocess runner: lsof -nP -iTCP -sTCP:LISTEN -F pPcntL +c 0
                       │     (drains stdout/stderr concurrently with run; 3s timeout)
-                      ├─> handle (exit==1 && stdout.isEmpty) → return []
+                      ├─> handle (exit==1 && stdout.isEmpty && stderr.isEmpty) → return []
                       ├─> parseLsofOutput → [(pid,port,binds[],family)]
                       └─> sysctl(KERN_PROCARGS2) per unique pid
                  └─> PortInventory.records = ...
@@ -607,7 +643,7 @@ Fixtures live under `Tests/AnyDoorTests/Fixtures/`. Tests load them with `Bundle
 - Submenu hotkey filtering remains unchanged: `PanelStore.rebuildHotkeySnapshots()` produces zero snapshots for `.portManager` regardless of whether the preference has a keycode set (regression guard since `.portManager` is the first new submenu item).
 - `isRefreshing` semantics with concurrent refreshes: stub runner exposes two `CheckedContinuation`s. Trigger `refresh()` twice; resolve the older one first; assert `isRefreshing == true` (newer scan still in flight); resolve the newer; assert `isRefreshing == false`. Reverse order also covered.
 - Subprocess runner timeout: stub runner returns `SubprocessResult(timedOut: true, ...)`; scanner throws `.lsofTimeout` regardless of exit code.
-- Subprocess runner cancellation: real `LsofRunner` test (best-effort; skip if CI cannot spawn `/usr/bin/yes`) — spawn `/usr/bin/yes`, wrap in a Task, cancel after 100ms, assert the process is no longer running shortly after.
+- Subprocess runner cancellation (logical): a `FakeSubprocessRunner` whose `run(...)` waits on an internal `CheckedContinuation`; the test wraps the scanner call in a Task, cancels the Task, and asserts the fake recorded a cancellation callback. This exercises the `withTaskCancellationHandler` wiring without spawning real processes — the hazardous `/usr/bin/yes` approach (where the cancellation logic *is* the unit under test, so a regression hangs the test process) is downgraded to a **manual dev-only smoke test** documented in the QA checklist, not a CI unit test.
 
 ### Manual QA checklist
 
@@ -626,6 +662,7 @@ Fixtures live under `Tests/AnyDoorTests/Fixtures/`. Tests load them with `Bundle
 - ⌘R triggers refresh; banner appears and disappears on transient failures.
 - ⌘T toggles list/tree view.
 - Open Settings → port-manager row shows no hotkey recorder (column reserved blank, matching App Shortcuts).
+- (Dev-only smoke check, not in CI) Temporarily point the runner at `/usr/bin/yes`, open the popover, then dismiss within ~200ms; verify with `ps aux | grep yes` that no orphan `yes` process remains. Skip on CI/automation; only run when modifying the subprocess runner.
 
 ### Out of scope for tests
 
@@ -675,6 +712,14 @@ None. All clarifications captured above.
 - Keyboard navigation inside the list.
 
 ## Revisions
+
+**2026-05-21 — third-round revisions**
+
+- Codified the MenuBarExtra interaction policy. `AnyDoorApp` uses `.menuBarExtraStyle(.window)`, so the menu bar panel auto-dismisses on key loss; combined with `MenuBarView.onDisappear { popover.hide() }`, a naive `makeKey()` on the popover would collapse the menu bar panel and immediately re-hide the popover. New requirements: popover host is an `NSPanel` with `.nonactivatingPanel`; `HoverPopover.isHoldingFocus` flips from `NSWindow` key notifications; `MenuBarView.onDisappear` guards the hide on that flag. Documented a fallback (local NSEvent monitor without taking key focus) for the case where `.menuBarExtraStyle(.window)` still collapses on any key transition. Added a QA gate that must pass before the feature ships.
+- Plumbed an `onClose: () -> Void` callback through `PortManagerPopoverView` → `KeyboardMonitor`. ESC-with-empty-search now invokes `onClose`, which `MenuBarView` wires to: clear search → call a new `HoverGate.reset()` (clears trigger/popover-hovered, cancels pending tasks, sets `isShown = false`) → `popover.hide()`. Prevents stuck gate state on the next hover.
+- Unified the empty-result rule to `exit == 1 && stdout.isEmpty && stderr.isEmpty` in all three places (Clarifications, Section 3 pipeline, Data Flow). Exit 1 with diagnostics on stderr is a real failure, not an empty list.
+- Removed all references to `ManagedAtomic`. The runner's `timedOut` flag uses `OSAllocatedUnfairLock<Bool>` from the standard library — no new package dependency.
+- Downgraded the "spawn `/usr/bin/yes` then cancel" cancellation test from a unit test to a dev-only smoke check. Unit tests use a `FakeSubprocessRunner` with `CheckedContinuation` to exercise the `withTaskCancellationHandler` wiring deterministically; the real-process variant lives in the QA checklist for use when modifying the runner.
 
 **2026-05-21 — second-round revisions**
 


### PR DESCRIPTION
## Summary

- Adds a new "端口管理" submenu in the menu bar panel that lists TCP listeners by hovering, with priority search (port → process name → pid), list/tree views, and per-pid kill (SIGTERM→500ms→SIGKILL with errno-mapped failure UI).
- Generalizes the hover-popover plumbing: `HoverPopover` gains opt-in key focus via a `KeyableHoverPanel: NSPanel` so the port-manager search field can receive text input while App Shortcuts keeps its read-only behavior; `MenuBarView` now keys `triggerFrames` by `BuiltinItem` so any future submenu can plug in.
- Backed by `PortScanner` (actor wrapping `lsof -nP -iTCP -sTCP:LISTEN -F` with concurrent pipe drain, 3s watchdog, KERN_PROCARGS2 enrichment) and `PortInventory` (`@MainActor @Observable`, refresh generation token + inflight count, two-phase kill state machine, viewMode persistence). 28 new tests, 49/49 passing.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 49/49 pass
- [x] Menu bar: 端口管理 row visible at default order 1900
- [x] Settings → 面板: 端口管理 shows `系统 · 子菜单` badge, no hotkey input
- [x] Hover 端口管理 → popover slides out on the right side of the row, vertically centered
- [x] Search: typing filters live; port number matches outrank name matches
- [x] ESC clears search if non-empty, otherwise closes the popover
- [x] ⌘R refreshes, ⌘T toggles list ↔ tree (persists across restart)
- [x] Kill a user process (e.g. `python3 -m http.server 8000`) — row disappears within ~1s
- [x] Kill a root process (e.g. ControlCenter) — red error indicator with tooltip, auto-dismisses after 3s
- [x] App Shortcuts hover behavior unchanged (regression check)
- [x] Menu bar panel stays open while typing in the search field (key-focus risk)