### PR TITLE
feat: add general settings tab (launch at login + permissions)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "originHash" : "7c5fa195f2feb9fecb1185661f228180770f7642c4736f9c2e5e8804b24304d1",
+  "pins" : [
+    {
+      "identity" : "askforpermission",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/riko2chen/AskForPermission.git",
+      "state" : {
+        "revision" : "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,18 @@ import PackageDescription
 let package = Package(
     name: "AnyDoor",
     platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(
+            url: "https://github.com/riko2chen/AskForPermission.git",
+            revision: "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e"
+        ),
+    ],
     targets: [
         .executableTarget(
             name: "AnyDoor",
+            dependencies: [
+                .product(name: "AskForPermission", package: "AskForPermission"),
+            ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import SwiftData
 import OSLog
+import AskForPermission
 
 private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "persistence")
 
@@ -32,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApplication.shared.setActivationPolicy(.accessory)
+        AskForPermission.configure(appName: "AnyDoor")
 
         // Run migrations / seeding on the main context
         let context = modelContainer.mainContext

--- a/Sources/AnyDoor/Models/PanelEntry.swift
+++ b/Sources/AnyDoor/Models/PanelEntry.swift
@@ -14,7 +14,8 @@ struct HotkeyDescriptor: Hashable, Sendable {
     let keyCode: Int
     let modifierFlags: Int
 
-    var displayString: String {
+    /// Ordered key symbols (modifiers first, then the key), one element per keycap.
+    var displayParts: [String] {
         var parts: [String] = []
         let flags = NSEvent.ModifierFlags(rawValue: UInt(modifierFlags))
         if flags.contains(.control) { parts.append("⌃") }
@@ -22,7 +23,11 @@ struct HotkeyDescriptor: Hashable, Sendable {
         if flags.contains(.shift) { parts.append("⇧") }
         if flags.contains(.command) { parts.append("⌘") }
         parts.append(KeyCodeMap.name(for: keyCode))
-        return parts.joined()
+        return parts
+    }
+
+    var displayString: String {
+        displayParts.joined()
     }
 }
 

--- a/Sources/AnyDoor/Services/AutomationPermission.swift
+++ b/Sources/AnyDoor/Services/AutomationPermission.swift
@@ -1,0 +1,61 @@
+import AppKit
+import CoreServices
+
+/// Automation (Apple Events) permission for the apps AnyDoor scripts.
+///
+/// AnyDoor sends Apple Events to System Events (the dark-mode toggle). Automation
+/// is a per-target TCC permission with no "drag into list" pane, so this offers a
+/// status check plus a request that shows the standard system prompt.
+///
+/// `AEDeterminePermissionToAutomateTarget` reports `procNotFound` when the target
+/// app is not running, so `activateSystemEvents()` must run before the first
+/// status read.
+enum AutomationPermission {
+    private static let systemEventsBundleID = "com.apple.systemevents"
+    private static let systemEventsURL = URL(
+        fileURLWithPath: "/System/Library/CoreServices/System Events.app")
+
+    /// Launches System Events (faceless, non-activating) so the status check
+    /// returns a real verdict instead of `procNotFound`.
+    static func activateSystemEvents() async {
+        guard NSRunningApplication
+            .runningApplications(withBundleIdentifier: systemEventsBundleID)
+            .isEmpty
+        else { return }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = false
+        config.addsToRecentItems = false
+        _ = try? await NSWorkspace.shared.openApplication(
+            at: systemEventsURL, configuration: config)
+    }
+
+    static var isGranted: Bool {
+        determine(askUserIfNeeded: false) == noErr
+    }
+
+    /// Shows the system Automation prompt when the state is undetermined.
+    /// Blocks until the user responds — call off the main actor. Returns true
+    /// when AnyDoor ends up authorized.
+    static func request() -> Bool {
+        determine(askUserIfNeeded: true) == noErr
+    }
+
+    static func openSettings() {
+        if let url = URL(string:
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private static func determine(askUserIfNeeded: Bool) -> OSStatus {
+        var target = AEAddressDesc()
+        let bundleID = systemEventsBundleID
+        let createStatus = bundleID.withCString {
+            AECreateDesc(typeApplicationBundleID, $0, bundleID.utf8.count, &target)
+        }
+        guard createStatus == noErr else { return OSStatus(createStatus) }
+        defer { AEDisposeDesc(&target) }
+        return AEDeterminePermissionToAutomateTarget(
+            &target, typeWildCard, typeWildCard, askUserIfNeeded)
+    }
+}

--- a/Sources/AnyDoor/Services/LaunchAtLogin.swift
+++ b/Sources/AnyDoor/Services/LaunchAtLogin.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ServiceManagement
+
+/// Thin wrapper over `SMAppService.mainApp` for the launch-at-login toggle.
+///
+/// Only meaningful when AnyDoor runs as an installed `.app` bundle. Under
+/// `swift run` the process has no bundle, so `isSupported` is false and the
+/// settings toggle stays disabled.
+enum LaunchAtLogin {
+    /// True only when the host process is a real `.app` bundle.
+    static var isSupported: Bool {
+        Bundle.main.bundleURL.pathExtension == "app"
+    }
+
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    static func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Providers/AutoHideMenuBarProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/AutoHideMenuBarProvider.swift
@@ -1,20 +1,27 @@
 import Foundation
 
-/// Toggles `_HIHideMenuBar` in NSGlobalDomain. When true, macOS automatically
-/// hides the menu bar and reveals it on hover (the "Automatically hide and
-/// show the menu bar" system preference).
+/// Toggles macOS "Automatically hide and show the menu bar".
 ///
-/// Reads via `CFPreferencesCopyAppValue` against `kCFPreferencesAnyApplication`
-/// (NSGlobalDomain). Writes via `/usr/bin/defaults` (CFPreferencesSetAppValue
-/// cannot write across the cfprefsd domain boundary). After write,
-/// `killall -HUP SystemUIServer` restarts the menu bar service to apply.
+/// Two defaults must be kept in sync:
+/// - `_HIHideMenuBar` (NSGlobalDomain) drives the actual behavior — WindowServer
+///   reads it to decide whether to auto-hide the menu bar on the desktop.
+/// - `AutoHideMenuBarOption` (com.apple.controlcenter) is the persistent source
+///   of truth behind the four-way picker in System Settings (0 = Always,
+///   1 = On Desktop Only, 2 = In Full Screen Only (default), 3 = Never). When the
+///   Dock restarts it re-derives `_HIHideMenuBar` from this value, so writing
+///   `_HIHideMenuBar` alone gets silently reverted.
 ///
-/// Note: on macOS Tahoe/26 the menu-bar appearance UI lives in Control Center /
-/// System Settings, but the underlying `_HIHideMenuBar` default still drives
-/// auto-hide behavior.
+/// Writing the defaults never applies live on its own. WindowServer only
+/// re-reads after the `AppleInterfaceMenuBarHidingChangedNotification`
+/// distributed notification is posted — this is what System Settings posts, and
+/// the only reliable trigger (restarting SystemUIServer / Dock does nothing).
 actor AutoHideMenuBarProvider: ToggleProvider {
     let itemKey: BuiltinItem = .autoHideMenuBar
     var permission: PermissionStatus { .notRequired }
+
+    // AutoHideMenuBarOption values for the toggle's on/off states.
+    private static let optionAlways = 0          // auto-hide on desktop and full screen
+    private static let optionFullScreenOnly = 2  // macOS default — visible on desktop
 
     func readState() async throws -> Bool {
         let raw = CFPreferencesCopyAppValue("_HIHideMenuBar" as CFString,
@@ -29,7 +36,15 @@ actor AutoHideMenuBarProvider: ToggleProvider {
             args: ["write", "NSGlobalDomain", "_HIHideMenuBar", "-bool",
                    autoHide ? "true" : "false"]
         )
-        _ = try? await ShellRunner.run("/usr/bin/killall", args: ["-HUP", "SystemUIServer"])
-        // SystemUIServer restart failure is non-fatal: the default is already written.
+        _ = try await ShellRunner.run(
+            "/usr/bin/defaults",
+            args: ["write", "com.apple.controlcenter", "AutoHideMenuBarOption", "-int",
+                   String(autoHide ? Self.optionAlways : Self.optionFullScreenOnly)]
+        )
+        // Live-apply trigger: WindowServer re-reads the prefs on this notification.
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name("AppleInterfaceMenuBarHidingChangedNotification"),
+            object: nil, userInfo: nil, deliverImmediately: true
+        )
     }
 }

--- a/Sources/AnyDoor/Views/AppShortcutsPopoverView.swift
+++ b/Sources/AnyDoor/Views/AppShortcutsPopoverView.swift
@@ -65,9 +65,7 @@ private struct AppShortcutRow: View {
                 .lineLimit(1)
             Spacer(minLength: 12)
             if let hotkey = entry.hotkey {
-                Text(hotkey.displayString)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                HotkeyLabel(hotkey: hotkey)
             }
         }
         .padding(.horizontal, 10).padding(.vertical, 6)

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -9,6 +9,7 @@ private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "settings"
 struct GeneralSettingsView: View {
     @State private var launchAtLogin = LaunchAtLogin.isEnabled
     @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
+    @State private var automationGranted = false
 
     var body: some View {
         Form {
@@ -31,14 +32,17 @@ struct GeneralSettingsView: View {
 
             Section("权限") {
                 accessibilityRow
+                automationRow
             }
         }
         .formStyle(.grouped)
-        // Poll while the tab is visible so the badge updates live after the
-        // user grants the permission in System Settings.
+        // Poll while the tab is visible so the badges update live after the
+        // user grants a permission in System Settings.
         .task {
+            await AutomationPermission.activateSystemEvents()
             while !Task.isCancelled {
                 accessibilityGranted = HotkeyService.hasAccessibilityPermission
+                automationGranted = AutomationPermission.isGranted
                 try? await Task.sleep(for: .seconds(1))
             }
         }
@@ -60,6 +64,31 @@ struct GeneralSettingsView: View {
                     .requestsPermission(.accessibility)
             } else {
                 Button("打开系统设置", action: openAccessibilitySettings)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var automationRow: some View {
+        HStack {
+            Label("自动化", systemImage: "gearshape.2")
+            Spacer()
+            if automationGranted {
+                Label("已授权", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else {
+                // Automation has no guided drag flow. Show the system prompt
+                // when undetermined; fall back to System Settings when the
+                // request resolves to a denial (the prompt no longer appears).
+                Button("申请授权") {
+                    Task {
+                        await AutomationPermission.activateSystemEvents()
+                        let granted = await Task.detached {
+                            AutomationPermission.request()
+                        }.value
+                        if !granted { AutomationPermission.openSettings() }
+                    }
+                }
             }
         }
     }

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -27,10 +27,6 @@ struct GeneralSettingsView: View {
                     }
             } header: {
                 Text("启动")
-            } footer: {
-                if !LaunchAtLogin.isSupported {
-                    Text("仅在已安装的 AnyDoor.app 中可用")
-                }
             }
 
             Section("权限") {

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -1,13 +1,77 @@
 import SwiftUI
+import AppKit
+import OSLog
+import AskForPermission
 
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "settings")
+
+@MainActor
 struct GeneralSettingsView: View {
+    @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
+
     var body: some View {
-        VStack {
-            Text("通用设置")
-                .font(.headline)
-            Text("暂无可配置项")
-                .foregroundStyle(.secondary)
+        Form {
+            Section {
+                Toggle("开机时启动 AnyDoor", isOn: $launchAtLogin)
+                    .disabled(!LaunchAtLogin.isSupported)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        // Skip the echo from our own revert assignment below.
+                        guard newValue != LaunchAtLogin.isEnabled else { return }
+                        do {
+                            try LaunchAtLogin.setEnabled(newValue)
+                        } catch {
+                            logger.error("LaunchAtLogin.setEnabled(\(newValue)) failed: \(error)")
+                            launchAtLogin = LaunchAtLogin.isEnabled
+                        }
+                    }
+            } header: {
+                Text("启动")
+            } footer: {
+                if !LaunchAtLogin.isSupported {
+                    Text("仅在已安装的 AnyDoor.app 中可用")
+                }
+            }
+
+            Section("权限") {
+                accessibilityRow
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .formStyle(.grouped)
+        // Poll while the tab is visible so the badge updates live after the
+        // user grants the permission in System Settings.
+        .task {
+            while !Task.isCancelled {
+                accessibilityGranted = HotkeyService.hasAccessibilityPermission
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var accessibilityRow: some View {
+        HStack {
+            Label("辅助功能", systemImage: "accessibility")
+            Spacer()
+            if accessibilityGranted {
+                Label("已授权", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if AskForPermission.isAvailable {
+                // Plain Text (not a Button) per AskForPermission guidance —
+                // the modifier owns the tap and runs the guided flight flow.
+                Text("去授权")
+                    .foregroundStyle(Color.accentColor)
+                    .requestsPermission(.accessibility)
+            } else {
+                Button("打开系统设置", action: openAccessibilitySettings)
+            }
+        }
+    }
+
+    private func openAccessibilitySettings() {
+        guard let url = URL(string:
+            "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility")
+        else { return }
+        NSWorkspace.shared.open(url)
     }
 }

--- a/Sources/AnyDoor/Views/HotkeyLabel.swift
+++ b/Sources/AnyDoor/Views/HotkeyLabel.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Renders a hotkey as a row of individual keycap badges (one per modifier and key),
+/// matching the keycap style used across modern macOS panels and command palettes.
+struct HotkeyLabel: View {
+    let hotkey: HotkeyDescriptor
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(Array(hotkey.displayParts.enumerated()), id: \.offset) { _, part in
+                Text(part)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 15)
+                    .padding(.horizontal, 3)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color.primary.opacity(0.09))
+                    )
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/PanelRowView.swift
+++ b/Sources/AnyDoor/Views/PanelRowView.swift
@@ -82,13 +82,12 @@ struct PanelRowView: View {
                 set: { _ in onToggle() }
             ))
             .toggleStyle(.switch)
+            .controlSize(.small)
             .labelsHidden()
             .disabled(needsPermission)
         case .action:
             if let hk = entry.hotkey {
-                Text(hk.displayString)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                HotkeyLabel(hotkey: hk)
             }
         case .submenu:
             Image(systemName: "chevron.right")

--- a/docs/superpowers/plans/2026-05-22-general-settings.md
+++ b/docs/superpowers/plans/2026-05-22-general-settings.md
@@ -1,0 +1,298 @@
+# General Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build out the empty "通用" Settings tab with a Launch at Login toggle and an Accessibility permission row backed by the AskForPermission guided grant flow.
+
+**Architecture:** A new `LaunchAtLogin` enum wraps `SMAppService.mainApp`. `GeneralSettingsView` is rewritten as a native grouped `Form`. The Accessibility row uses the `AskForPermission` SPM package's `.requestsPermission(.accessibility)` modifier for the guided flying-card flow, falling back to a plain System Settings deep-link when the process is not a `.app` bundle.
+
+**Tech Stack:** Swift 6.2, SwiftUI, `ServiceManagement` (`SMAppService`), `AskForPermission` (SPM dependency).
+
+**Testing note:** `SMAppService` and TCC are system integrations with no meaningful unit-test surface (per the spec). Each task is verified with `swift build`; Task 5 is a manual verification checklist.
+
+---
+
+### Task 1: Add the AskForPermission dependency
+
+**Files:**
+- Modify: `Package.swift`
+
+- [ ] **Step 1: Replace `Package.swift` with the dependency-aware version**
+
+```swift
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "AnyDoor",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(
+            url: "https://github.com/riko2chen/AskForPermission.git",
+            revision: "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e"
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "AnyDoor",
+            dependencies: [
+                .product(name: "AskForPermission", package: "AskForPermission"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "AnyDoorTests",
+            dependencies: ["AnyDoor"],
+            resources: [.process("Fixtures")],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)
+```
+
+- [ ] **Step 2: Resolve and build**
+
+Run: `swift build`
+Expected: SwiftPM fetches `AskForPermission` from GitHub (needs network, first run is slower), then `Build complete!`. The unchanged `AnyDoor` sources still compile because nothing imports the new module yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Package.swift Package.resolved
+git commit -m "build: add AskForPermission dependency"
+```
+
+(`Package.resolved` is created/updated by `swift build` — include it so the pinned revision is reproducible.)
+
+---
+
+### Task 2: Add the LaunchAtLogin service
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/LaunchAtLogin.swift`
+
+- [ ] **Step 1: Create `LaunchAtLogin.swift`**
+
+```swift
+import Foundation
+import ServiceManagement
+
+/// Thin wrapper over `SMAppService.mainApp` for the launch-at-login toggle.
+///
+/// Only meaningful when AnyDoor runs as an installed `.app` bundle. Under
+/// `swift run` the process has no bundle, so `isSupported` is false and the
+/// settings toggle stays disabled.
+enum LaunchAtLogin {
+    /// True only when the host process is a real `.app` bundle.
+    static var isSupported: Bool {
+        Bundle.main.bundleURL.pathExtension == "app"
+    }
+
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    static func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/LaunchAtLogin.swift
+git commit -m "feat(settings): add LaunchAtLogin service wrapper"
+```
+
+---
+
+### Task 3: Configure AskForPermission at launch
+
+**Files:**
+- Modify: `Sources/AnyDoor/AppDelegate.swift`
+
+- [ ] **Step 1: Add the import**
+
+In `Sources/AnyDoor/AppDelegate.swift`, add `import AskForPermission` to the import block. The block becomes:
+
+```swift
+import Cocoa
+import SwiftData
+import OSLog
+import AskForPermission
+```
+
+- [ ] **Step 2: Call `configure` in `applicationDidFinishLaunching`**
+
+In `applicationDidFinishLaunching(_:)`, add the `configure` call immediately after the activation-policy line. The start of the method becomes:
+
+```swift
+    @MainActor
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApplication.shared.setActivationPolicy(.accessory)
+        AskForPermission.configure(appName: "AnyDoor")
+
+        // Run migrations / seeding on the main context
+        let context = modelContainer.mainContext
+```
+
+Leave the rest of the method (including the existing `requestAccessibilityPermission()` call) unchanged.
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(settings): configure AskForPermission at launch"
+```
+
+---
+
+### Task 4: Rewrite GeneralSettingsView
+
+**Files:**
+- Modify (full rewrite): `Sources/AnyDoor/Views/GeneralSettingsView.swift`
+
+- [ ] **Step 1: Replace `GeneralSettingsView.swift` with the real settings form**
+
+```swift
+import SwiftUI
+import AppKit
+import OSLog
+import AskForPermission
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "settings")
+
+@MainActor
+struct GeneralSettingsView: View {
+    @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("开机时启动 AnyDoor", isOn: $launchAtLogin)
+                    .disabled(!LaunchAtLogin.isSupported)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        // Skip the echo from our own revert assignment below.
+                        guard newValue != LaunchAtLogin.isEnabled else { return }
+                        do {
+                            try LaunchAtLogin.setEnabled(newValue)
+                        } catch {
+                            logger.error("LaunchAtLogin.setEnabled(\(newValue)) failed: \(error)")
+                            launchAtLogin = LaunchAtLogin.isEnabled
+                        }
+                    }
+            } header: {
+                Text("启动")
+            } footer: {
+                if !LaunchAtLogin.isSupported {
+                    Text("仅在已安装的 AnyDoor.app 中可用")
+                }
+            }
+
+            Section("权限") {
+                accessibilityRow
+            }
+        }
+        .formStyle(.grouped)
+        // Poll while the tab is visible so the badge updates live after the
+        // user grants the permission in System Settings.
+        .task {
+            while !Task.isCancelled {
+                accessibilityGranted = HotkeyService.hasAccessibilityPermission
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var accessibilityRow: some View {
+        HStack {
+            Label("辅助功能", systemImage: "accessibility")
+            Spacer()
+            if accessibilityGranted {
+                Label("已授权", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if AskForPermission.isAvailable {
+                // Plain Text (not a Button) per AskForPermission guidance —
+                // the modifier owns the tap and runs the guided flight flow.
+                Text("去授权")
+                    .foregroundStyle(Color.accentColor)
+                    .requestsPermission(.accessibility)
+            } else {
+                Button("打开系统设置", action: openAccessibilitySettings)
+            }
+        }
+    }
+
+    private func openAccessibilitySettings() {
+        guard let url = URL(string:
+            "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility")
+        else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/GeneralSettingsView.swift
+git commit -m "feat(settings): build out general settings tab"
+```
+
+---
+
+### Task 5: Manual verification
+
+**Files:** none (verification only — no commit)
+
+These cannot be automated (`SMAppService`, TCC, login cycle). Run them and confirm each.
+
+- [ ] **Step 1: Dev-mode fallback check**
+
+Run: `swift run AnyDoor`
+Open the menu bar panel → 设置 → 通用 tab. Confirm:
+- The "开机时启动 AnyDoor" toggle is disabled, with footer "仅在已安装的 AnyDoor.app 中可用".
+- The 辅助功能 row shows either "已授权" or, if not granted, a "打开系统设置" button (the `swift run` process is not a `.app`, so the guided flow is unavailable).
+
+Quit the app when done.
+
+- [ ] **Step 2: Installed-app guided flow check**
+
+Run: `make install`, then launch `/Applications/AnyDoor.app`.
+Revoke the permission first: `tccutil reset Accessibility dev.bybee.AnyDoor`.
+Open 设置 → 通用. Confirm:
+- The 辅助功能 row shows "去授权".
+- Clicking "去授权" opens System Settings' Accessibility pane and runs the AskForPermission guided flying-card flow.
+- After granting, the badge flips to "已授权" within ~1s without reopening the window.
+
+- [ ] **Step 3: Launch at Login check**
+
+In the installed app's 通用 tab, toggle "开机时启动 AnyDoor" on.
+Confirm: `SMAppService` registered it — verify via System Settings → General → Login Items, or `sfltool dumpbtm | grep -i anydoor`.
+Toggle it off and confirm it is removed.

--- a/docs/superpowers/specs/2026-05-22-general-settings-design.md
+++ b/docs/superpowers/specs/2026-05-22-general-settings-design.md
@@ -20,9 +20,14 @@ menu bar utility are missing:
 - Add a Launch at Login toggle to the General tab.
 - Add an Accessibility permission row that shows live status and runs a guided
   grant flow.
+- Add an Automation permission row that shows live status and triggers the
+  standard system prompt (AnyDoor scripts System Events for the dark-mode
+  toggle).
 - Keep the General tab visually native (macOS grouped `Form`).
 
-Non-goals: about/version info, other permissions, menu bar icon customization.
+Non-goals: about/version info, Screen Recording (OCR/screenshot use interactive
+`screencapture -i`, which is user-mediated and exempt from the Screen Recording
+TCC gate), menu bar icon customization.
 
 ## Approach
 
@@ -80,6 +85,20 @@ Thin wrapper over `SMAppService.mainApp` (`import ServiceManagement`):
 
 `SMAppService` calls are synchronous and quick; no actor needed.
 
+### `Services/AutomationPermission.swift` (new)
+
+Wraps `AEDeterminePermissionToAutomateTarget` for the System Events target
+(`import CoreServices`):
+
+- `static var isGranted: Bool` — determination with `askUserIfNeeded: false`.
+- `static func request() -> Bool` — determination with `askUserIfNeeded: true`;
+  shows the system prompt when undetermined. Blocks until the user responds, so
+  callers run it off the main actor.
+- `static func activateSystemEvents() async` — launches System Events (faceless,
+  non-activating) when it is not running, because the determination API returns
+  `procNotFound` for a non-running target.
+- `static func openSettings()` — deep-links to the Automation privacy pane.
+
 ### `Views/GeneralSettingsView.swift` (rewritten)
 
 A `Form` with `.formStyle(.grouped)`, two sections:
@@ -88,11 +107,14 @@ A `Form` with `.formStyle(.grouped)`, two sections:
 - Toggle "开机时启动 AnyDoor", reflecting `LaunchAtLogin.isEnabled`.
 - On change, call `LaunchAtLogin.setEnabled(_:)`. If it throws, revert the
   toggle to the actual `SMAppService` status and log the error.
-- When `!LaunchAtLogin.isSupported`: toggle disabled, section footer reads
-  "仅在已安装的 AnyDoor.app 中可用".
+- When `!LaunchAtLogin.isSupported` (running via `swift run`): the toggle is
+  disabled. No explanatory footer — end users always run the installed `.app`.
 
 **权限 (Permissions)**
-- One row: SF Symbol + "辅助功能" + a trailing status badge.
+
+Two rows, each an SF Symbol + name + trailing status badge.
+
+*辅助功能 (Accessibility)*
 - Granted → "✓ 已授权" badge, no action.
 - Not granted + `AskForPermission.isAvailable` → a tappable "去授权" element
   carrying `.requestsPermission(.accessibility)`; tapping runs the guided
@@ -101,9 +123,19 @@ A `Form` with `.formStyle(.grouped)`, two sections:
   button deep-linking to
   `x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility`.
 
-Status is polled every ~1s with a `Timer` while the view is visible (via
-`.onAppear`/`.onDisappear`), reading `AXIsProcessTrusted()` so the badge updates
-live after the user grants the permission. Reuses `HotkeyService.hasAccessibilityPermission`.
+*自动化 (Automation)*
+- Granted → "✓ 已授权" badge, no action.
+- Not granted → a "申请授权" button. Automation has no guided drag flow, so the
+  button calls `AutomationPermission.request()` to show the standard system
+  prompt when undetermined; if the request resolves to a denial (the prompt no
+  longer reappears), it falls back to `AutomationPermission.openSettings()`.
+
+Both badges are polled every ~1s while the tab is visible, via a `.task` loop
+(cancelled on disappear). Accessibility reads
+`HotkeyService.hasAccessibilityPermission`; Automation reads
+`AutomationPermission.isGranted`. The `.task` first calls
+`AutomationPermission.activateSystemEvents()` so the automation check returns a
+real verdict instead of `procNotFound`.
 
 ### `AppDelegate` (modified)
 
@@ -119,6 +151,9 @@ Add `AskForPermission.configure(appName: "AnyDoor")` in
   in System Settings → General → Login Items (no extra UI for this edge case).
 - `AskForPermission.request` returning `.unavailable` is already handled by the
   `isAvailable` branch — the guided element is not shown in that case.
+- `AutomationPermission.request()` resolving to a denial: the row's button opens
+  System Settings → Automation as the fallback, since a denied state no longer
+  re-prompts.
 
 ## Testing
 
@@ -130,8 +165,11 @@ Verification is manual:
 - With the permission revoked (`tccutil reset Accessibility dev.bybee.AnyDoor`),
   open General settings, confirm the row shows "未授权" and the guided flow runs
   and the badge flips to "已授权" after granting.
-- Run via `swift run`, confirm the toggle is disabled with the footer note and
-  the permission row shows the "打开系统设置" fallback.
+- Run via `swift run`, confirm the toggle is disabled and the accessibility row
+  shows the "打开系统设置" fallback.
+- With Automation revoked (`tccutil reset AppleEvents dev.bybee.AnyDoor`), open
+  General settings, confirm the 自动化 row shows "申请授权"; tapping it shows the
+  system prompt, and the badge flips to "已授权" after allowing.
 
 ## UI language
 

--- a/docs/superpowers/specs/2026-05-22-general-settings-design.md
+++ b/docs/superpowers/specs/2026-05-22-general-settings-design.md
@@ -1,0 +1,139 @@
+# General Settings: Launch at Login + Accessibility Permission
+
+Date: 2026-05-22
+Status: Approved
+
+## Problem
+
+The Settings window's "通用" (General) tab is an empty placeholder
+(`GeneralSettingsView` renders only "暂无可配置项"). Two standard options for a
+menu bar utility are missing:
+
+1. **Launch at Login** — AnyDoor relies on global hotkeys; users expect it to
+   start automatically at login.
+2. **Accessibility permission status** — AnyDoor hard-depends on the
+   Accessibility permission (CGEvent tap), but nothing in the UI surfaces
+   whether it is granted or offers a path to grant it.
+
+## Goals
+
+- Add a Launch at Login toggle to the General tab.
+- Add an Accessibility permission row that shows live status and runs a guided
+  grant flow.
+- Keep the General tab visually native (macOS grouped `Form`).
+
+Non-goals: about/version info, other permissions, menu bar icon customization.
+
+## Approach
+
+### Accessibility grant flow
+
+The guided "drag the app icon into System Settings" interaction is provided by
+the `AskForPermission` Swift package
+(`https://github.com/riko2chen/AskForPermission`). It is added as an SPM
+dependency rather than reimplemented or vendored — the package exposes a clean
+facade and the interaction itself is ~2000 lines of animation/window-tracking
+code that cannot be made meaningfully lighter.
+
+The package is consumed via its `.requestsPermission(_:)` SwiftUI modifier:
+AnyDoor draws its own settings row, and the modifier captures the row's screen
+rect and runs the package's guided flow on tap. The package's own
+`PermissionsView` is not embedded — it is a fixed-size view with its own chrome
+that would not blend into a native grouped `Form`.
+
+### .app bundle requirement
+
+The guided flow requires the host process to be a real `.app` bundle (the user
+drags the app icon into the System Settings list). Under `swift run` the process
+has no bundle, so:
+
+- `AskForPermission.isAvailable` is `false` — the row falls back to a plain
+  "打开系统设置" button that deep-links to the Accessibility pane.
+- `LaunchAtLogin.isSupported` is `false` — the toggle is disabled with an
+  explanatory footer.
+
+Both conditions reduce to "is `Bundle.main.bundleURL` a `.app`".
+
+## Components
+
+### `Package.swift` (modified)
+
+Add the `AskForPermission` dependency, pinned to an exact revision (the repo has
+no version tags):
+
+```swift
+.package(url: "https://github.com/riko2chen/AskForPermission.git",
+         revision: "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e")
+```
+
+Add `AskForPermission` to the `AnyDoor` target's dependencies. The dependency
+compiles in its own declared language mode (Swift 5.9); AnyDoor stays on
+`.v6`.
+
+### `Services/LaunchAtLogin.swift` (new)
+
+Thin wrapper over `SMAppService.mainApp` (`import ServiceManagement`):
+
+- `static var isSupported: Bool` — `Bundle.main.bundleURL.pathExtension == "app"`.
+- `static var isEnabled: Bool` — `SMAppService.mainApp.status == .enabled`.
+- `static func setEnabled(_:) throws` — `register()` / `unregister()`.
+
+`SMAppService` calls are synchronous and quick; no actor needed.
+
+### `Views/GeneralSettingsView.swift` (rewritten)
+
+A `Form` with `.formStyle(.grouped)`, two sections:
+
+**启动 (Startup)**
+- Toggle "开机时启动 AnyDoor", reflecting `LaunchAtLogin.isEnabled`.
+- On change, call `LaunchAtLogin.setEnabled(_:)`. If it throws, revert the
+  toggle to the actual `SMAppService` status and log the error.
+- When `!LaunchAtLogin.isSupported`: toggle disabled, section footer reads
+  "仅在已安装的 AnyDoor.app 中可用".
+
+**权限 (Permissions)**
+- One row: SF Symbol + "辅助功能" + a trailing status badge.
+- Granted → "✓ 已授权" badge, no action.
+- Not granted + `AskForPermission.isAvailable` → a tappable "去授权" element
+  carrying `.requestsPermission(.accessibility)`; tapping runs the guided
+  flying-card flow.
+- Not granted + `!AskForPermission.isAvailable` → a plain "打开系统设置"
+  button deep-linking to
+  `x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility`.
+
+Status is polled every ~1s with a `Timer` while the view is visible (via
+`.onAppear`/`.onDisappear`), reading `AXIsProcessTrusted()` so the badge updates
+live after the user grants the permission. Reuses `HotkeyService.hasAccessibilityPermission`.
+
+### `AppDelegate` (modified)
+
+Add `AskForPermission.configure(appName: "AnyDoor")` in
+`applicationDidFinishLaunching`. The existing launch-time
+`requestAccessibilityPermission()` call is left unchanged.
+
+## Error handling
+
+- `LaunchAtLogin.setEnabled` throwing: revert the toggle to the real
+  `SMAppService.mainApp.status`, log via `os.Logger`. If `register()` results in
+  `.requiresApproval`, the toggle stays off and the user is expected to approve
+  in System Settings → General → Login Items (no extra UI for this edge case).
+- `AskForPermission.request` returning `.unavailable` is already handled by the
+  `isAvailable` branch — the guided element is not shown in that case.
+
+## Testing
+
+`SMAppService` and TCC are system integrations that cannot be meaningfully unit
+tested (no fakes worth the indirection — `LaunchAtLogin` is a thin pass-through).
+Verification is manual:
+
+- `make install`, toggle Launch at Login on, log out/in, confirm AnyDoor starts.
+- With the permission revoked (`tccutil reset Accessibility dev.bybee.AnyDoor`),
+  open General settings, confirm the row shows "未授权" and the guided flow runs
+  and the badge flips to "已授权" after granting.
+- Run via `swift run`, confirm the toggle is disabled with the footer note and
+  the permission row shows the "打开系统设置" fallback.
+
+## UI language
+
+All user-facing strings remain Chinese, consistent with the rest of the app.
+Code comments, this spec, and commit messages are English.


### PR DESCRIPTION
## Summary

Builds out the previously empty "通用" Settings tab:

- **Launch at Login** — toggle backed by `SMAppService.mainApp`. Disabled when running non-bundled (`swift run`).
- **辅助功能 (Accessibility)** — live status row; runs the `AskForPermission` guided drag-to-grant flow, with a System Settings deep-link fallback when not running as a `.app`.
- **自动化 (Automation)** — live status row for the System Events target (dark-mode toggle); "申请授权" triggers the standard system prompt and falls back to System Settings on a denied state.

Adds the `AskForPermission` SPM dependency (pinned to an exact revision). Design captured in `docs/superpowers/specs/2026-05-22-general-settings-design.md`.

## Test plan

- [x] `swift run`: launch-at-login toggle disabled; accessibility row shows the "打开系统设置" fallback.
- [x] Installed `.app` (`make install`): with Accessibility revoked (`tccutil reset Accessibility dev.bybee.AnyDoor`), the row shows "去授权" and the guided flying-card flow runs; badge flips to "已授权" within ~1s of granting.
- [x] With Automation revoked (`tccutil reset AppleEvents dev.bybee.AnyDoor`), the 自动化 row shows "申请授权"; tapping it shows the system prompt and the badge flips to "已授权" after allowing.
- [x] Launch-at-login toggle on → AnyDoor registered in System Settings → General → Login Items.