### PR TITLE
feat: add screen color picker

### DIFF
--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -60,6 +60,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             FlushDNSProvider(),
             KeyboardLockProvider(),
             OCRProvider(),
+            PickColorProvider(),
         ]
         PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)
 

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -13,6 +13,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case emptyTrash
     case screenshot
     case ocr
+    case pickColor
     case displaySleep
     case systemSleep
     case hideDock
@@ -35,7 +36,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .appShortcuts, .portManager: return .submenu
         case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
-        case .lockScreen, .emptyTrash, .screenshot, .ocr, .displaySleep, .systemSleep,
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .pickColor, .displaySleep, .systemSleep,
              .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
         }
     }
@@ -52,6 +53,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .emptyTrash: return "清空废纸篓"
         case .screenshot: return "截图到剪贴板"
         case .ocr: return "屏幕取词"
+        case .pickColor: return "屏幕取色"
         case .displaySleep: return "显示器睡眠"
         case .systemSleep: return "系统休眠"
         case .hideDock: return "隐藏 Dock"
@@ -77,6 +79,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .emptyTrash: return "trash.fill"
         case .screenshot: return "camera.viewfinder"
         case .ocr: return "text.viewfinder"
+        case .pickColor: return "eyedropper"
         case .displaySleep: return "moon.zzz.fill"
         case .systemSleep: return "powersleep"
         case .hideDock: return "dock.rectangle"
@@ -103,6 +106,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .emptyTrash: return 800
         case .screenshot: return 900
         case .ocr: return 950
+        case .pickColor: return 975
         case .displaySleep: return 1000
         case .systemSleep: return 1100
         case .hideDock: return 1200

--- a/Sources/AnyDoor/Services/ColorSampler.swift
+++ b/Sources/AnyDoor/Services/ColorSampler.swift
@@ -27,12 +27,16 @@ enum ColorSampler {
                     continuation.resume(returning: .cancelled)
                     return
                 }
-                guard let hex = color.sRGBHexString else {
+                // Derive both the hex string and the swatch from the same sRGB
+                // representation, so the previewed swatch matches the value the
+                // user pastes (the raw NSColor may be in a wider gamut).
+                guard let hex = color.sRGBHexString,
+                      let srgb = color.usingColorSpace(.sRGB) else {
                     continuation.resume(returning: .conversionFailed)
                     return
                 }
                 continuation.resume(
-                    returning: .picked(hex: hex, swatch: Color(nsColor: color))
+                    returning: .picked(hex: hex, swatch: Color(nsColor: srgb))
                 )
             }
         }

--- a/Sources/AnyDoor/Services/ColorSampler.swift
+++ b/Sources/AnyDoor/Services/ColorSampler.swift
@@ -1,0 +1,40 @@
+import AppKit
+import SwiftUI
+
+/// Adapts `NSColorSampler`'s completion-handler API into `async`.
+///
+/// `NSColorSampler` presents the macOS system color-sampling loupe and must be
+/// used on the main thread. The picked `NSColor` is converted to `Sendable`
+/// values inside the completion handler so it never crosses an actor boundary.
+@MainActor
+enum ColorSampler {
+    /// The result of one color-sampling session.
+    enum Outcome: Sendable {
+        /// The user picked a color: `hex` is `"#RRGGBB"`, `swatch` previews it.
+        case picked(hex: String, swatch: Color)
+        /// A color was picked but could not be represented in sRGB.
+        case conversionFailed
+        /// The user dismissed the loupe without picking (e.g. pressed Escape).
+        case cancelled
+    }
+
+    /// Presents the system color loupe and waits for the user to pick a pixel
+    /// or cancel.
+    static func sample() async -> Outcome {
+        await withCheckedContinuation { continuation in
+            NSColorSampler().show { color in
+                guard let color else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+                guard let hex = color.sRGBHexString else {
+                    continuation.resume(returning: .conversionFailed)
+                    return
+                }
+                continuation.resume(
+                    returning: .picked(hex: hex, swatch: Color(nsColor: color))
+                )
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Providers/PickColorProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/PickColorProvider.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Foundation
+
+/// Presents the macOS system color-sampling loupe, copies the picked color to
+/// the clipboard as an uppercase HEX string, and shows a bottom-center toast
+/// reporting the outcome.
+///
+/// Every error is absorbed and mapped to a toast — `run()` never propagates.
+actor PickColorProvider: ActionProvider {
+    let itemKey: BuiltinItem = .pickColor
+
+    var permission: PermissionStatus { .notRequired }
+
+    func run() async {
+        switch await ColorSampler.sample() {
+        case .cancelled:
+            return // user cancelled — silent, no toast
+        case .conversionFailed:
+            await ToastPresenter.shared.show(.failure("取色失败"))
+        case .picked(let hex, let swatch):
+            await MainActor.run {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(hex, forType: .string)
+            }
+            await ToastPresenter.shared.show(
+                .color(message: "已复制 \(hex)", swatch: swatch)
+            )
+        }
+    }
+}

--- a/Sources/AnyDoor/Utilities/NSColor+Hex.swift
+++ b/Sources/AnyDoor/Utilities/NSColor+Hex.swift
@@ -1,0 +1,21 @@
+import AppKit
+
+extension NSColor {
+    /// The color as an uppercase `"#RRGGBB"` string in the sRGB color space.
+    ///
+    /// Returns `nil` when the color cannot be converted to sRGB (e.g. pattern
+    /// colors). Each component is clamped to `0...1` before scaling — sampling
+    /// on wide-gamut displays can yield components slightly outside that range.
+    var sRGBHexString: String? {
+        guard let srgb = usingColorSpace(.sRGB) else { return nil }
+        func channel(_ value: CGFloat) -> Int {
+            Int((min(max(value, 0), 1) * 255).rounded())
+        }
+        return String(
+            format: "#%02X%02X%02X",
+            channel(srgb.redComponent),
+            channel(srgb.greenComponent),
+            channel(srgb.blueComponent)
+        )
+    }
+}

--- a/Sources/AnyDoor/Views/ToastView.swift
+++ b/Sources/AnyDoor/Views/ToastView.swift
@@ -1,41 +1,30 @@
 import SwiftUI
 
-/// The status a toast reports. `Sendable` so it can cross the OCRProvider → ToastPresenter
-/// (actor → MainActor) boundary.
+/// The status a toast reports. `Sendable` so it can cross provider actor →
+/// `ToastPresenter` (`@MainActor`) boundaries. `Color` is `Sendable`, so the
+/// `.color` swatch crosses the boundary unchanged.
 enum ToastStyle: Sendable {
     case success(String)
     case failure(String)
+    case color(message: String, swatch: Color)
 
     var message: String {
         switch self {
-        case .success(let text), .failure(let text): return text
-        }
-    }
-
-    var iconName: String {
-        switch self {
-        case .success: return "checkmark.circle.fill"
-        case .failure: return "xmark.circle.fill"
-        }
-    }
-
-    var iconColor: Color {
-        switch self {
-        case .success: return .green
-        case .failure: return .red
+        case .success(let text), .failure(let text):
+            return text
+        case .color(let message, _):
+            return message
         }
     }
 }
 
-/// A compact status pill: an SF Symbol icon next to a single line of text.
+/// A compact status pill: a leading icon or color swatch next to one line of text.
 struct ToastView: View {
     let style: ToastStyle
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: style.iconName)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(style.iconColor)
+            leading
             Text(verbatim: style.message)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary)
@@ -44,5 +33,31 @@ struct ToastView: View {
         .padding(.vertical, 10)
         .background(.regularMaterial, in: Capsule())
         .fixedSize()
+    }
+
+    /// SF Symbol for success/failure; a bordered color swatch for `.color`.
+    @ViewBuilder
+    private var leading: some View {
+        switch style {
+        case .success:
+            symbol("checkmark.circle.fill", color: .green)
+        case .failure:
+            symbol("xmark.circle.fill", color: .red)
+        case .color(_, let swatch):
+            RoundedRectangle(cornerRadius: 4)
+                .fill(swatch)
+                .frame(width: 16, height: 16)
+                // Thin border keeps near-white swatches visible on the material.
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                )
+        }
+    }
+
+    private func symbol(_ name: String, color: Color) -> some View {
+        Image(systemName: name)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(color)
     }
 }

--- a/Tests/AnyDoorTests/ColorHexTests.swift
+++ b/Tests/AnyDoorTests/ColorHexTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+final class ColorHexTests: XCTestCase {
+
+    func testBlackProducesAllZeroes() {
+        XCTAssertEqual(NSColor.black.sRGBHexString, "#000000")
+    }
+
+    func testWhiteProducesAllFs() {
+        XCTAssertEqual(NSColor.white.sRGBHexString, "#FFFFFF")
+    }
+
+    func testMidToneColorRoundsEachChannel() {
+        // 0.5*255=127.5→128 (0x80), 0.25*255=63.75→64 (0x40), 0.75*255=191.25→191 (0xBF)
+        let color = NSColor(srgbRed: 0.5, green: 0.25, blue: 0.75, alpha: 1)
+        XCTAssertEqual(color.sRGBHexString, "#8040BF")
+    }
+
+    func testComponentsOutsideUnitRangeAreClamped() {
+        // Wide-gamut conversions can yield components slightly outside 0...1.
+        // red 1.4 clamps to 1→FF, green -0.2 clamps to 0→00, blue 1.0→FF.
+        let color = NSColor(srgbRed: 1.4, green: -0.2, blue: 1.0, alpha: 1)
+        XCTAssertEqual(color.sRGBHexString, "#FF00FF")
+    }
+}

--- a/Tests/AnyDoorTests/ColorHexTests.swift
+++ b/Tests/AnyDoorTests/ColorHexTests.swift
@@ -24,4 +24,10 @@ final class ColorHexTests: XCTestCase {
         let color = NSColor(srgbRed: 1.4, green: -0.2, blue: 1.0, alpha: 1)
         XCTAssertEqual(color.sRGBHexString, "#FF00FF")
     }
+
+    func testPatternColorReturnsNil() {
+        // Pattern colors have no color-space representation, so conversion fails.
+        let patternColor = NSColor(patternImage: NSImage())
+        XCTAssertNil(patternColor.sRGBHexString)
+    }
 }

--- a/Tests/AnyDoorTests/MigrationTests.swift
+++ b/Tests/AnyDoorTests/MigrationTests.swift
@@ -52,6 +52,18 @@ final class BuiltinItemTests: XCTestCase {
         XCTAssertFalse(BuiltinItem.ocr.requiresAutomation)
         XCTAssertNil(BuiltinItem.ocr.feedbackSound)
     }
+
+    func testPickColorIsAnActionItem() {
+        XCTAssertEqual(BuiltinItem.pickColor.kind, .action)
+    }
+
+    func testPickColorMetadata() {
+        XCTAssertEqual(BuiltinItem.pickColor.title, "屏幕取色")
+        XCTAssertEqual(BuiltinItem.pickColor.symbol, "eyedropper")
+        XCTAssertEqual(BuiltinItem.pickColor.defaultOrder, 975)
+        XCTAssertFalse(BuiltinItem.pickColor.requiresAutomation)
+        XCTAssertNil(BuiltinItem.pickColor.feedbackSound)
+    }
 }
 
 final class KeyBindingOrderBackfillTests: XCTestCase {

--- a/docs/superpowers/plans/2026-05-22-pick-color.md
+++ b/docs/superpowers/plans/2026-05-22-pick-color.md
@@ -1,0 +1,504 @@
+# Pick Color Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a built-in screen color picker that shows the macOS system color loupe, copies the picked color to the clipboard as an uppercase HEX string, and confirms with a toast.
+
+**Architecture:** A new `BuiltinItem.pickColor` action item, backed by an `actor PickColorProvider` modeled on `OCRProvider`. The provider calls a `@MainActor ColorSampler` helper that wraps `NSColorSampler` (the system loupe) in `async`. Color-to-HEX conversion lives in a testable `NSColor` extension. The existing toast gains a `.color` style that shows a color swatch instead of an SF Symbol.
+
+**Tech Stack:** Swift 6.2 (strict concurrency, `.v6` language mode), AppKit (`NSColorSampler`, `NSColor`, `NSPasteboard`), SwiftUI (`Color`, toast view), XCTest.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `Sources/AnyDoor/Utilities/NSColor+Hex.swift` — `NSColor.sRGBHexString` computed property. Pure, testable color-to-HEX conversion.
+- `Sources/AnyDoor/Services/ColorSampler.swift` — `@MainActor enum ColorSampler` adapting `NSColorSampler`'s completion-handler API into `async`, returning a `Sendable` outcome.
+- `Sources/AnyDoor/Services/Providers/PickColorProvider.swift` — `actor PickColorProvider: ActionProvider`. Orchestrates loupe → clipboard → toast.
+- `Tests/AnyDoorTests/ColorHexTests.swift` — unit tests for `sRGBHexString`.
+
+**Modified files:**
+
+- `Sources/AnyDoor/Models/BuiltinItem.swift` — add the `.pickColor` catalog case.
+- `Sources/AnyDoor/Views/ToastView.swift` — add `ToastStyle.color` and a swatch branch in `ToastView`.
+- `Sources/AnyDoor/AppDelegate.swift` — register `PickColorProvider()`.
+- `Tests/AnyDoorTests/MigrationTests.swift` — extend `BuiltinItemTests` with `.pickColor` assertions.
+
+**Task dependency order:** Task 1 (hex) → Task 2 (catalog) → Task 3 (sampler, needs Task 1) → Task 4 (toast) → Task 5 (provider, needs Tasks 1-4) → Task 6 (manual verification).
+
+---
+
+## Task 1: NSColor → HEX conversion
+
+**Files:**
+- Create: `Sources/AnyDoor/Utilities/NSColor+Hex.swift`
+- Test: `Tests/AnyDoorTests/ColorHexTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnyDoorTests/ColorHexTests.swift`:
+
+```swift
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+final class ColorHexTests: XCTestCase {
+
+    func testBlackProducesAllZeroes() {
+        XCTAssertEqual(NSColor.black.sRGBHexString, "#000000")
+    }
+
+    func testWhiteProducesAllFs() {
+        XCTAssertEqual(NSColor.white.sRGBHexString, "#FFFFFF")
+    }
+
+    func testMidToneColorRoundsEachChannel() {
+        // 0.5*255=127.5→128 (0x80), 0.25*255=63.75→64 (0x40), 0.75*255=191.25→191 (0xBF)
+        let color = NSColor(srgbRed: 0.5, green: 0.25, blue: 0.75, alpha: 1)
+        XCTAssertEqual(color.sRGBHexString, "#8040BF")
+    }
+
+    func testComponentsOutsideUnitRangeAreClamped() {
+        // Wide-gamut conversions can yield components slightly outside 0...1.
+        // red 1.4 clamps to 1→FF, green -0.2 clamps to 0→00, blue 1.0→FF.
+        let color = NSColor(srgbRed: 1.4, green: -0.2, blue: 1.0, alpha: 1)
+        XCTAssertEqual(color.sRGBHexString, "#FF00FF")
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter ColorHexTests`
+Expected: FAIL — compile error `value of type 'NSColor' has no member 'sRGBHexString'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnyDoor/Utilities/NSColor+Hex.swift`:
+
+```swift
+import AppKit
+
+extension NSColor {
+    /// The color as an uppercase `"#RRGGBB"` string in the sRGB color space.
+    ///
+    /// Returns `nil` when the color cannot be converted to sRGB (e.g. pattern
+    /// colors). Each component is clamped to `0...1` before scaling — sampling
+    /// on wide-gamut displays can yield components slightly outside that range.
+    var sRGBHexString: String? {
+        guard let srgb = usingColorSpace(.sRGB) else { return nil }
+        func channel(_ value: CGFloat) -> Int {
+            Int((min(max(value, 0), 1) * 255).rounded())
+        }
+        return String(
+            format: "#%02X%02X%02X",
+            channel(srgb.redComponent),
+            channel(srgb.greenComponent),
+            channel(srgb.blueComponent)
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter ColorHexTests`
+Expected: PASS — 4 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Utilities/NSColor+Hex.swift Tests/AnyDoorTests/ColorHexTests.swift
+git commit -m "feat(color): add NSColor sRGB hex conversion"
+```
+
+---
+
+## Task 2: BuiltinItem.pickColor catalog entry
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/BuiltinItem.swift`
+- Test: `Tests/AnyDoorTests/MigrationTests.swift` (extend `BuiltinItemTests`)
+
+- [ ] **Step 1: Write the failing test**
+
+In `Tests/AnyDoorTests/MigrationTests.swift`, inside `final class BuiltinItemTests`, add these two methods after `testOCRMetadata()` (before the closing `}` of the class):
+
+```swift
+    func testPickColorIsAnActionItem() {
+        XCTAssertEqual(BuiltinItem.pickColor.kind, .action)
+    }
+
+    func testPickColorMetadata() {
+        XCTAssertEqual(BuiltinItem.pickColor.title, "屏幕取色")
+        XCTAssertEqual(BuiltinItem.pickColor.symbol, "eyedropper")
+        XCTAssertEqual(BuiltinItem.pickColor.defaultOrder, 975)
+        XCTAssertFalse(BuiltinItem.pickColor.requiresAutomation)
+        XCTAssertNil(BuiltinItem.pickColor.feedbackSound)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter BuiltinItemTests`
+Expected: FAIL — compile error `type 'BuiltinItem' has no member 'pickColor'`.
+
+- [ ] **Step 3: Add the enum case**
+
+In `Sources/AnyDoor/Models/BuiltinItem.swift`, add `case pickColor` immediately after `case ocr`:
+
+```swift
+    case ocr
+    case pickColor
+    case displaySleep
+```
+
+- [ ] **Step 4: Add `.pickColor` to the `kind` action group**
+
+In the `var kind: Kind` switch, replace the `.action` case:
+
+Old:
+```swift
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .displaySleep, .systemSleep,
+             .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+```
+
+New:
+```swift
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .pickColor, .displaySleep, .systemSleep,
+             .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+```
+
+- [ ] **Step 5: Add the `title` case**
+
+In `var title: String`, add after the `.ocr` line:
+
+```swift
+        case .ocr: return "屏幕取词"
+        case .pickColor: return "屏幕取色"
+```
+
+- [ ] **Step 6: Add the `symbol` case**
+
+In `var symbol: String`, add after the `.ocr` line:
+
+```swift
+        case .ocr: return "text.viewfinder"
+        case .pickColor: return "eyedropper"
+```
+
+- [ ] **Step 7: Add the `defaultOrder` case**
+
+In `var defaultOrder: Double`, add after the `.ocr` line:
+
+```swift
+        case .ocr: return 950
+        case .pickColor: return 975
+```
+
+Note: `requiresAutomation` and `feedbackSound` both have `default:` clauses, so they need no change — `.pickColor` falls through to `false` / `nil`.
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `swift test --filter BuiltinItemTests`
+Expected: PASS — `BuiltinItemTests` all pass, including `testAllCasesHaveDistinctOrder` (975 is unique between ocr 950 and displaySleep 1000).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/BuiltinItem.swift Tests/AnyDoorTests/MigrationTests.swift
+git commit -m "feat(panel): add pick-color builtin catalog entry"
+```
+
+---
+
+## Task 3: ColorSampler async loupe wrapper
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/ColorSampler.swift`
+
+No unit test: `NSColorSampler` presents real interactive system UI and cannot be exercised headlessly. Verified by compilation here and manually in Task 6.
+
+- [ ] **Step 1: Write the implementation**
+
+Create `Sources/AnyDoor/Services/ColorSampler.swift`:
+
+```swift
+import AppKit
+import SwiftUI
+
+/// Adapts `NSColorSampler`'s completion-handler API into `async`.
+///
+/// `NSColorSampler` presents the macOS system color-sampling loupe and must be
+/// used on the main thread. The picked `NSColor` is converted to `Sendable`
+/// values inside the completion handler so it never crosses an actor boundary.
+@MainActor
+enum ColorSampler {
+    /// The result of one color-sampling session.
+    enum Outcome: Sendable {
+        /// The user picked a color: `hex` is `"#RRGGBB"`, `swatch` previews it.
+        case picked(hex: String, swatch: Color)
+        /// A color was picked but could not be represented in sRGB.
+        case conversionFailed
+        /// The user dismissed the loupe without picking (e.g. pressed Escape).
+        case cancelled
+    }
+
+    /// Presents the system color loupe and waits for the user to pick a pixel
+    /// or cancel.
+    static func sample() async -> Outcome {
+        await withCheckedContinuation { continuation in
+            NSColorSampler().show { color in
+                guard let color else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+                guard let hex = color.sRGBHexString else {
+                    continuation.resume(returning: .conversionFailed)
+                    return
+                }
+                continuation.resume(
+                    returning: .picked(hex: hex, swatch: Color(nsColor: color))
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no warnings about `ColorSampler.swift`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/ColorSampler.swift
+git commit -m "feat(color): add ColorSampler async loupe wrapper"
+```
+
+---
+
+## Task 4: Color swatch toast style
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/ToastView.swift`
+
+No unit test: `ToastView` is a SwiftUI view; rendering is verified manually in Task 6. The change is build-verified here.
+
+- [ ] **Step 1: Replace the contents of `ToastView.swift`**
+
+`ToastStyle` gains a `.color` case and `ToastView` switches on the style for its leading element. The per-style `iconName` / `iconColor` accessors are removed (they were only ever used inside `ToastView`; confirm with the grep in Step 2).
+
+Replace the entire contents of `Sources/AnyDoor/Views/ToastView.swift` with:
+
+```swift
+import SwiftUI
+
+/// The status a toast reports. `Sendable` so it can cross provider actor →
+/// `ToastPresenter` (`@MainActor`) boundaries. `Color` is `Sendable`, so the
+/// `.color` swatch crosses the boundary unchanged.
+enum ToastStyle: Sendable {
+    case success(String)
+    case failure(String)
+    case color(message: String, swatch: Color)
+
+    var message: String {
+        switch self {
+        case .success(let text), .failure(let text):
+            return text
+        case .color(let message, _):
+            return message
+        }
+    }
+}
+
+/// A compact status pill: a leading icon or color swatch next to one line of text.
+struct ToastView: View {
+    let style: ToastStyle
+
+    var body: some View {
+        HStack(spacing: 8) {
+            leading
+            Text(verbatim: style.message)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: Capsule())
+        .fixedSize()
+    }
+
+    /// SF Symbol for success/failure; a bordered color swatch for `.color`.
+    @ViewBuilder
+    private var leading: some View {
+        switch style {
+        case .success:
+            symbol("checkmark.circle.fill", color: .green)
+        case .failure:
+            symbol("xmark.circle.fill", color: .red)
+        case .color(_, let swatch):
+            RoundedRectangle(cornerRadius: 4)
+                .fill(swatch)
+                .frame(width: 16, height: 16)
+                // Thin border keeps near-white swatches visible on the material.
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                )
+        }
+    }
+
+    private func symbol(_ name: String, color: Color) -> some View {
+        Image(systemName: name)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(color)
+    }
+}
+```
+
+- [ ] **Step 2: Verify no other file referenced the removed accessors**
+
+Run: `grep -rn "iconName\|iconColor" Sources/`
+Expected: no matches. (If any appear, they must be updated — but `ToastStyle` was the only definer and `ToastView` the only consumer.)
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` — `OCRProvider`'s existing `.success` / `.failure` calls still typecheck.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/ToastView.swift
+git commit -m "feat(toast): add color swatch toast style"
+```
+
+---
+
+## Task 5: PickColorProvider and registration
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Providers/PickColorProvider.swift`
+- Modify: `Sources/AnyDoor/AppDelegate.swift:44-63`
+
+No unit test: the provider drives interactive system UI (`NSColorSampler`) and writes the system pasteboard. Behavior is verified manually in Task 6; the full test suite is run here to confirm no regression.
+
+- [ ] **Step 1: Write the provider**
+
+Create `Sources/AnyDoor/Services/Providers/PickColorProvider.swift`:
+
+```swift
+import AppKit
+import Foundation
+
+/// Presents the macOS system color-sampling loupe, copies the picked color to
+/// the clipboard as an uppercase HEX string, and shows a bottom-center toast
+/// reporting the outcome.
+///
+/// Every error is absorbed and mapped to a toast — `run()` never propagates.
+actor PickColorProvider: ActionProvider {
+    let itemKey: BuiltinItem = .pickColor
+
+    var permission: PermissionStatus { .notRequired }
+
+    func run() async {
+        switch await ColorSampler.sample() {
+        case .cancelled:
+            return // user cancelled — silent, no toast
+        case .conversionFailed:
+            await ToastPresenter.shared.show(.failure("取色失败"))
+        case .picked(let hex, let swatch):
+            await MainActor.run {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(hex, forType: .string)
+            }
+            await ToastPresenter.shared.show(
+                .color(message: "已复制 \(hex)", swatch: swatch)
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register the provider in `AppDelegate`**
+
+In `Sources/AnyDoor/AppDelegate.swift`, add `PickColorProvider()` to the `providers` array. Replace:
+
+Old:
+```swift
+            KeyboardLockProvider(),
+            OCRProvider(),
+        ]
+```
+
+New:
+```swift
+            KeyboardLockProvider(),
+            OCRProvider(),
+            PickColorProvider(),
+        ]
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!`
+
+- [ ] **Step 4: Run the full test suite to confirm no regression**
+
+Run: `swift test`
+Expected: all tests pass. `PanelStoreTests.testTopLevelEntriesCount` and `MigrationTests` seeding tests derive counts from `BuiltinItem.allCases`, so the new case does not break them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Providers/PickColorProvider.swift Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(panel): add screen color picker action"
+```
+
+---
+
+## Task 6: Manual verification
+
+**Files:** none — runtime verification only.
+
+`NSColorSampler`, the system pasteboard, and the toast window cannot be exercised by the headless test suite. Verify the feature by running the app.
+
+- [ ] **Step 1: Launch the app**
+
+Run: `swift run AnyDoor`
+Expected: the menu bar icon appears. Grant Accessibility permission if prompted (System Settings → Privacy & Security → Accessibility).
+
+- [ ] **Step 2: Verify the panel row**
+
+Open the menu bar panel. Expected: a `屏幕取色` row with an eyedropper icon appears, positioned just below `屏幕取词` (OCR).
+
+- [ ] **Step 3: Verify a successful pick**
+
+Click `屏幕取色`. Expected: the system color loupe appears. Hover over a known-color region (e.g. a pure-red swatch) and click. Expected: a bottom-center toast shows a color swatch plus `已复制 #RRGGBB`. Paste into a text field and confirm the clipboard holds that exact uppercase HEX string.
+
+- [ ] **Step 4: Verify cancellation**
+
+Click `屏幕取色`, then press Escape while the loupe is showing. Expected: no toast, and the clipboard is unchanged.
+
+- [ ] **Step 5: Verify the hotkey path**
+
+In the panel settings (`面板` tab), record a hotkey for `屏幕取色`. Close settings, press the hotkey. Expected: the loupe appears exactly as it does from the panel row.
+
+- [ ] **Step 6: Report**
+
+Report the results of Steps 2-5. If all pass, the feature is complete.
+
+---
+
+## Notes on spec deviations
+
+- The spec (`docs/superpowers/specs/2026-05-22-pick-color-design.md`) places the `NSColor` → HEX conversion inside `PickColorProvider`. This plan moves it into `ColorSampler` (on `@MainActor`) because `NSColor` is not `Sendable` and cannot cross from `ColorSampler` (`@MainActor`) to `PickColorProvider` (an `actor`). `ColorSampler.sample()` returns a `Sendable` `Outcome` enum that preserves the spec's three outcomes (picked / conversion-failed / cancelled), so the provider still owns every clipboard and toast decision. Behavior matches the spec exactly.
+- The swatch border uses `Color(nsColor: .separatorColor)` — the system separator color — rather than an unspecified stroke; this is the concrete realization of the spec's "thin `.separator` stroke".

--- a/docs/superpowers/specs/2026-05-22-pick-color-design.md
+++ b/docs/superpowers/specs/2026-05-22-pick-color-design.md
@@ -1,0 +1,159 @@
+# Pick Color — Design
+
+## Goal
+
+Add a built-in **screen color picker** to AnyDoor's panel. Activating it shows
+the macOS system color-sampling loupe (the same magnifier used by SwiftUI's
+`ColorPicker` eyedropper). The user clicks a pixel on screen, the color is
+copied to the clipboard as an uppercase HEX string, and a bottom-center toast
+confirms the result.
+
+## Background
+
+The panel already ships one capture-style action, `OCRProvider` (`屏幕取词`),
+which uses `RegionCapture` + `TextRecognizer`, copies to the clipboard, and
+reports via `ToastPresenter`. Pick Color follows the same shape but is simpler:
+the loupe, clipboard write, and cancellation handling are all provided by a
+single native API.
+
+## Approach
+
+Use **`NSColorSampler`** (AppKit, macOS 10.15+). It presents the system loupe,
+returns an `NSColor?` via a completion handler, and yields `nil` when the user
+cancels. It runs as a system service and does not require the app to hold
+Screen Recording permission. No custom overlay window or `screencapture`
+invocation is needed.
+
+Alternatives rejected: a hand-built overlay loupe (large effort, worse UX,
+needs Screen Recording permission); `screencapture -i` pixel sampling (region
+selection, not a magnifier — wrong interaction).
+
+## Components
+
+### 1. `BuiltinItem.pickColor`
+
+New case in the code-defined catalog (`Models/BuiltinItem.swift`):
+
+- `kind`: `.action`
+- `title`: `"屏幕取色"`
+- `symbol`: `"eyedropper"`
+- `defaultOrder`: `975` (between `ocr` 950 and `displaySleep` 1000)
+- `requiresAutomation`: `false`
+- `feedbackSound`: `nil`
+
+`BuiltinPreferenceSeeder` already diffs `BuiltinItem.allCases` against existing
+rows on every launch and appends new items at the end, so existing users get a
+`BuiltinPreference` row automatically — visibility, ordering, and hotkey
+support come for free.
+
+### 2. `ColorSampler` — new file `Services/ColorSampler.swift`
+
+`@MainActor` helper that adapts `NSColorSampler`'s completion-handler API into
+`async`. `NSColorSampler` must be used on the main thread.
+
+```swift
+@MainActor
+enum ColorSampler {
+    /// Presents the system color loupe. Returns nil when the user cancels.
+    static func sample() async -> NSColor? {
+        await withCheckedContinuation { continuation in
+            NSColorSampler().show { color in
+                continuation.resume(returning: color)
+            }
+        }
+    }
+}
+```
+
+### 3. `PickColorProvider` — new file `Services/Providers/PickColorProvider.swift`
+
+An `actor` conforming to `ActionProvider`, modeled on `OCRProvider`:
+
+- `itemKey`: `.pickColor`
+- `permission`: `.notRequired`
+- `run()` (absorbs all errors, never propagates — declared `async`, not
+  `async throws`):
+  1. `await ColorSampler.sample()` — if `nil`, return silently (user cancelled).
+  2. Convert the `NSColor` to the sRGB color space via
+     `usingColorSpace(.sRGB)`. If that fails, show a failure toast.
+  3. Read `redComponent` / `greenComponent` / `blueComponent` (0...1), scale to
+     0...255 with rounding, and format as `#RRGGBB` uppercase
+     (`String(format: "#%02X%02X%02X", r, g, b)`).
+  4. On `MainActor`, write the HEX string to `NSPasteboard.general`
+     (`clearContents()` then `setString(_:forType:.string)`).
+  5. Show a success toast: `.color(message: "已复制 \(hex)", swatch: swatchColor)`,
+     where `swatchColor` is `Color(.sRGB, red:, green:, blue:)` built from the
+     same components.
+
+### 4. Toast extension — `Views/ToastView.swift`
+
+`ToastStyle` gains a third case:
+
+```swift
+case color(message: String, swatch: Color)
+```
+
+`Color` conforms to `Sendable`, so the style still crosses the
+provider-actor → `ToastPresenter`-`MainActor` boundary unchanged.
+
+`ToastView` is restructured to switch on the style for its leading element:
+
+- `.success` / `.failure`: SF Symbol image (current behavior — green
+  checkmark / red x).
+- `.color`: a 16×16 rounded-rectangle swatch filled with `swatch`, with a thin
+  `.separator` stroke so light/near-white colors stay visible against the
+  toast's material background.
+
+The `message` accessor stays exhaustive over all three cases. The per-style
+icon name/color logic moves inline into the `ToastView` leading-element switch
+(it no longer needs to be exhaustive over a case that has no SF Symbol).
+
+`ToastPresenter` needs no changes — it already sizes itself to the hosting
+view's `fittingSize`, so a slightly wider color toast lays out correctly.
+
+### 5. Registration — `AppDelegate.swift`
+
+Append `PickColorProvider()` to the `providers` array in
+`applicationDidFinishLaunching`.
+
+## Data Flow
+
+```
+Panel row click / hotkey
+  └─> PanelStore.run(.pickColor)            (actionsInFlight guard)
+        └─> PickColorProvider.run()
+              ├─> ColorSampler.sample()      (MainActor, system loupe)
+              │     └─> nil  → return silently (cancelled)
+              ├─> NSColor → sRGB → "#RRGGBB"
+              ├─> NSPasteboard.general.setString(hex)   (MainActor)
+              └─> ToastPresenter.show(.color(...))       (MainActor)
+```
+
+## Error Handling
+
+Consistent with `OCRProvider`:
+
+- **Cancellation** (`NSColorSampler` returns `nil`): silent, no toast.
+- **Color-space conversion failure**: failure toast `"取色失败"`.
+- `run()` never throws; every failure path resolves to a toast or a silent
+  return. `PanelStore.run` already guards against overlapping invocations via
+  `actionsInFlight`.
+
+## Testing
+
+- Manual: build with `swift run AnyDoor`, open the panel, trigger 屏幕取色,
+  pick a known color (e.g. pure red), confirm the clipboard holds `#FF0000`
+  and the toast shows the value plus a matching swatch.
+- Manual: press Esc during sampling — confirm no toast and no clipboard change.
+- Manual: assign a hotkey in the panel settings and confirm it triggers the
+  loupe.
+- The HEX-formatting conversion (`NSColor` sRGB components → `#RRGGBB`) is the
+  only pure logic worth a unit test; if extracted into a small testable
+  function, cover black, white, and a mid-tone value.
+
+## Out of Scope
+
+- Color formats other than uppercase HEX (RGB/HSL, lowercase) — single format
+  by decision.
+- Color history or a recently-picked palette.
+- A settings UI for choosing the output format.


### PR DESCRIPTION
## Summary

Adds a **screen color picker** built-in panel action ("屏幕取色"). Activating it shows the macOS system color-sampling loupe (`NSColorSampler` — the same magnifier SwiftUI's `ColorPicker` eyedropper uses); the picked color is copied to the clipboard as an uppercase `#RRGGBB` HEX string, and a toast confirms with the value plus a matching color swatch. Cancelling the loupe (Escape) is silent.

## Implementation

- `Utilities/NSColor+Hex.swift` — `NSColor` → uppercase `#RRGGBB` sRGB conversion, with per-channel clamping for wide-gamut input.
- `Models/BuiltinItem.swift` — new `.pickColor` action case in the catalog (eyedropper icon, order 975).
- `Services/ColorSampler.swift` — `@MainActor` wrapper adapting `NSColorSampler`'s completion-handler API into `async`, returning a `Sendable` `Outcome` so it can cross into the provider actor.
- `Views/ToastView.swift` — new `ToastStyle.color` style rendering a bordered color swatch; per-style icon logic refactored into a `leading` view builder.
- `Services/Providers/PickColorProvider.swift` — `actor` orchestrating loupe → clipboard → toast, modeled on `OCRProvider`.
- `AppDelegate.swift` — registers the provider.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] Unit tests for HEX conversion: black, white, mid-tone rounding, out-of-range clamping, nil path — 5 tests
- [x] `swift build` clean; full suite 66 tests pass
- [x] Panel shows the 屏幕取色 row (eyedropper icon) below 屏幕取词
- [x] Pick a known color → clipboard holds the exact `#RRGGBB`; toast shows value + matching swatch
- [x] Press Escape during sampling → no toast, clipboard unchanged
- [x] Assigned hotkey triggers the loupe