### PR TITLE
feat: add OCR screen text recognition action

### DIFF
--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -57,6 +57,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             RestartMenuBarProvider(),
             FlushDNSProvider(),
             KeyboardLockProvider(),
+            OCRProvider(),
         ]
         PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)
 

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -12,6 +12,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case lockScreen
     case emptyTrash
     case screenshot
+    case ocr
     case displaySleep
     case systemSleep
     case hideDock
@@ -34,7 +35,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .appShortcuts, .portManager: return .submenu
         case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
-        case .lockScreen, .emptyTrash, .screenshot, .displaySleep, .systemSleep,
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .displaySleep, .systemSleep,
              .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
         }
     }
@@ -50,6 +51,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .lockScreen: return "锁定屏幕"
         case .emptyTrash: return "清空废纸篓"
         case .screenshot: return "截图到剪贴板"
+        case .ocr: return "屏幕取词"
         case .displaySleep: return "显示器睡眠"
         case .systemSleep: return "系统休眠"
         case .hideDock: return "隐藏 Dock"
@@ -74,6 +76,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .lockScreen: return "lock.fill"
         case .emptyTrash: return "trash.fill"
         case .screenshot: return "camera.viewfinder"
+        case .ocr: return "text.viewfinder"
         case .displaySleep: return "moon.zzz.fill"
         case .systemSleep: return "powersleep"
         case .hideDock: return "dock.rectangle"
@@ -99,6 +102,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .lockScreen: return 700
         case .emptyTrash: return 800
         case .screenshot: return 900
+        case .ocr: return 950
         case .displaySleep: return 1000
         case .systemSleep: return 1100
         case .hideDock: return 1200

--- a/Sources/AnyDoor/Services/PanelStore.swift
+++ b/Sources/AnyDoor/Services/PanelStore.swift
@@ -29,6 +29,9 @@ final class PanelStore {
     /// Per-item in-flight guard preventing overlapping toggles from desynchronizing state.
     private var togglesInFlight: Set<BuiltinItem> = []
 
+    /// Per-item in-flight guard preventing overlapping action runs from racing.
+    private var actionsInFlight: Set<BuiltinItem> = []
+
     private init() {}
 
     func bootstrap(
@@ -149,8 +152,15 @@ final class PanelStore {
     }
 
     /// Run a one-shot action.
+    ///
+    /// Guarded against overlapping calls: a second invocation for the same item while the
+    /// first is mid-flight is dropped. Actor isolation alone does not serialize runs — an
+    /// `actor` provider yields its executor at every `await`.
     func run(_ item: BuiltinItem) async {
         guard let provider = providers[item] as? any ActionProvider else { return }
+        guard !actionsInFlight.contains(item) else { return }
+        actionsInFlight.insert(item)
+        defer { actionsInFlight.remove(item) }
         do {
             try await provider.run()
         } catch {

--- a/Sources/AnyDoor/Services/Providers/OCRProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/OCRProvider.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Foundation
+
+/// Captures a screen region, recognizes its text with Vision, copies the text to
+/// the clipboard, and shows a bottom-center toast reporting the outcome.
+///
+/// Every error is absorbed and mapped to a toast — `run()` never propagates.
+actor OCRProvider: ActionProvider {
+    let itemKey: BuiltinItem = .ocr
+
+    var permission: PermissionStatus { .notRequired }
+
+    func run() async {
+        do {
+            guard let image = try await RegionCapture.captureRegion() else {
+                return // user cancelled — silent, no toast
+            }
+            let lines = try await TextRecognizer.recognize(image)
+            guard !lines.isEmpty else {
+                await ToastPresenter.shared.show(.failure("未识别到文字"))
+                return
+            }
+            let text = lines.joined(separator: "\n")
+            await MainActor.run {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
+            }
+            await ToastPresenter.shared.show(.success("已复制到剪贴板"))
+        } catch {
+            await ToastPresenter.shared.show(.failure("识别失败"))
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift
@@ -8,7 +8,7 @@ actor ScreenshotProvider: ActionProvider {
 
     func run() async throws {
         do {
-            _ = try await ShellRunner.run("/usr/sbin/screencapture", args: ["-i", "-c"])
+            _ = try await ShellRunner.run("/usr/sbin/screencapture", args: ["-i", "-c"], timeout: nil)
         } catch BuiltinError.shellFailed {
             // screencapture exits non-zero when the user cancels with Esc; treat cancellation as a no-op.
         }

--- a/Sources/AnyDoor/Services/RegionCapture.swift
+++ b/Sources/AnyDoor/Services/RegionCapture.swift
@@ -1,0 +1,61 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Errors surfaced by the OCR capture pipeline.
+enum OCRError: Error {
+    /// screencapture produced a file but it could not be decoded into a CGImage.
+    case imageDecodeFailed
+}
+
+/// Wraps the native macOS interactive screen-selection tool (`screencapture -i -s`).
+/// Owns the temp-file lifecycle.
+enum RegionCapture {
+    /// Presents the macOS region-selection UI and returns the captured image.
+    ///
+    /// Returns `nil` when the user cancels — cancellation is detected by the
+    /// *absence* of a temp file, because `screencapture`'s cancel exit code is
+    /// undocumented and unreliable. Holding Control during selection routes the
+    /// capture to the clipboard (native behavior), which also produces no file
+    /// and is therefore treated as a cancellation.
+    ///
+    /// Throws `OCRError.imageDecodeFailed` when a file is produced but cannot be
+    /// decoded, and rethrows any process-launch failure.
+    static func captureRegion() async throws -> CGImage? {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anydoor-ocr-\(UUID().uuidString).png")
+        let tempPath = tempURL.path
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        do {
+            // -i: interactive; -s: selection-only (disables spacebar window mode).
+            // timeout nil: the user controls how long the selection takes.
+            _ = try await ShellRunner.run(
+                "/usr/sbin/screencapture",
+                args: ["-i", "-s", tempPath],
+                timeout: nil
+            )
+        } catch BuiltinError.shellFailed {
+            // Non-zero exit. screencapture's cancel exit code is undocumented,
+            // so do not treat this as a failure here — fall through to the
+            // file-presence check, which is the reliable signal.
+        }
+        // A genuine launch failure throws a non-BuiltinError and propagates.
+
+        guard FileManager.default.fileExists(atPath: tempPath) else {
+            return nil // user cancelled, or Control-routed the capture to the clipboard
+        }
+        guard let image = decodeImage(at: tempURL) else {
+            throw OCRError.imageDecodeFailed
+        }
+        return image
+    }
+
+    private static func decodeImage(at url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+        return image
+    }
+}

--- a/Sources/AnyDoor/Services/RegionCapture.swift
+++ b/Sources/AnyDoor/Services/RegionCapture.swift
@@ -51,11 +51,18 @@ enum RegionCapture {
         return image
     }
 
-    private static func decodeImage(at url: URL) -> CGImage? {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+    /// Decodes the PNG at `url` into a CGImage. Internal (not private) so the
+    /// file-deletion-survival behavior can be unit-tested.
+    ///
+    /// `kCGImageSourceShouldCacheImmediately` forces a full pixel decode at creation
+    /// time, while the file still exists. Without it the returned CGImage decodes
+    /// lazily on first pixel access — but the caller deletes the temp file as soon as
+    /// `captureRegion()` returns, so a lazy image would read back nothing.
+    static func decodeImage(at url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
             return nil
         }
-        return image
+        let options: [CFString: Any] = [kCGImageSourceShouldCacheImmediately: true]
+        return CGImageSourceCreateImageAtIndex(source, 0, options as CFDictionary)
     }
 }

--- a/Sources/AnyDoor/Services/ShellRunner.swift
+++ b/Sources/AnyDoor/Services/ShellRunner.swift
@@ -6,11 +6,12 @@ import Foundation
 /// linking against the corresponding C API would be more complex than calling out.
 enum ShellRunner {
     /// Launch a binary with args. Returns combined stdout/stderr. Throws on non-zero exit
-    /// or timeout (default 5 seconds).
+    /// or timeout. Pass `timeout: nil` for interactive subprocesses that have no meaningful
+    /// time budget (e.g. `screencapture -i`).
     static func run(
         _ path: String,
         args: [String] = [],
-        timeout: TimeInterval = 5
+        timeout: TimeInterval? = 5
     ) async throws -> String {
         try await Task.detached(priority: .userInitiated) {
             let process = Process()
@@ -23,10 +24,10 @@ enum ShellRunner {
 
             try process.run()
 
-            // Timeout watchdog
-            let deadline = Date().addingTimeInterval(timeout)
+            // Timeout watchdog — only armed when a timeout is supplied.
+            let deadline = timeout.map { Date().addingTimeInterval($0) }
             while process.isRunning {
-                if Date() > deadline {
+                if let deadline, Date() > deadline {
                     process.terminate()
                     let data = try? pipe.fileHandleForReading.readToEnd()
                     let output = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""

--- a/Sources/AnyDoor/Services/TextRecognizer.swift
+++ b/Sources/AnyDoor/Services/TextRecognizer.swift
@@ -1,0 +1,26 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+/// Recognizes text in a still image using the macOS Vision framework.
+enum TextRecognizer {
+    /// Recognizes text in `image`. Returns one string per recognized text block,
+    /// ordered top-to-bottom. An empty array means no text was found (not an error).
+    static func recognize(_ image: CGImage) async throws -> [String] {
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.automaticallyDetectsLanguage = false
+        request.recognitionLanguages = [
+            Locale.Language(identifier: "zh-Hans"),
+            Locale.Language(identifier: "en-US"),
+        ]
+
+        let observations = try await request.perform(on: image)
+
+        // Vision's normalized coordinate space has Y increasing upward, so the
+        // top-most text block has the largest topLeft.y.
+        return observations
+            .sorted { $0.topLeft.y > $1.topLeft.y }
+            .map(\.transcript)
+    }
+}

--- a/Sources/AnyDoor/Views/ToastPresenter.swift
+++ b/Sources/AnyDoor/Views/ToastPresenter.swift
@@ -1,0 +1,87 @@
+import AppKit
+import SwiftUI
+
+/// Owns a single borderless toast window shown at the bottom-center of the screen.
+/// `show(_:)` is the only public entry point; the toast auto-dismisses after ~1s.
+@MainActor
+final class ToastPresenter {
+    static let shared = ToastPresenter()
+
+    private let panel: ToastPanel
+    private let hostingController: NSHostingController<ToastView>
+    private var dismissTask: Task<Void, Never>?
+
+    private init() {
+        let controller = NSHostingController(rootView: ToastView(style: .success("")))
+        controller.sizingOptions = [.preferredContentSize]
+        self.hostingController = controller
+
+        let panel = ToastPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 44),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.level = .statusBar
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.hidesOnDeactivate = false
+        panel.contentViewController = controller
+        self.panel = panel
+    }
+
+    /// Show a toast. A new call replaces the current toast in place and resets the timer.
+    func show(_ style: ToastStyle) {
+        dismissTask?.cancel()
+
+        hostingController.rootView = ToastView(style: style)
+        hostingController.view.layoutSubtreeIfNeeded()
+        let size = hostingController.view.fittingSize
+        if size.width > 0 && size.height > 0 {
+            panel.setContentSize(size)
+        }
+        positionPanel(size: panel.frame.size)
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            panel.animator().alphaValue = 1
+        }
+
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 1_000_000_000) // hold 1.0s
+            guard !Task.isCancelled else { return }
+            self.dismiss()
+        }
+    }
+
+    private func dismiss() {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            panel.animator().alphaValue = 0
+        } completionHandler: { [panel] in
+            panel.orderOut(nil)
+        }
+    }
+
+    /// Bottom-center of the screen containing the mouse cursor (fallback: main screen),
+    /// clear of the Dock.
+    private func positionPanel(size: NSSize) {
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+        guard let visible = screen?.visibleFrame else { return }
+        let originX = visible.midX - size.width / 2
+        let originY = visible.minY + 120
+        panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+    }
+}
+
+/// Borderless panel that never takes focus — the toast is purely informational.
+private final class ToastPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/Sources/AnyDoor/Views/ToastView.swift
+++ b/Sources/AnyDoor/Views/ToastView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The status a toast reports. `Sendable` so it can cross the OCRProvider → ToastPresenter
+/// (actor → MainActor) boundary.
+enum ToastStyle: Sendable {
+    case success(String)
+    case failure(String)
+
+    var message: String {
+        switch self {
+        case .success(let text), .failure(let text): return text
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .success: return "checkmark.circle.fill"
+        case .failure: return "xmark.circle.fill"
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .success: return .green
+        case .failure: return .red
+        }
+    }
+}
+
+/// A compact status pill: an SF Symbol icon next to a single line of text.
+struct ToastView: View {
+    let style: ToastStyle
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: style.iconName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(style.iconColor)
+            Text(verbatim: style.message)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: Capsule())
+        .fixedSize()
+    }
+}

--- a/Tests/AnyDoorTests/MigrationTests.swift
+++ b/Tests/AnyDoorTests/MigrationTests.swift
@@ -40,6 +40,18 @@ final class BuiltinItemTests: XCTestCase {
         XCTAssertTrue(BuiltinItem.emptyTrash.requiresAutomation)
         XCTAssertFalse(BuiltinItem.keepAwake.requiresAutomation)
     }
+
+    func testOCRIsAnActionItem() {
+        XCTAssertEqual(BuiltinItem.ocr.kind, .action)
+    }
+
+    func testOCRMetadata() {
+        XCTAssertEqual(BuiltinItem.ocr.title, "屏幕取词")
+        XCTAssertEqual(BuiltinItem.ocr.symbol, "text.viewfinder")
+        XCTAssertEqual(BuiltinItem.ocr.defaultOrder, 950)
+        XCTAssertFalse(BuiltinItem.ocr.requiresAutomation)
+        XCTAssertNil(BuiltinItem.ocr.feedbackSound)
+    }
 }
 
 final class KeyBindingOrderBackfillTests: XCTestCase {

--- a/Tests/AnyDoorTests/PanelStoreTests.swift
+++ b/Tests/AnyDoorTests/PanelStoreTests.swift
@@ -2,6 +2,24 @@ import XCTest
 import SwiftData
 @testable import AnyDoor
 
+/// An ActionProvider whose first `run()` re-enters `PanelStore.shared.run(.ocr)`
+/// while it is itself still in-flight. The in-flight guard must drop that
+/// re-entrant call, leaving `runCount == 1`. Without the guard the re-entrant
+/// call invokes `run()` a second time and `runCount` reaches 2.
+actor ReentrantProbeProvider: ActionProvider {
+    let itemKey: BuiltinItem = .ocr
+    var permission: PermissionStatus { .notRequired }
+
+    private(set) var runCount = 0
+
+    func run() async throws {
+        runCount += 1
+        if runCount == 1 {
+            await PanelStore.shared.run(.ocr)
+        }
+    }
+}
+
 final class PanelStoreTests: XCTestCase {
 
     @MainActor
@@ -45,5 +63,23 @@ final class PanelStoreTests: XCTestCase {
         store.bootstrap(modelContainer: container, providers: [])
 
         XCTAssertEqual(store.appShortcutChildren.map(\.title), ["A", "B"])
+    }
+
+    @MainActor
+    func testRunDropsOverlappingCallForSameItem() async throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: KeyBinding.self, BuiltinPreference.self,
+            configurations: config
+        )
+        let provider = ReentrantProbeProvider()
+        let store = PanelStore.shared
+        store.bootstrap(modelContainer: container, providers: [provider])
+
+        // The provider re-enters store.run(.ocr) while its first run is in-flight.
+        await store.run(.ocr)
+
+        let count = await provider.runCount
+        XCTAssertEqual(count, 1, "a run re-entered while the same item is in-flight must be dropped")
     }
 }

--- a/Tests/AnyDoorTests/RegionCaptureTests.swift
+++ b/Tests/AnyDoorTests/RegionCaptureTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+/// `@MainActor` because the helper draws with AppKit (`NSImage.lockFocus`), which
+/// must run on the main thread.
+@MainActor
+final class RegionCaptureTests: XCTestCase {
+
+    /// Renders `text` as black text on white and writes it to `url` as a PNG.
+    private func writeTextPNG(_ text: String, to url: URL) throws {
+        let size = NSSize(width: 700, height: 180)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        text.draw(at: NSPoint(x: 40, y: 60), withAttributes: [
+            .font: NSFont.systemFont(ofSize: 64),
+            .foregroundColor: NSColor.black,
+        ])
+        image.unlockFocus()
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            throw XCTSkip("failed to encode the test PNG")
+        }
+        try png.write(to: url)
+    }
+
+    /// Reproduces the OCRProvider flow: decode a screencapture-style PNG, then delete
+    /// the file (as `RegionCapture.captureRegion` does via `defer`) before recognition.
+    /// The decoded CGImage must not lazily depend on the now-deleted file.
+    func testDecodedImageSurvivesSourceFileDeletion() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anydoor-ocr-test-\(UUID().uuidString).png")
+        try writeTextPNG("Persisted", to: url)
+
+        let decoded = try XCTUnwrap(RegionCapture.decodeImage(at: url))
+        try FileManager.default.removeItem(at: url)
+
+        let lines = try await TextRecognizer.recognize(decoded)
+        XCTAssertTrue(lines.joined().contains("Persisted"),
+                      "recognition must work after the source file is deleted; got: \(lines)")
+    }
+}

--- a/Tests/AnyDoorTests/ShellRunnerTests.swift
+++ b/Tests/AnyDoorTests/ShellRunnerTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import AnyDoor
+
+final class ShellRunnerTests: XCTestCase {
+
+    /// An explicit short timeout still terminates a long-running process.
+    func testExplicitTimeoutKillsLongProcess() async {
+        do {
+            _ = try await ShellRunner.run("/bin/sleep", args: ["2"], timeout: 0.3)
+            XCTFail("expected the watchdog to terminate the process")
+        } catch BuiltinError.shellFailed(_, let output) {
+            XCTAssertTrue(output.contains("timeout"), "got: \(output)")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    /// A nil timeout disables the watchdog: the same 1s process that an explicit
+    /// 0.3s timeout would kill now runs to completion.
+    func testNilTimeoutDoesNotKillProcess() async throws {
+        let start = Date()
+        _ = try await ShellRunner.run("/bin/sleep", args: ["1"], timeout: nil)
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertGreaterThan(elapsed, 0.8, "process should have run for ~1s, not been killed early")
+    }
+}

--- a/Tests/AnyDoorTests/TextRecognizerTests.swift
+++ b/Tests/AnyDoorTests/TextRecognizerTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+/// `@MainActor` because the helper draws with AppKit (`NSImage.lockFocus`), which
+/// must run on the main thread.
+@MainActor
+final class TextRecognizerTests: XCTestCase {
+
+    /// Renders each string as a separate line of black system-font text on white,
+    /// first element at the top. Returns the rasterized CGImage.
+    private func renderImage(lines: [String]) throws -> CGImage {
+        let width: CGFloat = 800
+        let lineHeight: CGFloat = 100
+        let height = max(lineHeight, lineHeight * CGFloat(lines.count)) + 40
+        let size = NSSize(width: width, height: height)
+
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 56),
+            .foregroundColor: NSColor.black,
+        ]
+        // AppKit's origin is bottom-left; draw the first line near the top.
+        for (index, line) in lines.enumerated() {
+            let y = height - 40 - lineHeight * CGFloat(index) - 60
+            line.draw(at: NSPoint(x: 40, y: y), withAttributes: attrs)
+        }
+        image.unlockFocus()
+
+        var rect = NSRect(origin: .zero, size: size)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+            throw XCTSkip("failed to rasterize the test image")
+        }
+        return cgImage
+    }
+
+    func testRecognizesEnglishText() async throws {
+        let image = try renderImage(lines: ["Hello World"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("Hello"), "got: \(joined)")
+        XCTAssertTrue(joined.contains("World"), "got: \(joined)")
+    }
+
+    func testRecognizesChineseText() async throws {
+        let image = try renderImage(lines: ["你好世界"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined()
+        XCTAssertTrue(joined.contains("你好"), "got: \(joined)")
+    }
+
+    func testReturnsLinesTopToBottom() async throws {
+        let image = try renderImage(lines: ["Sunrise", "Mountain"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined(separator: "\n")
+        guard let sunrise = joined.range(of: "Sunrise"),
+              let mountain = joined.range(of: "Mountain") else {
+            XCTFail("both lines should be recognized; got: \(joined)")
+            return
+        }
+        XCTAssertLessThan(sunrise.lowerBound, mountain.lowerBound,
+                          "Sunrise (top) should precede Mountain (bottom); got: \(joined)")
+    }
+
+    func testBlankImageReturnsEmpty() async throws {
+        let image = try renderImage(lines: [])
+        let result = try await TextRecognizer.recognize(image)
+        XCTAssertEqual(result, [])
+    }
+}

--- a/docs/superpowers/plans/2026-05-22-ocr-screen-text.md
+++ b/docs/superpowers/plans/2026-05-22-ocr-screen-text.md
@@ -1,0 +1,937 @@
+# OCR Screen Text Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an OCR action to AnyDoor that captures a screen region, recognizes its text with the macOS Vision framework, copies the text to the clipboard, and shows a transient bottom-center toast reporting success or failure.
+
+**Architecture:** A new `BuiltinItem.ocr` action wired through the existing `ActionProvider` / `PanelStore` infrastructure. `OCRProvider` (an `actor`) orchestrates three isolated units — `RegionCapture` (native `screencapture` wrapper), `TextRecognizer` (Vision wrapper), and `ToastPresenter` (a `@MainActor` toast-window singleton). Two existing files are hardened along the way: `ShellRunner` gains an optional/`nil` timeout for interactive subprocesses, and `PanelStore.run` gains a per-item in-flight guard.
+
+**Tech Stack:** Swift 6.2 (strict concurrency, language mode v6), macOS 26, SwiftUI + AppKit, Vision framework (`RecognizeTextRequest`), SPM, XCTest.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+- `Sources/AnyDoor/Services/TextRecognizer.swift` — Vision text-recognition wrapper. Pure, UI-free, shell-free.
+- `Sources/AnyDoor/Services/RegionCapture.swift` — interactive `screencapture` wrapper + `OCRError` enum. Owns the temp-file lifecycle.
+- `Sources/AnyDoor/Services/Providers/OCRProvider.swift` — `ActionProvider` orchestrating capture → recognize → clipboard → toast.
+- `Sources/AnyDoor/Views/ToastView.swift` — SwiftUI toast content + `ToastStyle` enum.
+- `Sources/AnyDoor/Views/ToastPresenter.swift` — `@MainActor` singleton owning the toast `NSPanel`.
+- `Tests/AnyDoorTests/ShellRunnerTests.swift` — timeout-behavior tests.
+- `Tests/AnyDoorTests/TextRecognizerTests.swift` — recognition tests with programmatically rendered images.
+
+**Modified files:**
+
+- `Sources/AnyDoor/Services/ShellRunner.swift` — `timeout` becomes `TimeInterval?`; `nil` disables the watchdog.
+- `Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift` — pass `timeout: nil` (same interactive `screencapture`, same latent 5s-kill bug).
+- `Sources/AnyDoor/Models/BuiltinItem.swift` — add `case ocr`.
+- `Sources/AnyDoor/Services/PanelStore.swift` — add `actionsInFlight` guard to `run(_:)`.
+- `Sources/AnyDoor/AppDelegate.swift` — register `OCRProvider()`.
+- `Tests/AnyDoorTests/MigrationTests.swift` — extend `BuiltinItemTests` with `.ocr` assertions.
+- `Tests/AnyDoorTests/PanelStoreTests.swift` — add the in-flight-guard test + gated stub provider.
+
+**Test approach note:** The spec mentions a "PNG fixture under `Tests/.../Fixtures/`" for `TextRecognizer`. This plan instead renders test images programmatically (black system-font text on white) inside the test. This is a deliberate refinement — it avoids committing a binary blob, is fully reproducible, and still exercises the real Vision engine. No `Fixtures/` change is needed.
+
+---
+
+## Task 1: ShellRunner optional timeout (+ ScreenshotProvider fix)
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/ShellRunner.swift`
+- Modify: `Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift:11`
+- Test: `Tests/AnyDoorTests/ShellRunnerTests.swift` (create)
+
+`ShellRunner.run` currently always enforces a 5-second timeout. An interactive `screencapture` selection routinely exceeds 5 seconds, killing the user's selection mid-drag. Make the timeout optional; `nil` skips the watchdog.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnyDoorTests/ShellRunnerTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class ShellRunnerTests: XCTestCase {
+
+    /// An explicit short timeout still terminates a long-running process.
+    func testExplicitTimeoutKillsLongProcess() async {
+        do {
+            _ = try await ShellRunner.run("/bin/sleep", args: ["2"], timeout: 0.3)
+            XCTFail("expected the watchdog to terminate the process")
+        } catch BuiltinError.shellFailed(_, let output) {
+            XCTAssertTrue(output.contains("timeout"), "got: \(output)")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    /// A nil timeout disables the watchdog: the same 1s process that an explicit
+    /// 0.3s timeout would kill now runs to completion.
+    func testNilTimeoutDoesNotKillProcess() async throws {
+        let start = Date()
+        _ = try await ShellRunner.run("/bin/sleep", args: ["1"], timeout: nil)
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertGreaterThan(elapsed, 0.8, "process should have run for ~1s, not been killed early")
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter ShellRunnerTests`
+Expected: compile failure — `ShellRunner.run` does not accept `timeout: nil` (`timeout` is `TimeInterval`, not `TimeInterval?`).
+
+- [ ] **Step 3: Make the timeout optional in ShellRunner**
+
+In `Sources/AnyDoor/Services/ShellRunner.swift`, replace the entire `run` function body. The signature's `timeout` becomes `TimeInterval?`, and the watchdog loop only enforces a deadline when a timeout is set:
+
+```swift
+    /// Launch a binary with args. Returns combined stdout/stderr. Throws on non-zero exit
+    /// or timeout. Pass `timeout: nil` for interactive subprocesses that have no meaningful
+    /// time budget (e.g. `screencapture -i`).
+    static func run(
+        _ path: String,
+        args: [String] = [],
+        timeout: TimeInterval? = 5
+    ) async throws -> String {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: path)
+            process.arguments = args
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            try process.run()
+
+            // Timeout watchdog — only armed when a timeout is supplied.
+            let deadline = timeout.map { Date().addingTimeInterval($0) }
+            while process.isRunning {
+                if let deadline, Date() > deadline {
+                    process.terminate()
+                    let data = try? pipe.fileHandleForReading.readToEnd()
+                    let output = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                    throw BuiltinError.shellFailed(code: -1, output: "timeout: \(output)")
+                }
+                try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            }
+
+            let data = try pipe.fileHandleForReading.readToEnd() ?? Data()
+            let output = String(data: data, encoding: .utf8) ?? ""
+
+            if process.terminationStatus != 0 {
+                throw BuiltinError.shellFailed(code: process.terminationStatus, output: output)
+            }
+            return output
+        }.value
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter ShellRunnerTests`
+Expected: PASS (2 tests, ~1.3s total).
+
+- [ ] **Step 5: Fix ScreenshotProvider to use the nil timeout**
+
+In `Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift`, line 11, add `timeout: nil` to the existing call so a long screenshot selection is not killed:
+
+```swift
+            _ = try await ShellRunner.run("/usr/sbin/screencapture", args: ["-i", "-c"], timeout: nil)
+```
+
+- [ ] **Step 6: Build to verify the whole package still compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/ShellRunner.swift Sources/AnyDoor/Services/Providers/ScreenshotProvider.swift Tests/AnyDoorTests/ShellRunnerTests.swift
+git commit -m "fix(shell): support nil timeout for interactive subprocesses
+
+ShellRunner always enforced a 5s watchdog, which kills an interactive
+screencapture selection mid-drag. Make the timeout optional; nil disables
+the watchdog. Apply it to ScreenshotProvider, which has the same bug."
+```
+
+---
+
+## Task 2: Add the `BuiltinItem.ocr` case
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/BuiltinItem.swift`
+- Test: `Tests/AnyDoorTests/MigrationTests.swift` (extend `BuiltinItemTests`)
+
+- [ ] **Step 1: Write the failing test**
+
+In `Tests/AnyDoorTests/MigrationTests.swift`, add these methods inside the existing `final class BuiltinItemTests: XCTestCase` block:
+
+```swift
+    func testOCRIsAnActionItem() {
+        XCTAssertEqual(BuiltinItem.ocr.kind, .action)
+    }
+
+    func testOCRMetadata() {
+        XCTAssertEqual(BuiltinItem.ocr.title, "屏幕取词")
+        XCTAssertEqual(BuiltinItem.ocr.symbol, "text.viewfinder")
+        XCTAssertEqual(BuiltinItem.ocr.defaultOrder, 950)
+        XCTAssertFalse(BuiltinItem.ocr.requiresAutomation)
+        XCTAssertNil(BuiltinItem.ocr.feedbackSound)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter BuiltinItemTests`
+Expected: compile failure — `BuiltinItem` has no member `ocr`.
+
+- [ ] **Step 3: Add the enum case**
+
+In `Sources/AnyDoor/Models/BuiltinItem.swift`, add `case ocr` immediately after `case screenshot`:
+
+```swift
+    case screenshot
+    case ocr
+    case displaySleep
+```
+
+- [ ] **Step 4: Add `.ocr` to the `kind` switch**
+
+In the `kind` computed property, add `.ocr` to the `.action` group:
+
+```swift
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .displaySleep, .systemSleep,
+             .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+```
+
+- [ ] **Step 5: Add `.ocr` to the `title` switch**
+
+In the `title` computed property, add a case after `case .screenshot:`:
+
+```swift
+        case .screenshot: return "截图到剪贴板"
+        case .ocr: return "屏幕取词"
+```
+
+- [ ] **Step 6: Add `.ocr` to the `symbol` switch**
+
+In the `symbol` computed property, add a case after `case .screenshot:`:
+
+```swift
+        case .screenshot: return "camera.viewfinder"
+        case .ocr: return "text.viewfinder"
+```
+
+- [ ] **Step 7: Add `.ocr` to the `defaultOrder` switch**
+
+In the `defaultOrder` computed property, add a case after `case .screenshot: return 900`:
+
+```swift
+        case .screenshot: return 900
+        case .ocr: return 950
+```
+
+`requiresAutomation` and `feedbackSound` both have a `default` arm, so `.ocr` needs no entry there.
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `swift test --filter BuiltinItemTests`
+Expected: PASS. `testAllCasesHaveDistinctOrder` still passes (950 is unique).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/BuiltinItem.swift Tests/AnyDoorTests/MigrationTests.swift
+git commit -m "feat(builtin): add ocr action item"
+```
+
+---
+
+## Task 3: Add the action in-flight guard to PanelStore
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift`
+- Test: `Tests/AnyDoorTests/PanelStoreTests.swift`
+
+`PanelStore.run(_:)` has no overlap guard. An `actor` provider yields its executor at every `await`, so two hotkey presses can interleave two OCR runs that race the clipboard. Add a per-item guard mirroring the existing `togglesInFlight`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `Tests/AnyDoorTests/PanelStoreTests.swift`, add a gated stub provider and a test. Add the stub at file scope (after the imports, before or after the existing class):
+
+```swift
+/// An ActionProvider whose `run()` blocks until `unblock()` is called, and which
+/// signals (via an AsyncStream) the moment its body starts executing. Used to hold
+/// one run in-flight while a second overlapping run is attempted.
+actor GatedActionProvider: ActionProvider {
+    let itemKey: BuiltinItem
+    var permission: PermissionStatus { .notRequired }
+
+    private(set) var runCount = 0
+    private let startStream: AsyncStream<Void>
+    private let startContinuation: AsyncStream<Void>.Continuation
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(itemKey: BuiltinItem) {
+        self.itemKey = itemKey
+        (startStream, startContinuation) = AsyncStream.makeStream(of: Void.self)
+    }
+
+    func run() async throws {
+        runCount += 1
+        startContinuation.yield(())
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.releaseContinuation = continuation
+        }
+    }
+
+    /// Suspends until `run()` has started executing at least once.
+    func waitForStart() async {
+        for await _ in startStream { return }
+    }
+
+    /// Lets the currently-suspended `run()` return.
+    func unblock() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+```
+
+Add this test method inside `final class PanelStoreTests: XCTestCase`:
+
+```swift
+    @MainActor
+    func testRunDropsOverlappingCallForSameItem() async throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: KeyBinding.self, BuiltinPreference.self,
+            configurations: config
+        )
+        let provider = GatedActionProvider(itemKey: .ocr)
+        let store = PanelStore.shared
+        store.bootstrap(modelContainer: container, providers: [provider])
+
+        // First run: enters run(), passes the guard, and suspends inside provider.run().
+        let firstRun = Task { await store.run(.ocr) }
+        await provider.waitForStart()
+
+        // Second run while the first is still in-flight — must be dropped.
+        await store.run(.ocr)
+
+        // Let the first run finish.
+        await provider.unblock()
+        await firstRun.value
+
+        let count = await provider.runCount
+        XCTAssertEqual(count, 1, "overlapping run for the same item must be dropped")
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter testRunDropsOverlappingCallForSameItem`
+Expected: FAIL — `runCount` is `2`, because `run(_:)` has no guard and the second call invokes `provider.run()` again.
+
+- [ ] **Step 3: Add the `actionsInFlight` property**
+
+In `Sources/AnyDoor/Services/PanelStore.swift`, add a property next to the existing `togglesInFlight` declaration (after the `togglesInFlight` line, around line 30):
+
+```swift
+    /// Per-item in-flight guard preventing overlapping toggles from desynchronizing state.
+    private var togglesInFlight: Set<BuiltinItem> = []
+
+    /// Per-item in-flight guard preventing overlapping action runs from racing.
+    private var actionsInFlight: Set<BuiltinItem> = []
+```
+
+- [ ] **Step 4: Guard the `run(_:)` method**
+
+In `Sources/AnyDoor/Services/PanelStore.swift`, replace the entire `run(_:)` method:
+
+```swift
+    /// Run a one-shot action.
+    ///
+    /// Guarded against overlapping calls: a second invocation for the same item while the
+    /// first is mid-flight is dropped. Actor isolation alone does not serialize runs — an
+    /// `actor` provider yields its executor at every `await`.
+    func run(_ item: BuiltinItem) async {
+        guard let provider = providers[item] as? any ActionProvider else { return }
+        guard !actionsInFlight.contains(item) else { return }
+        actionsInFlight.insert(item)
+        defer { actionsInFlight.remove(item) }
+        do {
+            try await provider.run()
+        } catch {
+            logger.error("Run \(item.rawValue) failed: \(error)")
+        }
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `swift test --filter testRunDropsOverlappingCallForSameItem`
+Expected: PASS — `runCount` is `1`.
+
+- [ ] **Step 6: Run the full PanelStore suite for regressions**
+
+Run: `swift test --filter PanelStoreTests`
+Expected: PASS (all PanelStore tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PanelStore.swift Tests/AnyDoorTests/PanelStoreTests.swift
+git commit -m "fix(panel): guard run against overlapping action invocations"
+```
+
+---
+
+## Task 4: TextRecognizer (Vision wrapper)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/TextRecognizer.swift`
+- Test: `Tests/AnyDoorTests/TextRecognizerTests.swift` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnyDoorTests/TextRecognizerTests.swift`:
+
+```swift
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+/// `@MainActor` because the helper draws with AppKit (`NSImage.lockFocus`), which
+/// must run on the main thread.
+@MainActor
+final class TextRecognizerTests: XCTestCase {
+
+    /// Renders each string as a separate line of black system-font text on white,
+    /// first element at the top. Returns the rasterized CGImage.
+    private func renderImage(lines: [String]) throws -> CGImage {
+        let width: CGFloat = 800
+        let lineHeight: CGFloat = 100
+        let height = max(lineHeight, lineHeight * CGFloat(lines.count)) + 40
+        let size = NSSize(width: width, height: height)
+
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 56),
+            .foregroundColor: NSColor.black,
+        ]
+        // AppKit's origin is bottom-left; draw the first line near the top.
+        for (index, line) in lines.enumerated() {
+            let y = height - 40 - lineHeight * CGFloat(index) - 60
+            line.draw(at: NSPoint(x: 40, y: y), withAttributes: attrs)
+        }
+        image.unlockFocus()
+
+        var rect = NSRect(origin: .zero, size: size)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+            throw XCTSkip("failed to rasterize the test image")
+        }
+        return cgImage
+    }
+
+    func testRecognizesEnglishText() async throws {
+        let image = try renderImage(lines: ["Hello World"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("Hello"), "got: \(joined)")
+        XCTAssertTrue(joined.contains("World"), "got: \(joined)")
+    }
+
+    func testRecognizesChineseText() async throws {
+        let image = try renderImage(lines: ["你好世界"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined()
+        XCTAssertTrue(joined.contains("你好"), "got: \(joined)")
+    }
+
+    func testReturnsLinesTopToBottom() async throws {
+        let image = try renderImage(lines: ["AlphaOne", "BetaTwo"])
+        let result = try await TextRecognizer.recognize(image)
+        let joined = result.joined(separator: "\n")
+        guard let alpha = joined.range(of: "AlphaOne"),
+              let beta = joined.range(of: "BetaTwo") else {
+            XCTFail("both lines should be recognized; got: \(joined)")
+            return
+        }
+        XCTAssertLessThan(alpha.lowerBound, beta.lowerBound,
+                          "AlphaOne (top) should precede BetaTwo (bottom); got: \(joined)")
+    }
+
+    func testBlankImageReturnsEmpty() async throws {
+        let image = try renderImage(lines: [])
+        let result = try await TextRecognizer.recognize(image)
+        XCTAssertEqual(result, [])
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter TextRecognizerTests`
+Expected: compile failure — no type `TextRecognizer`.
+
+- [ ] **Step 3: Implement TextRecognizer**
+
+Create `Sources/AnyDoor/Services/TextRecognizer.swift`:
+
+```swift
+import CoreGraphics
+import Foundation
+import Vision
+
+/// Recognizes text in a still image using the macOS Vision framework.
+enum TextRecognizer {
+    /// Recognizes text in `image`. Returns one string per recognized text block,
+    /// ordered top-to-bottom. An empty array means no text was found (not an error).
+    static func recognize(_ image: CGImage) async throws -> [String] {
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.automaticallyDetectsLanguage = false
+        request.recognitionLanguages = [
+            Locale.Language(identifier: "zh-Hans"),
+            Locale.Language(identifier: "en-US"),
+        ]
+
+        let observations = try await request.perform(on: image)
+
+        // Vision's normalized coordinate space has Y increasing upward, so the
+        // top-most text block has the largest topLeft.y.
+        return observations
+            .sorted { $0.topLeft.y > $1.topLeft.y }
+            .map(\.transcript)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter TextRecognizerTests`
+Expected: PASS (4 tests). If `testRecognizesChineseText` fails, confirm `recognitionLanguages` includes `zh-Hans`.
+
+- [ ] **Step 5: Build to verify the package compiles**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/TextRecognizer.swift Tests/AnyDoorTests/TextRecognizerTests.swift
+git commit -m "feat(ocr): add TextRecognizer Vision wrapper"
+```
+
+---
+
+## Task 5: RegionCapture (screencapture wrapper)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/RegionCapture.swift`
+
+This unit is interactive (it presents the native selection UI) and cannot be exercised by an automated test. It is build-verified here and manually verified in Task 9.
+
+- [ ] **Step 1: Implement RegionCapture**
+
+Create `Sources/AnyDoor/Services/RegionCapture.swift`:
+
+```swift
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Errors surfaced by the OCR capture pipeline.
+enum OCRError: Error {
+    /// screencapture produced a file but it could not be decoded into a CGImage.
+    case imageDecodeFailed
+}
+
+/// Wraps the native macOS interactive screen-selection tool (`screencapture -i -s`).
+/// Owns the temp-file lifecycle.
+enum RegionCapture {
+    /// Presents the macOS region-selection UI and returns the captured image.
+    ///
+    /// Returns `nil` when the user cancels — cancellation is detected by the
+    /// *absence* of a temp file, because `screencapture`'s cancel exit code is
+    /// undocumented and unreliable. Holding Control during selection routes the
+    /// capture to the clipboard (native behavior), which also produces no file
+    /// and is therefore treated as a cancellation.
+    ///
+    /// Throws `OCRError.imageDecodeFailed` when a file is produced but cannot be
+    /// decoded, and rethrows any process-launch failure.
+    static func captureRegion() async throws -> CGImage? {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anydoor-ocr-\(UUID().uuidString).png")
+        let tempPath = tempURL.path
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        do {
+            // -i: interactive; -s: selection-only (disables spacebar window mode).
+            // timeout nil: the user controls how long the selection takes.
+            _ = try await ShellRunner.run(
+                "/usr/sbin/screencapture",
+                args: ["-i", "-s", tempPath],
+                timeout: nil
+            )
+        } catch BuiltinError.shellFailed {
+            // Non-zero exit. screencapture's cancel exit code is undocumented,
+            // so do not treat this as a failure here — fall through to the
+            // file-presence check, which is the reliable signal.
+        }
+        // A genuine launch failure throws a non-BuiltinError and propagates.
+
+        guard FileManager.default.fileExists(atPath: tempPath) else {
+            return nil // user cancelled, or Control-routed the capture to the clipboard
+        }
+        guard let image = decodeImage(at: tempURL) else {
+            throw OCRError.imageDecodeFailed
+        }
+        return image
+    }
+
+    private static func decodeImage(at url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+        return image
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify the package compiles**
+
+Run: `swift build`
+Expected: `Build complete!` If the compiler reports `CGImage` is not `Sendable` at the `captureRegion` return, that is unexpected on the macOS 26 SDK (`CGImage` is `Sendable` there) — stop and report rather than adding a workaround.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/RegionCapture.swift
+git commit -m "feat(ocr): add RegionCapture screencapture wrapper"
+```
+
+---
+
+## Task 6: ToastStyle + ToastView
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/ToastView.swift`
+
+- [ ] **Step 1: Implement ToastStyle and ToastView**
+
+Create `Sources/AnyDoor/Views/ToastView.swift`:
+
+```swift
+import SwiftUI
+
+/// The status a toast reports. `Sendable` so it can cross the OCRProvider → ToastPresenter
+/// (actor → MainActor) boundary.
+enum ToastStyle: Sendable {
+    case success(String)
+    case failure(String)
+
+    var message: String {
+        switch self {
+        case .success(let text), .failure(let text): return text
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .success: return "checkmark.circle.fill"
+        case .failure: return "xmark.circle.fill"
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .success: return .green
+        case .failure: return .red
+        }
+    }
+}
+
+/// A compact status pill: an SF Symbol icon next to a single line of text.
+struct ToastView: View {
+    let style: ToastStyle
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: style.iconName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(style.iconColor)
+            Text(verbatim: style.message)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: Capsule())
+        .fixedSize()
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify the package compiles**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/ToastView.swift
+git commit -m "feat(ocr): add ToastView and ToastStyle"
+```
+
+---
+
+## Task 7: ToastPresenter (toast window)
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/ToastPresenter.swift`
+
+- [ ] **Step 1: Implement ToastPresenter**
+
+Create `Sources/AnyDoor/Views/ToastPresenter.swift`:
+
+```swift
+import AppKit
+import SwiftUI
+
+/// Owns a single borderless toast window shown at the bottom-center of the screen.
+/// `show(_:)` is the only public entry point; the toast auto-dismisses after ~1s.
+@MainActor
+final class ToastPresenter {
+    static let shared = ToastPresenter()
+
+    private let panel: ToastPanel
+    private let hostingController: NSHostingController<ToastView>
+    private var dismissTask: Task<Void, Never>?
+
+    private init() {
+        let controller = NSHostingController(rootView: ToastView(style: .success("")))
+        controller.sizingOptions = [.preferredContentSize]
+        self.hostingController = controller
+
+        let panel = ToastPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 44),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.level = .statusBar
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.hidesOnDeactivate = false
+        panel.contentViewController = controller
+        self.panel = panel
+    }
+
+    /// Show a toast. A new call replaces the current toast in place and resets the timer.
+    func show(_ style: ToastStyle) {
+        dismissTask?.cancel()
+
+        hostingController.rootView = ToastView(style: style)
+        hostingController.view.layoutSubtreeIfNeeded()
+        let size = hostingController.view.fittingSize
+        if size.width > 0 && size.height > 0 {
+            panel.setContentSize(size)
+        }
+        positionPanel(size: panel.frame.size)
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            panel.animator().alphaValue = 1
+        }
+
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 1_000_000_000) // hold 1.0s
+            guard !Task.isCancelled else { return }
+            self.dismiss()
+        }
+    }
+
+    private func dismiss() {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            panel.animator().alphaValue = 0
+        } completionHandler: { [panel] in
+            panel.orderOut(nil)
+        }
+    }
+
+    /// Bottom-center of the screen containing the mouse cursor (fallback: main screen),
+    /// clear of the Dock.
+    private func positionPanel(size: NSSize) {
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+        guard let visible = screen?.visibleFrame else { return }
+        let originX = visible.midX - size.width / 2
+        let originY = visible.minY + 120
+        panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+    }
+}
+
+/// Borderless panel that never takes focus — the toast is purely informational.
+private final class ToastPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+```
+
+- [ ] **Step 2: Build to verify the package compiles**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/ToastPresenter.swift
+git commit -m "feat(ocr): add ToastPresenter toast window"
+```
+
+---
+
+## Task 8: OCRProvider (orchestration)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Providers/OCRProvider.swift`
+
+- [ ] **Step 1: Implement OCRProvider**
+
+Create `Sources/AnyDoor/Services/Providers/OCRProvider.swift`:
+
+```swift
+import AppKit
+import Foundation
+
+/// Captures a screen region, recognizes its text with Vision, copies the text to
+/// the clipboard, and shows a bottom-center toast reporting the outcome.
+///
+/// Every error is absorbed and mapped to a toast — `run()` never propagates.
+actor OCRProvider: ActionProvider {
+    let itemKey: BuiltinItem = .ocr
+
+    var permission: PermissionStatus { .notRequired }
+
+    func run() async {
+        do {
+            guard let image = try await RegionCapture.captureRegion() else {
+                return // user cancelled — silent, no toast
+            }
+            let lines = try await TextRecognizer.recognize(image)
+            guard !lines.isEmpty else {
+                await ToastPresenter.shared.show(.failure("未识别到文字"))
+                return
+            }
+            let text = lines.joined(separator: "\n")
+            await MainActor.run {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
+            }
+            await ToastPresenter.shared.show(.success("已复制到剪贴板"))
+        } catch {
+            await ToastPresenter.shared.show(.failure("识别失败"))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify the package compiles**
+
+Run: `swift build`
+Expected: `Build complete!` `OCRProvider.run()` is non-throwing; it satisfies the `ActionProvider` requirement `func run() async throws` (a non-throwing body satisfies a throwing requirement).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Providers/OCRProvider.swift
+git commit -m "feat(ocr): add OCRProvider orchestrating capture, recognition, and toast"
+```
+
+---
+
+## Task 9: Wire OCRProvider into AppDelegate + full verification
+
+**Files:**
+- Modify: `Sources/AnyDoor/AppDelegate.swift`
+
+- [ ] **Step 1: Register the provider**
+
+In `Sources/AnyDoor/AppDelegate.swift`, add `OCRProvider()` to the `providers` array. It is the last entry, after `KeyboardLockProvider()`:
+
+```swift
+            FlushDNSProvider(),
+            KeyboardLockProvider(),
+            OCRProvider(),
+        ]
+```
+
+- [ ] **Step 2: Build the whole package**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `swift test`
+Expected: all tests pass — `ShellRunnerTests`, `TextRecognizerTests`, `BuiltinItemTests` (with the new `.ocr` cases), `PanelStoreTests` (with `testRunDropsOverlappingCallForSameItem`), and every pre-existing test.
+
+- [ ] **Step 4: Manual verification — happy path**
+
+Run: `swift run AnyDoor`
+
+Then, in the running app:
+1. Grant Accessibility permission if prompted (System Settings → Privacy & Security → Accessibility).
+2. Open the menu bar panel — confirm a "屏幕取词" row appears (an action row with the `text.viewfinder` icon). On an existing install it is at the bottom of the panel; on a fresh data store it is just after "截图到剪贴板".
+3. Click the "屏幕取词" row. The native selection crosshair appears.
+4. Drag a rectangle over some on-screen text (mix Chinese + English if possible).
+5. Confirm: a green-check toast "已复制到剪贴板" appears at the bottom-center of the screen and fades out after ~1 second.
+6. Paste (⌘V) into any text field and confirm the recognized text matches the selected region, with line breaks between blocks.
+
+- [ ] **Step 5: Manual verification — edge cases**
+
+1. **Cancel:** Trigger "屏幕取词", then press Esc. Confirm nothing happens — no toast, clipboard unchanged.
+2. **No text:** Trigger "屏幕取词" and select a blank area (e.g. empty desktop). Confirm a red-x toast "未识别到文字" appears and the clipboard is unchanged.
+3. **Slow selection:** Trigger "屏幕取词" and wait more than 5 seconds before completing the drag. Confirm the selection is NOT cancelled (the ShellRunner watchdog no longer fires).
+4. **Hotkey:** Open Settings → 面板 tab, record a hotkey for "屏幕取词", close Settings, and trigger that hotkey. Confirm the selection UI appears and the flow works.
+5. **Rapid double-trigger:** Press the OCR hotkey twice in quick succession. Confirm only one selection crosshair appears (the in-flight guard drops the second).
+6. **Screenshot regression:** Trigger the existing "截图到剪贴板" action and confirm it still works, including a selection that takes more than 5 seconds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(ocr): register OCRProvider in the provider registry"
+```
+
+---
+
+## Self-Review Checklist (completed during plan authoring)
+
+- **Spec coverage:** capture (`RegionCapture`, Task 5), recognition (`TextRecognizer`, Task 4), clipboard write + toast (`OCRProvider`, Task 8), toast window (`ToastPresenter`/`ToastView`, Tasks 6-7), `BuiltinItem.ocr` (Task 2), provider registration (Task 9), `ShellRunner` optional timeout + `ScreenshotProvider` fix (Task 1), `PanelStore.run` in-flight guard (Task 3). All spec sections map to a task.
+- **Panel ordering:** the spec's "no migration; existing installs append at end" decision needs no code — `BuiltinPreferenceSeeder` already does this. Covered by the manual check in Task 9 Step 4.
+- **Type consistency:** `recognize(_ image: CGImage) async throws -> [String]`, `captureRegion() async throws -> CGImage?`, `ToastStyle` (`.success`/`.failure` with `String`), `ToastPresenter.shared.show(_:)`, `OCRError.imageDecodeFailed` — names are identical across all tasks that reference them.
+- **No placeholders:** every step contains complete code or an exact command.

--- a/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
+++ b/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
@@ -55,7 +55,7 @@ global hotkey from the panel settings exactly like any other action item
 | Cancellation (Esc) | Detected by **temp-file absence** after the command, not by exit code. Silent no-op — no toast, clipboard untouched |
 | Control modifier during capture | If the user holds Control while selecting, `screencapture` writes the capture to the clipboard instead of the file (native, non-suppressible behavior). No file is produced, so OCR treats it as a cancellation (silent). Accepted edge case |
 | OCR engine | Vision framework, modern Swift API `RecognizeTextRequest` |
-| Recognition languages | Explicit `recognitionLanguages = [Locale.Language("zh-Hans"), Locale.Language("en-US")]`; `automaticallyDetectsLanguage = false`; `recognitionLevel = .accurate` |
+| Recognition languages | Explicit `recognitionLanguages = [Locale.Language(identifier: "zh-Hans"), Locale.Language(identifier: "en-US")]`; `automaticallyDetectsLanguage = false`; `recognitionLevel = .accurate` |
 | Multi-line handling | One string per recognized observation, joined top-to-bottom with `\n` |
 | Empty result | Failure toast "未识别到文字"; clipboard untouched |
 | Concurrency guard | `PanelStore.run(_:)` gains a per-item in-flight guard (mirroring the existing `toggle` guard) so a re-trigger while OCR is mid-flight is dropped |
@@ -69,7 +69,7 @@ global hotkey from the panel settings exactly like any other action item
 
 ## Architecture
 
-Five new units plus small edits to four existing files. Each new unit has a
+Five new units plus small edits to five existing files. Each new unit has a
 single responsibility and a narrow interface.
 
 ```
@@ -119,6 +119,9 @@ Sources/AnyDoor/
 - `AppDelegate.swift` — register `OCRProvider()` in the `providers` array.
 - `Services/ShellRunner.swift` — make the timeout optional so an interactive
   subprocess can run without the watchdog (see ShellRunner change below).
+- `Services/Providers/ScreenshotProvider.swift` — pass `timeout: nil` to its
+  `ShellRunner.run` call; it runs the same interactive `screencapture -i` and
+  carries the identical latent 5-second-kill bug (see ShellRunner change).
 - `Services/PanelStore.swift` — add a per-item in-flight guard to `run(_:)`
   (see Action In-Flight Guard below).
 - `BuiltinPreferenceSeeder` — no code change required; it iterates
@@ -154,14 +157,25 @@ static func run(_ path: String, args: [String] = [],
 ```
 
 When `timeout` is `nil`, the watchdog loop is skipped and the runner simply
-waits for the process to exit. All existing call sites are unaffected (the
-`5` default is unchanged). `RegionCapture` passes `timeout: nil`.
+waits for the process to exit. The `5` default is unchanged, so call sites
+that pass nothing keep compiling and keep their current behavior.
+
+Two interactive callers should run without the watchdog:
+
+- `RegionCapture` (new) passes `timeout: nil`.
+- `ScreenshotProvider` (existing) runs `screencapture -i -c` and today carries
+  the same latent bug — a screenshot selection lasting longer than 5 seconds
+  is killed mid-drag. Since this round already establishes that interactive
+  `screencapture` has no meaningful timeout, fix it in the same pass: change
+  its `ShellRunner.run` call to pass `timeout: nil`. This is a one-line,
+  in-scope fix that removes the inconsistency rather than leaving known debt.
 
 ## Component Details
 
 ### `TextRecognizer`
 
-Pure, UI-free, shell-free. The only unit with an automated test.
+Pure, UI-free, shell-free — the only new OCR *service* with a fixture-backed
+automated test (see Testing for the full automated-test set).
 
 ```
 enum TextRecognizer {
@@ -398,6 +412,9 @@ All cases are handled inside `OCRProvider.run()`; nothing propagates out.
   OCR action and the assigned hotkey, and confirming: clipboard contents,
   toast appearance/position/timing, a >5s selection is not killed, and a
   rapid double-trigger starts only one capture.
+- **`ScreenshotProvider` regression**: manually confirm the existing
+  "截图到剪贴板" action still works and a >5s screenshot selection is no longer
+  killed after the `timeout: nil` change.
 
 ## Open Questions
 

--- a/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
+++ b/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
@@ -1,0 +1,296 @@
+# OCR Screen Text — Design
+
+**Date**: 2026-05-22
+**Status**: Approved (design phase)
+**Author**: Brainstorming session
+
+## Summary
+
+Add an OCR action to the AnyDoor panel. When triggered, the user drags a
+selection rectangle over any part of the screen (the native macOS region
+selection UI). The selected region is recognized with the built-in Vision
+text recognition engine, the recognized text is written to the system
+clipboard, and a small transient toast at the bottom-center of the screen
+reports success or failure. The toast auto-dismisses after ~1 second.
+
+The feature reuses the existing `BuiltinItem` / `ActionProvider`
+infrastructure, so the OCR entry can be reordered, hidden, and assigned a
+global hotkey from the panel settings exactly like any other action item
+(e.g. "截图到剪贴板").
+
+## Goals
+
+- Trigger via the panel row or an assignable global hotkey.
+- Capture an arbitrary screen region using the native macOS selection UI.
+- Recognize text with the macOS Vision framework (no third-party engine).
+- Recognize mixed Chinese + English automatically.
+- Write the recognized text to `NSPasteboard.general`.
+- Show a non-interactive toast at the bottom-center of the screen reporting
+  success or failure, auto-dismissing after ~1 second.
+- Provide a reusable `ToastPresenter` UI primitive that other features can
+  use later.
+
+## Non-Goals
+
+- No full-screen OCR and no OCR of a pre-existing clipboard image; region
+  selection is the only input source in this iteration.
+- No custom selection overlay (ScreenCaptureKit); the native `screencapture`
+  tool is used.
+- No translation, no text post-processing beyond joining recognized lines.
+- No user-configurable recognition languages or recognition level; both are
+  fixed (see Clarifications). Configurability is deferred.
+- No toast queue / stacking; a new toast replaces the current one.
+- No history of past recognitions.
+- No preview of the recognized text inside the toast; the toast shows status
+  only.
+
+## Clarifications Captured
+
+| Topic | Decision |
+|-------|----------|
+| Input source | Interactive region selection via `screencapture -i` |
+| Capture mechanism | `screencapture -i <tempfile>` to a temp PNG, decoded to `CGImage`, temp file deleted afterward |
+| Cancellation (Esc) | Silent no-op — no toast, clipboard untouched |
+| OCR engine | Vision framework, modern Swift API `RecognizeTextRequest` |
+| Recognition languages | Automatic, `["zh-Hans", "en-US"]`; `.accurate` recognition level |
+| Multi-line handling | One string per recognized observation, joined top-to-bottom with `\n` |
+| Empty result | Failure toast "未识别到文字"; clipboard untouched |
+| Toast content | Status only (icon + text); no recognized-text preview |
+| Toast position | Bottom-center of the screen containing the mouse cursor |
+| Toast lifetime | Fade-in 0.15s → hold 1.0s → fade-out 0.2s |
+| Re-trigger | New toast replaces the current one (cancel pending dismiss, reset timer) |
+| Permission | `OCRProvider.permission = .notRequired` |
+| Menu integration | New `BuiltinItem.ocr` with `kind = .action` |
+
+## Architecture
+
+Five new units plus small edits to three existing files. Each new unit has a
+single responsibility and a narrow interface.
+
+```
+                 hotkey / panel row
+                        │
+                        ▼
+        ┌───────────────────────────────┐
+        │  OCRProvider (actor)          │   ActionProvider
+        │  run():                       │
+        │   1. RegionCapture.capture()  │──► CGImage? (nil = cancelled)
+        │   2. TextRecognizer.recognize │──► [String]
+        │   3. NSPasteboard write       │
+        │   4. ToastPresenter.show()    │
+        └───────────────────────────────┘
+                        │ await (MainActor hop)
+                        ▼
+        ┌───────────────────────────────┐
+        │  ToastPresenter (@MainActor)  │  owns one NSPanel
+        │  show(ToastStyle)             │  hosts ToastView
+        └───────────────────────────────┘
+```
+
+### New files
+
+```
+Sources/AnyDoor/
+├── Services/
+│   ├── TextRecognizer.swift      # Vision wrapper, pure, testable
+│   ├── RegionCapture.swift       # screencapture -i wrapper
+│   └── Providers/
+│       └── OCRProvider.swift     # ActionProvider orchestrating the flow
+└── Views/
+    ├── ToastPresenter.swift      # @MainActor singleton, owns the toast NSPanel
+    └── ToastView.swift           # SwiftUI content (icon + text + material)
+```
+
+### Modified files
+
+- `Models/BuiltinItem.swift` — add `case ocr`:
+  - `kind = .action`
+  - `title = "屏幕取词"`
+  - `symbol = "text.viewfinder"`
+  - `defaultOrder = 950` (just after `.screenshot` at 900)
+  - `requiresAutomation = false`
+  - `feedbackSound = nil`
+- `AppDelegate.swift` — register `OCRProvider()` in the `providers` array.
+- `BuiltinPreferenceSeeder` — no code change required; it iterates
+  `BuiltinItem.allCases`, so the new case is seeded automatically.
+
+## Component Details
+
+### `TextRecognizer`
+
+Pure, UI-free, shell-free. The only unit with an automated test.
+
+```
+enum TextRecognizer {
+    static func recognize(_ image: CGImage) async throws -> [String]
+}
+```
+
+- Uses Vision's modern Swift API `RecognizeTextRequest`.
+- `recognitionLevel = .accurate`.
+- Recognition languages fixed to `["zh-Hans", "en-US"]`.
+- Returns the top candidate string of each observation, ordered
+  top-to-bottom (sorted by observation bounding-box origin Y, descending in
+  Vision's normalized coordinate space).
+- Throws on a Vision engine error. An empty result is `[]`, not an error.
+
+> Note: the exact `RecognizeTextRequest` API surface (property names,
+> `perform(on:)` signature, observation accessor) is verified against the
+> current macOS 26 SDK during implementation; the contract above is the
+> stable part.
+
+### `RegionCapture`
+
+Wraps the native selection tool. Owns the temp-file lifecycle.
+
+```
+enum RegionCapture {
+    /// Returns nil when the user cancels the selection.
+    static func captureRegion() async throws -> CGImage?
+}
+```
+
+- Builds a unique temp path under `FileManager.default.temporaryDirectory`.
+- Runs `/usr/sbin/screencapture` with `["-i", <tempPath>]` via `ShellRunner`.
+- Cancellation detection: if `ShellRunner` throws `BuiltinError.shellFailed`,
+  **or** the temp file does not exist after the command returns, treat it as
+  cancellation and return `nil`.
+- If the temp file exists but cannot be decoded to a `CGImage`, throw an
+  error (surfaces as a failure toast).
+- Always deletes the temp file before returning (`defer`).
+
+### `OCRProvider`
+
+`actor` conforming to `ActionProvider`. Orchestrates and absorbs all errors.
+
+```
+actor OCRProvider: ActionProvider {
+    let itemKey: BuiltinItem = .ocr
+    var permission: PermissionStatus { .notRequired }
+    func run() async
+}
+```
+
+`run()` sequence (the whole body is wrapped in `do` / `catch`):
+
+1. `let image = try await RegionCapture.captureRegion()`
+   - `RegionCapture` returns `nil` only for cancellation → return silently.
+   - A thrown error (e.g. image decode failure) is caught by the outer
+     `catch` → failure toast "识别失败".
+2. `let lines = try await TextRecognizer.recognize(image)`
+   - a thrown error is caught by the outer `catch` → failure toast "识别失败".
+3. `lines.isEmpty` → failure toast "未识别到文字", return (clipboard untouched).
+4. Join `lines` with `\n`, write to `NSPasteboard.general` (clear then set
+   `.string`), then success toast "已复制到剪贴板".
+
+Cancellation must be distinguishable from failure: `RegionCapture` signals
+cancellation with a `nil` return value and signals every real fault by
+throwing, so the `nil` check and the `catch` block never overlap.
+
+`run()` catches every error internally and maps it to a toast; it never
+propagates an error out. The clipboard write and every `ToastPresenter` call
+hop to `@MainActor` via `await`.
+
+> `ActionProvider.run()` is currently `func run() async throws`. `OCRProvider`
+> implements it without ever throwing (a non-throwing body satisfies a
+> `throws` requirement). No protocol change needed.
+
+### `ToastPresenter`
+
+`@MainActor` `final class`, singleton (`ToastPresenter.shared`). Sole owner of
+the toast window.
+
+```
+enum ToastStyle: Sendable {
+    case success(String)
+    case failure(String)
+}
+
+@MainActor
+final class ToastPresenter {
+    static let shared: ToastPresenter
+    func show(_ style: ToastStyle)
+}
+```
+
+Window:
+
+- `NSPanel`, style mask `[.borderless, .nonactivatingPanel]`.
+- `isOpaque = false`, `backgroundColor = .clear`, `hasShadow = true`.
+- `ignoresMouseEvents = true` (click-through, non-interactive).
+- `canBecomeKey = false`, `canBecomeMain = false` (never steals focus).
+- `level = .statusBar`.
+- `collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]`
+  so it appears above full-screen apps and on every Space.
+- Content hosted by an `NSHostingController<ToastView>`; the panel is sized to
+  the view's `fittingSize` on each `show`.
+
+Positioning:
+
+- Target screen = the `NSScreen` whose `frame` contains `NSEvent.mouseLocation`,
+  falling back to `NSScreen.main`.
+- Horizontally centered on the screen's `visibleFrame`.
+- Vertical origin ≈ `visibleFrame.minY + 120` (bottom-center, clear of the Dock).
+
+Lifecycle:
+
+- `show(_:)`: cancel any pending dismiss `Task`, update `ToastView` content,
+  resize + reposition the panel, `orderFrontRegardless()` (no `makeKey`),
+  animate `alphaValue` 0 → 1 over 0.15s.
+- A single cancellable `Task` then sleeps 1.0s, animates `alphaValue` 1 → 0
+  over 0.2s, and calls `orderOut(nil)`.
+- Re-trigger while a toast is visible: the new `show` cancels the pending
+  dismiss `Task`, swaps content, and restarts the timer — the new toast
+  replaces the old one in place.
+
+### `ToastView`
+
+SwiftUI view driven by `ToastStyle`.
+
+- `HStack` of an SF Symbol icon and a `Text` label.
+- Success: `checkmark.circle.fill`; failure: `xmark.circle.fill`.
+- Background: `.regularMaterial` in a `Capsule`, consistent with the macOS 26
+  visual language; comfortable padding.
+- Fixed, compact width driven by content; single line of text.
+
+## Error Handling
+
+All cases are handled inside `OCRProvider.run()`; nothing propagates out.
+
+| Situation | Behavior |
+|-----------|----------|
+| Esc cancels selection (shell non-zero **or** temp file absent) | Silent — no toast |
+| Capture succeeded but image decode failed | Failure toast "识别失败" |
+| Vision engine throws | Failure toast "识别失败" |
+| Recognition result empty | Failure toast "未识别到文字", clipboard untouched |
+| Recognition succeeded | Write clipboard + success toast "已复制到剪贴板" |
+
+## Concurrency
+
+- `OCRProvider` is an `actor`, off the main actor. `TextRecognizer.recognize`
+  is `async` and operates on `Sendable` inputs (`CGImage`), so it runs fine in
+  the actor context.
+- `ToastPresenter` is `@MainActor`; calls from `OCRProvider` cross the
+  boundary with `await`. `ToastStyle` is `Sendable`.
+- The `NSPasteboard` write is performed on `@MainActor`.
+- No CGEvent-tap interaction; the hotkey dispatch path (callback →
+  `DispatchQueue.main.async` → `PanelStore.dispatch`) is unchanged. The OCR
+  work happens well after the tap callback returns, so the ~1s tap budget is
+  not at risk.
+
+## Testing
+
+- **`TextRecognizerTests`** (automated, Swift Testing): add a PNG fixture under
+  `Tests/AnyDoorTests/Fixtures/` containing known Chinese + English text;
+  load it as a `CGImage`; assert `recognize()` returns strings containing the
+  expected substrings, in top-to-bottom order.
+- **`BuiltinItem` coverage**: extend existing/colocated tests so the new
+  `.ocr` case's `kind`, `title`, and `symbol` are asserted.
+- **`RegionCapture`, `ToastPresenter`, `OCRProvider`**: interactive /
+  windowing units — verified manually via `swift run AnyDoor`, triggering the
+  OCR action and the assigned hotkey, and confirming clipboard contents and
+  toast appearance/position/timing.
+
+## Open Questions
+
+None. All design decisions are captured above.

--- a/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
+++ b/docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md
@@ -23,7 +23,8 @@ global hotkey from the panel settings exactly like any other action item
 - Trigger via the panel row or an assignable global hotkey.
 - Capture an arbitrary screen region using the native macOS selection UI.
 - Recognize text with the macOS Vision framework (no third-party engine).
-- Recognize mixed Chinese + English automatically.
+- Recognize mixed Chinese + English text (explicit `zh-Hans` + `en-US`
+  recognition language list).
 - Write the recognized text to `NSPasteboard.general`.
 - Show a non-interactive toast at the bottom-center of the screen reporting
   success or failure, auto-dismissing after ~1 second.
@@ -48,23 +49,27 @@ global hotkey from the panel settings exactly like any other action item
 
 | Topic | Decision |
 |-------|----------|
-| Input source | Interactive region selection via `screencapture -i` |
-| Capture mechanism | `screencapture -i <tempfile>` to a temp PNG, decoded to `CGImage`, temp file deleted afterward |
-| Cancellation (Esc) | Silent no-op — no toast, clipboard untouched |
+| Input source | Interactive region selection via `screencapture -i -s` (selection-only; `-s` disables the spacebar window-capture mode) |
+| Capture mechanism | `screencapture -i -s <tempfile>` to a temp PNG, decoded to `CGImage`, temp file deleted afterward |
+| Capture timeout | None — the interactive selection runs with no watchdog; `ShellRunner` is extended to accept an optional/`nil` timeout (see ShellRunner change) |
+| Cancellation (Esc) | Detected by **temp-file absence** after the command, not by exit code. Silent no-op — no toast, clipboard untouched |
+| Control modifier during capture | If the user holds Control while selecting, `screencapture` writes the capture to the clipboard instead of the file (native, non-suppressible behavior). No file is produced, so OCR treats it as a cancellation (silent). Accepted edge case |
 | OCR engine | Vision framework, modern Swift API `RecognizeTextRequest` |
-| Recognition languages | Automatic, `["zh-Hans", "en-US"]`; `.accurate` recognition level |
+| Recognition languages | Explicit `recognitionLanguages = [Locale.Language("zh-Hans"), Locale.Language("en-US")]`; `automaticallyDetectsLanguage = false`; `recognitionLevel = .accurate` |
 | Multi-line handling | One string per recognized observation, joined top-to-bottom with `\n` |
 | Empty result | Failure toast "未识别到文字"; clipboard untouched |
+| Concurrency guard | `PanelStore.run(_:)` gains a per-item in-flight guard (mirroring the existing `toggle` guard) so a re-trigger while OCR is mid-flight is dropped |
 | Toast content | Status only (icon + text); no recognized-text preview |
 | Toast position | Bottom-center of the screen containing the mouse cursor |
 | Toast lifetime | Fade-in 0.15s → hold 1.0s → fade-out 0.2s |
 | Re-trigger | New toast replaces the current one (cancel pending dismiss, reset timer) |
 | Permission | `OCRProvider.permission = .notRequired` |
 | Menu integration | New `BuiltinItem.ocr` with `kind = .action` |
+| Panel ordering | `defaultOrder = 950` positions OCR after "截图到剪贴板" on fresh installs only. Existing installs receive the row appended at the end of the panel (the seeder's standing contract); the user can reorder it in panel settings. No migration |
 
 ## Architecture
 
-Five new units plus small edits to three existing files. Each new unit has a
+Five new units plus small edits to four existing files. Each new unit has a
 single responsibility and a narrow interface.
 
 ```
@@ -107,12 +112,50 @@ Sources/AnyDoor/
   - `kind = .action`
   - `title = "屏幕取词"`
   - `symbol = "text.viewfinder"`
-  - `defaultOrder = 950` (just after `.screenshot` at 900)
+  - `defaultOrder = 950` (positions OCR after `.screenshot` at 900 — see the
+    Panel Ordering note below)
   - `requiresAutomation = false`
   - `feedbackSound = nil`
 - `AppDelegate.swift` — register `OCRProvider()` in the `providers` array.
+- `Services/ShellRunner.swift` — make the timeout optional so an interactive
+  subprocess can run without the watchdog (see ShellRunner change below).
+- `Services/PanelStore.swift` — add a per-item in-flight guard to `run(_:)`
+  (see Action In-Flight Guard below).
 - `BuiltinPreferenceSeeder` — no code change required; it iterates
   `BuiltinItem.allCases`, so the new case is seeded automatically.
+
+### Panel Ordering (existing vs fresh installs)
+
+`BuiltinPreferenceSeeder` only applies `defaultOrder` on a **fresh install**
+(`existing.isEmpty`). For an install that already has `BuiltinPreference`
+rows, the seeder appends every new `BuiltinItem` at the end of the panel
+(`maxOrder + 100`, incrementing). Therefore:
+
+- **Fresh install** — OCR appears right after "截图到剪贴板".
+- **Existing install** — OCR appears at the bottom of the panel; the user can
+  drag it anywhere in panel settings.
+
+This matches how every previously-added built-in behaved and keeps the
+seeder's documented contract intact. No migration is written. `defaultOrder`
+is still defined because it governs the fresh-install seeding order (every
+`BuiltinItem` case must supply one). `MigrationTests` continues to assert the
+append-at-end behavior for existing installs.
+
+### ShellRunner change
+
+`ShellRunner.run` currently defaults to a 5-second timeout and `terminate()`s
+the subprocess when it elapses. An interactive `screencapture` selection
+routinely takes longer than 5 seconds, which would kill the user's selection
+mid-drag. The fix: make the parameter optional —
+
+```
+static func run(_ path: String, args: [String] = [],
+                timeout: TimeInterval? = 5) async throws -> String
+```
+
+When `timeout` is `nil`, the watchdog loop is skipped and the runner simply
+waits for the process to exit. All existing call sites are unaffected (the
+`5` default is unchanged). `RegionCapture` passes `timeout: nil`.
 
 ## Component Details
 
@@ -126,18 +169,20 @@ enum TextRecognizer {
 }
 ```
 
-- Uses Vision's modern Swift API `RecognizeTextRequest`.
-- `recognitionLevel = .accurate`.
-- Recognition languages fixed to `["zh-Hans", "en-US"]`.
-- Returns the top candidate string of each observation, ordered
-  top-to-bottom (sorted by observation bounding-box origin Y, descending in
-  Vision's normalized coordinate space).
+- Uses Vision's modern Swift API `RecognizeTextRequest` (verified against the
+  macOS 26 SDK `Vision.swiftinterface`):
+  - `recognitionLevel = .accurate`
+  - `recognitionLanguages = [Locale.Language(identifier: "zh-Hans"), Locale.Language(identifier: "en-US")]`
+    — the property is `[Foundation.Locale.Language]`, **not** `[String]`.
+  - `automaticallyDetectsLanguage = false` — keep the explicit language list
+    authoritative (the SDK default is `false`, default language `en-US`;
+    setting the list explicitly is what enables Chinese recognition).
+- Runs `try await request.perform(on: cgImage)` → `[RecognizedTextObservation]`.
+- For each observation, takes `observation.transcript` (the recognized text
+  string; available macOS 26+).
+- Orders results top-to-bottom by observation bounding-box origin Y
+  (descending — Vision's normalized coordinate space has Y increasing upward).
 - Throws on a Vision engine error. An empty result is `[]`, not an error.
-
-> Note: the exact `RecognizeTextRequest` API surface (property names,
-> `perform(on:)` signature, observation accessor) is verified against the
-> current macOS 26 SDK during implementation; the contract above is the
-> stable part.
 
 ### `RegionCapture`
 
@@ -150,14 +195,32 @@ enum RegionCapture {
 }
 ```
 
-- Builds a unique temp path under `FileManager.default.temporaryDirectory`.
-- Runs `/usr/sbin/screencapture` with `["-i", <tempPath>]` via `ShellRunner`.
-- Cancellation detection: if `ShellRunner` throws `BuiltinError.shellFailed`,
-  **or** the temp file does not exist after the command returns, treat it as
-  cancellation and return `nil`.
-- If the temp file exists but cannot be decoded to a `CGImage`, throw an
-  error (surfaces as a failure toast).
+- Builds a unique temp path with a `.png` extension under
+  `FileManager.default.temporaryDirectory`.
+- Runs `/usr/sbin/screencapture` with `["-i", "-s", <tempPath>]` via
+  `ShellRunner`, passing `timeout: nil` (no watchdog — the user controls how
+  long the selection takes).
+  - `-s` restricts the interaction to mouse selection, disabling the
+    spacebar window-capture mode.
+- Outcome classification after the command:
+
+  | Signal | Meaning | Result |
+  |--------|---------|--------|
+  | `ShellRunner` throws a process-launch error (not `BuiltinError.shellFailed`) | screencapture could not run | rethrow → failure toast |
+  | `BuiltinError.shellFailed` (non-zero exit) **and** temp file absent | user cancelled (screencapture's cancel exit code is undocumented and unreliable) | return `nil` |
+  | No throw / `shellFailed`, temp file **absent** | user cancelled, or held Control to copy to clipboard | return `nil` |
+  | Temp file **present** but undecodable to `CGImage` | corrupt/empty capture | throw `OCRError.imageDecodeFailed` → failure toast |
+  | Temp file **present** and decodable | success | return the `CGImage` |
+
+  Rationale: `screencapture`'s exit code on cancellation is not documented and
+  varies; the only reliable success signal is a decodable file. A genuine
+  *launch* failure surfaces as a non-`shellFailed` error and is escalated to a
+  failure toast. A non-zero exit with no file is indistinguishable from a
+  cancel and is therefore treated as one.
 - Always deletes the temp file before returning (`defer`).
+
+`OCRError` is a small `enum OCRError: Error { case imageDecodeFailed }`
+defined alongside `RegionCapture`.
 
 ### `OCRProvider`
 
@@ -194,6 +257,40 @@ hop to `@MainActor` via `await`.
 > `ActionProvider.run()` is currently `func run() async throws`. `OCRProvider`
 > implements it without ever throwing (a non-throwing body satisfies a
 > `throws` requirement). No protocol change needed.
+
+`OCRProvider` does **not** rely on actor isolation to prevent overlapping
+runs. An `actor` releases its executor at every `await`, so a second
+`run()` could interleave at the `RegionCapture` await and spawn a second
+`screencapture` selection, racing two OCR pipelines and clobbering the
+clipboard out of order. Overlap is prevented one level up, in
+`PanelStore.run` — see Action In-Flight Guard.
+
+### Action In-Flight Guard
+
+`PanelStore.toggle(_:)` already drops overlapping calls via a
+`togglesInFlight: Set<BuiltinItem>` guard. `PanelStore.run(_:)` has no
+equivalent, so every hotkey press / row tap spawns a fresh
+`Task { await run(item) }` with nothing to serialize them.
+
+Add a symmetric guard:
+
+```
+private var actionsInFlight: Set<BuiltinItem> = []
+
+func run(_ item: BuiltinItem) async {
+    guard let provider = providers[item] as? any ActionProvider else { return }
+    guard !actionsInFlight.contains(item) else { return }
+    actionsInFlight.insert(item)
+    defer { actionsInFlight.remove(item) }
+    do { try await provider.run() }
+    catch { logger.error("Run \(item.rawValue) failed: \(error)") }
+}
+```
+
+`run` is `@MainActor`; the `contains` check and `insert` execute
+synchronously before the first `await`, so a second `Task` entering `run`
+for the same item observes the guard and returns. This protects OCR and,
+as a side effect, hardens every other action against double-triggering.
 
 ### `ToastPresenter`
 
@@ -259,11 +356,14 @@ All cases are handled inside `OCRProvider.run()`; nothing propagates out.
 
 | Situation | Behavior |
 |-----------|----------|
-| Esc cancels selection (shell non-zero **or** temp file absent) | Silent — no toast |
-| Capture succeeded but image decode failed | Failure toast "识别失败" |
+| Esc cancels selection (no temp file produced) | Silent — no toast |
+| Control held during selection (capture goes to clipboard, no file) | Silent — no toast (treated as cancellation) |
+| `screencapture` fails to launch (non-`shellFailed` error) | Failure toast "识别失败" |
+| Temp file produced but undecodable (`OCRError.imageDecodeFailed`) | Failure toast "识别失败" |
 | Vision engine throws | Failure toast "识别失败" |
 | Recognition result empty | Failure toast "未识别到文字", clipboard untouched |
 | Recognition succeeded | Write clipboard + success toast "已复制到剪贴板" |
+| Re-trigger while OCR mid-flight | Dropped by `PanelStore.run` in-flight guard |
 
 ## Concurrency
 
@@ -273,6 +373,9 @@ All cases are handled inside `OCRProvider.run()`; nothing propagates out.
 - `ToastPresenter` is `@MainActor`; calls from `OCRProvider` cross the
   boundary with `await`. `ToastStyle` is `Sendable`.
 - The `NSPasteboard` write is performed on `@MainActor`.
+- Actor isolation does **not** serialize OCR runs (an `actor` yields at every
+  `await`). Overlap is prevented by the `PanelStore.run` in-flight guard —
+  see Action In-Flight Guard.
 - No CGEvent-tap interaction; the hotkey dispatch path (callback →
   `DispatchQueue.main.async` → `PanelStore.dispatch`) is unchanged. The OCR
   work happens well after the tap callback returns, so the ~1s tap budget is
@@ -286,10 +389,15 @@ All cases are handled inside `OCRProvider.run()`; nothing propagates out.
   expected substrings, in top-to-bottom order.
 - **`BuiltinItem` coverage**: extend existing/colocated tests so the new
   `.ocr` case's `kind`, `title`, and `symbol` are asserted.
+- **`PanelStore.run` in-flight guard** (automated, `PanelStoreTests`): a test
+  provider whose `run()` suspends on a continuation; assert a second
+  `run(.ocr)` issued while the first is suspended is dropped (the provider's
+  `run()` body executes once).
 - **`RegionCapture`, `ToastPresenter`, `OCRProvider`**: interactive /
   windowing units — verified manually via `swift run AnyDoor`, triggering the
-  OCR action and the assigned hotkey, and confirming clipboard contents and
-  toast appearance/position/timing.
+  OCR action and the assigned hotkey, and confirming: clipboard contents,
+  toast appearance/position/timing, a >5s selection is not killed, and a
+  rapid double-trigger starts only one capture.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Adds a "屏幕取词" (screen text grab) action to the AnyDoor panel: an
interactive screen-region selection is recognized with the macOS Vision
framework, the text is copied to the clipboard, and a transient
bottom-center toast reports success or failure (auto-dismiss after ~1s).
The action is a standard `BuiltinItem`, so it can be reordered, hidden,
and assigned a global hotkey like any other action.

New units, each with a single responsibility:

- `RegionCapture` — wraps `screencapture -i -s`, owns the temp-file
  lifecycle, classifies the outcome by file presence.
- `TextRecognizer` — Vision `RecognizeTextRequest` wrapper (zh-Hans +
  en-US, `.accurate`), returns text blocks ordered top-to-bottom.
- `OCRProvider` — `actor` orchestrating capture → recognition →
  clipboard → toast; absorbs every error into a toast.
- `ToastPresenter` / `ToastView` — a reusable `@MainActor` toast window.

Shared infrastructure hardened along the way:

- `ShellRunner.run` timeout is now optional; `nil` disables the watchdog
  so an interactive `screencapture` selection is not killed at 5s. The
  same latent bug in `ScreenshotProvider` is fixed in the same pass.
- `PanelStore.run` gains a per-item in-flight guard, mirroring the
  existing toggle guard, so overlapping action runs cannot race.

Design and plan: `docs/superpowers/specs/2026-05-22-ocr-screen-text-design.md`,
`docs/superpowers/plans/2026-05-22-ocr-screen-text.md`.

## Test plan

- [x] `swift test` — 59 tests pass, including: `ShellRunner` nil/explicit
      timeout behavior, `BuiltinItem.ocr` metadata, `PanelStore.run`
      in-flight guard, `TextRecognizer` recognition (English / Chinese /
      ordering), and `RegionCapture` decoded-image-survives-file-deletion.
- [x] Manual: trigger 屏幕取词, drag a region over mixed Chinese/English
      text → "已复制到剪贴板" toast, pasted text matches the selection.
- [x] Manual: Esc cancels silently; blank area → "未识别到文字"; a >5s
      selection is not killed; assigned hotkey works; rapid double-trigger
      starts only one capture; existing "截图到剪贴板" action still works.