### PR TITLE
feat(settings): add menu bar icon visibility and picker

### DIFF
--- a/Sources/AnyDoor/AnyDoor.swift
+++ b/Sources/AnyDoor/AnyDoor.swift
@@ -5,8 +5,11 @@ import SwiftData
 struct AnyDoorApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    @AppStorage(MenuBarIcon.visibilityKey) private var iconVisible = true
+    @AppStorage(MenuBarIcon.nameKey) private var iconName = MenuBarIcon.defaultName
+
     var body: some Scene {
-        MenuBarExtra("AnyDoor", systemImage: "door.left.hand.open") {
+        MenuBarExtra("AnyDoor", systemImage: iconName, isInserted: $iconVisible) {
             MenuBarView()
                 .modelContainer(appDelegate.modelContainer)
         }

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -81,6 +81,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         HotkeyService.shared.stop()
     }
 
+    /// When the icon is hidden the menu bar item disappears and the app keeps
+    /// the `.accessory` policy (no Dock icon). Re-launching AnyDoor from
+    /// Finder/Spotlight lands here; with no visible window, re-open Settings so
+    /// the user can turn the icon back on.
+    @MainActor
+    func applicationShouldHandleReopen(_ sender: NSApplication,
+                                       hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        }
+        return true
+    }
+
     /// Hot-reload entry point used by views after data changes.
     @MainActor
     func refreshBindings() {

--- a/Sources/AnyDoor/Models/MenuBarIcon.swift
+++ b/Sources/AnyDoor/Models/MenuBarIcon.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Storage keys, default value, and the catalog of SF Symbols offered for the
+/// menu bar icon. Consumed by `AnyDoorApp` (keys + default) and
+/// `GeneralSettingsView` (the picker).
+enum MenuBarIcon {
+    /// UserDefaults key for whether the menu bar item is shown.
+    static let visibilityKey = "menuBar.iconVisible"
+
+    /// UserDefaults key for the selected SF Symbol name.
+    static let nameKey = "menuBar.iconName"
+
+    /// Default icon — matches the symbol the app originally shipped with.
+    static let defaultName = "door.left.hand.open"
+
+    /// Ordered SF Symbol names offered in the picker. Door theme, on-brand
+    /// with the "AnyDoor" name.
+    static let options: [String] = [
+        "door.left.hand.open",
+        "door.left.hand.closed",
+        "door.right.hand.open",
+        "door.sliding.right.hand.open",
+        "door.garage.open",
+        "door.french.open",
+    ]
+}

--- a/Sources/AnyDoor/Models/MenuBarIcon.swift
+++ b/Sources/AnyDoor/Models/MenuBarIcon.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Storage keys, default value, and the catalog of SF Symbols offered for the
 /// menu bar icon. Consumed by `AnyDoorApp` (keys + default) and
 /// `GeneralSettingsView` (the picker).

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -10,6 +10,8 @@ struct GeneralSettingsView: View {
     @State private var launchAtLogin = LaunchAtLogin.isEnabled
     @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
     @State private var automationGranted = false
+    @AppStorage(MenuBarIcon.visibilityKey) private var menuBarIconVisible = true
+    @AppStorage(MenuBarIcon.nameKey) private var menuBarIconName = MenuBarIcon.defaultName
 
     var body: some View {
         Form {
@@ -28,6 +30,19 @@ struct GeneralSettingsView: View {
                     }
             } header: {
                 Text("启动")
+            }
+
+            Section("菜单栏") {
+                Toggle("显示菜单栏图标", isOn: $menuBarIconVisible)
+
+                LabeledContent("菜单栏图标") {
+                    HStack(spacing: 8) {
+                        ForEach(MenuBarIcon.options, id: \.self) { name in
+                            iconSwatch(name)
+                        }
+                    }
+                }
+                .disabled(!menuBarIconVisible)
             }
 
             Section("权限") {
@@ -91,6 +106,32 @@ struct GeneralSettingsView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func iconSwatch(_ name: String) -> some View {
+        let isSelected = menuBarIconName == name
+        Button {
+            menuBarIconName = name
+        } label: {
+            Image(systemName: name)
+                .font(.system(size: 16))
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(
+                            isSelected ? Color.accentColor : Color.secondary.opacity(0.3),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                )
+                .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+        }
+        .buttonStyle(.plain)
+        .help(name)
     }
 
     private func openAccessibilitySettings() {

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -108,10 +108,9 @@ struct GeneralSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private func iconSwatch(_ name: String) -> some View {
         let isSelected = menuBarIconName == name
-        Button {
+        return Button {
             menuBarIconName = name
         } label: {
             Image(systemName: name)

--- a/Tests/AnyDoorTests/MenuBarIconTests.swift
+++ b/Tests/AnyDoorTests/MenuBarIconTests.swift
@@ -19,5 +19,7 @@ final class MenuBarIconTests: XCTestCase {
 
     func testStorageKeysAreDistinct() {
         XCTAssertNotEqual(MenuBarIcon.visibilityKey, MenuBarIcon.nameKey)
+        XCTAssertEqual(MenuBarIcon.visibilityKey, "menuBar.iconVisible")
+        XCTAssertEqual(MenuBarIcon.nameKey, "menuBar.iconName")
     }
 }

--- a/Tests/AnyDoorTests/MenuBarIconTests.swift
+++ b/Tests/AnyDoorTests/MenuBarIconTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import AnyDoor
+
+final class MenuBarIconTests: XCTestCase {
+    func testDefaultNameIsSelectable() {
+        XCTAssertTrue(
+            MenuBarIcon.options.contains(MenuBarIcon.defaultName),
+            "Default icon must appear in the offered options so the picker can show it as selected"
+        )
+    }
+
+    func testOptionsHaveNoDuplicates() {
+        XCTAssertEqual(
+            Set(MenuBarIcon.options).count,
+            MenuBarIcon.options.count,
+            "Icon options must be unique"
+        )
+    }
+
+    func testStorageKeysAreDistinct() {
+        XCTAssertNotEqual(MenuBarIcon.visibilityKey, MenuBarIcon.nameKey)
+    }
+}

--- a/docs/superpowers/plans/2026-05-22-menu-bar-icon-settings.md
+++ b/docs/superpowers/plans/2026-05-22-menu-bar-icon-settings.md
@@ -1,0 +1,350 @@
+# Menu Bar Icon Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user show/hide AnyDoor's menu bar icon and pick which system SF Symbol it displays, from the General settings tab.
+
+**Architecture:** Two scalar preferences (`Bool` + `String`) stored in `UserDefaults` via `@AppStorage`. The `App` struct reads them to drive `MenuBarExtra`'s `isInserted` binding and dynamic `systemImage`. A new `MenuBarIcon` value type owns the storage keys, default, and icon catalog. `AppDelegate` gains `applicationShouldHandleReopen` so re-launching the app re-opens Settings after the icon is hidden.
+
+**Tech Stack:** Swift 6.2, SwiftUI (`MenuBarExtra`, `@AppStorage`), AppKit (`NSApplicationDelegate`), XCTest, SPM.
+
+---
+
+## File Structure
+
+- **Create** `Sources/AnyDoor/Models/MenuBarIcon.swift` — storage key constants, default icon name, ordered SF Symbol catalog.
+- **Create** `Tests/AnyDoorTests/MenuBarIconTests.swift` — unit tests for the catalog invariants.
+- **Modify** `Sources/AnyDoor/AnyDoor.swift` — add `@AppStorage` properties, change `MenuBarExtra` to use dynamic `systemImage` + `isInserted`.
+- **Modify** `Sources/AnyDoor/AppDelegate.swift` — add `applicationShouldHandleReopen`.
+- **Modify** `Sources/AnyDoor/Views/GeneralSettingsView.swift` — add a "菜单栏" section with the visibility toggle and icon swatch row.
+
+---
+
+## Task 1: `MenuBarIcon` catalog type
+
+**Files:**
+- Create: `Sources/AnyDoor/Models/MenuBarIcon.swift`
+- Test: `Tests/AnyDoorTests/MenuBarIconTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnyDoorTests/MenuBarIconTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class MenuBarIconTests: XCTestCase {
+    func testDefaultNameIsSelectable() {
+        XCTAssertTrue(
+            MenuBarIcon.options.contains(MenuBarIcon.defaultName),
+            "Default icon must appear in the offered options so the picker can show it as selected"
+        )
+    }
+
+    func testOptionsHaveNoDuplicates() {
+        XCTAssertEqual(
+            Set(MenuBarIcon.options).count,
+            MenuBarIcon.options.count,
+            "Icon options must be unique"
+        )
+    }
+
+    func testStorageKeysAreDistinct() {
+        XCTAssertNotEqual(MenuBarIcon.visibilityKey, MenuBarIcon.nameKey)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter MenuBarIconTests`
+Expected: FAIL — compile error, `cannot find 'MenuBarIcon' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Sources/AnyDoor/Models/MenuBarIcon.swift`:
+
+```swift
+import Foundation
+
+/// Storage keys, default value, and the catalog of SF Symbols offered for the
+/// menu bar icon. Consumed by `AnyDoorApp` (keys + default) and
+/// `GeneralSettingsView` (the picker).
+enum MenuBarIcon {
+    /// UserDefaults key for whether the menu bar item is shown.
+    static let visibilityKey = "menuBar.iconVisible"
+
+    /// UserDefaults key for the selected SF Symbol name.
+    static let nameKey = "menuBar.iconName"
+
+    /// Default icon — matches the symbol the app originally shipped with.
+    static let defaultName = "door.left.hand.open"
+
+    /// Ordered SF Symbol names offered in the picker. Door theme, on-brand
+    /// with the "AnyDoor" name.
+    static let options: [String] = [
+        "door.left.hand.open",
+        "door.left.hand.closed",
+        "door.right.hand.open",
+        "door.sliding.right.hand.open",
+        "door.garage.open",
+        "door.french.open",
+    ]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter MenuBarIconTests`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/MenuBarIcon.swift Tests/AnyDoorTests/MenuBarIconTests.swift
+git commit -m "feat(menubar): add MenuBarIcon catalog and storage keys"
+```
+
+---
+
+## Task 2: Dynamic menu bar icon and visibility
+
+**Files:**
+- Modify: `Sources/AnyDoor/AnyDoor.swift`
+
+- [ ] **Step 1: Replace the file contents**
+
+Overwrite `Sources/AnyDoor/AnyDoor.swift` with:
+
+```swift
+import SwiftUI
+import SwiftData
+
+@main
+struct AnyDoorApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    @AppStorage(MenuBarIcon.visibilityKey) private var iconVisible = true
+    @AppStorage(MenuBarIcon.nameKey) private var iconName = MenuBarIcon.defaultName
+
+    var body: some Scene {
+        MenuBarExtra("AnyDoor", systemImage: iconName, isInserted: $iconVisible) {
+            MenuBarView()
+                .modelContainer(appDelegate.modelContainer)
+        }
+        .menuBarExtraStyle(.window)
+
+        Settings {
+            SettingsView()
+                .modelContainer(appDelegate.modelContainer)
+        }
+    }
+}
+```
+
+Note: `@AppStorage` defaults (`true`, `MenuBarIcon.defaultName`) apply only when
+the key is absent, so existing installs and fresh launches both start with a
+visible `door.left.hand.open` icon. When either stored value changes, the `App`
+body recomputes and `MenuBarExtra` swaps its symbol or inserts/removes itself.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/AnyDoor.swift
+git commit -m "feat(menubar): drive menu bar icon from stored preferences"
+```
+
+---
+
+## Task 3: Re-open Settings after the icon is hidden
+
+**Files:**
+- Modify: `Sources/AnyDoor/AppDelegate.swift`
+
+- [ ] **Step 1: Add the reopen handler**
+
+In `Sources/AnyDoor/AppDelegate.swift`, insert this method immediately after the
+existing `applicationWillTerminate(_:)` method (which currently ends at the
+`}` closing the `HotkeyService.shared.stop()` body):
+
+```swift
+    /// When the icon is hidden the menu bar item disappears and the app keeps
+    /// the `.accessory` policy (no Dock icon). Re-launching AnyDoor from
+    /// Finder/Spotlight lands here; with no visible window, re-open Settings so
+    /// the user can turn the icon back on.
+    @MainActor
+    func applicationShouldHandleReopen(_ sender: NSApplication,
+                                       hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        }
+        return true
+    }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(menubar): reopen Settings on relaunch when icon is hidden"
+```
+
+---
+
+## Task 4: Menu bar section in General settings
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/GeneralSettingsView.swift`
+
+- [ ] **Step 1: Add the `@AppStorage` properties**
+
+In `Sources/AnyDoor/Views/GeneralSettingsView.swift`, the struct currently
+declares three `@State` properties:
+
+```swift
+    @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
+    @State private var automationGranted = false
+```
+
+Add two `@AppStorage` properties directly below them:
+
+```swift
+    @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var accessibilityGranted = HotkeyService.hasAccessibilityPermission
+    @State private var automationGranted = false
+    @AppStorage(MenuBarIcon.visibilityKey) private var menuBarIconVisible = true
+    @AppStorage(MenuBarIcon.nameKey) private var menuBarIconName = MenuBarIcon.defaultName
+```
+
+- [ ] **Step 2: Add the menu bar section to the Form**
+
+In the same file, the `Form` currently contains the `启动` section followed by
+the `权限` section. Insert a new section between them. The `启动` section ends
+with:
+
+```swift
+            } header: {
+                Text("启动")
+            }
+
+            Section("权限") {
+```
+
+Replace that exact text with:
+
+```swift
+            } header: {
+                Text("启动")
+            }
+
+            Section("菜单栏") {
+                Toggle("显示菜单栏图标", isOn: $menuBarIconVisible)
+
+                LabeledContent("菜单栏图标") {
+                    HStack(spacing: 8) {
+                        ForEach(MenuBarIcon.options, id: \.self) { name in
+                            iconSwatch(name)
+                        }
+                    }
+                }
+                .disabled(!menuBarIconVisible)
+            }
+
+            Section("权限") {
+```
+
+- [ ] **Step 3: Add the `iconSwatch` helper**
+
+In the same file, add this method inside the struct, immediately before the
+existing `private func openAccessibilitySettings()` method:
+
+```swift
+    @ViewBuilder
+    private func iconSwatch(_ name: String) -> some View {
+        let isSelected = menuBarIconName == name
+        Button {
+            menuBarIconName = name
+        } label: {
+            Image(systemName: name)
+                .font(.system(size: 16))
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(
+                            isSelected ? Color.accentColor : Color.secondary.opacity(0.3),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                )
+                .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+        }
+        .buttonStyle(.plain)
+        .help(name)
+    }
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/GeneralSettingsView.swift
+git commit -m "feat(settings): add menu bar icon visibility and picker"
+```
+
+---
+
+## Task 5: Manual verification
+
+**Files:** none (manual run).
+
+- [ ] **Step 1: Build and run**
+
+Run: `swift run AnyDoor`
+Expected: app launches, menu bar shows the `door.left.hand.open` icon.
+
+- [ ] **Step 2: Verify the icon picker**
+
+Open Settings → 通用 tab. In the new "菜单栏" section, click each icon swatch.
+Expected: the selected swatch highlights with the accent color, and the menu
+bar icon updates to the chosen symbol immediately.
+
+- [ ] **Step 3: Verify hide / show**
+
+Toggle "显示菜单栏图标" off.
+Expected: the menu bar icon disappears, and the icon swatch row becomes
+disabled (greyed out). Toggle it back on — the icon returns.
+
+- [ ] **Step 4: Verify the reopen fallback**
+
+With "显示菜单栏图标" still off and the Settings window closed, re-launch
+AnyDoor from Finder or Spotlight (the running instance, not a second copy).
+Expected: the Settings window re-opens so the icon can be turned back on.
+
+- [ ] **Step 5: Verify persistence**
+
+Quit AnyDoor and run `swift run AnyDoor` again.
+Expected: the previously chosen icon and visibility state are restored.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `swift test`
+Expected: all tests pass, including `MenuBarIconTests`.

--- a/docs/superpowers/specs/2026-05-22-menu-bar-icon-settings-design.md
+++ b/docs/superpowers/specs/2026-05-22-menu-bar-icon-settings-design.md
@@ -1,0 +1,155 @@
+# Menu Bar Icon Settings — Design
+
+## Goal
+
+Add two user-facing controls to the General settings tab:
+
+1. **Show menu bar icon** — toggle the visibility of AnyDoor's menu bar item.
+2. **Menu bar icon** — pick which system SF Symbol the menu bar item displays.
+
+## Context
+
+- `MenuBarExtra` is declared in `Sources/AnyDoor/AnyDoor.swift` with a hardcoded
+  `systemImage: "door.left.hand.open"`.
+- The app uses the `.accessory` activation policy: no Dock icon. The menu bar
+  item is the only entry point to the panel and the Settings window.
+- Settings live under the "通用" (General) tab — `GeneralSettingsView`.
+- The project persists relational data (`KeyBinding`, `BuiltinPreference`) in
+  SwiftData, but already uses `UserDefaults` for simpler state (`PortInventory`).
+
+## Decisions
+
+### Storage: `@AppStorage` / UserDefaults
+
+The two preferences are scalars (a `Bool` and a `String`), not relational data.
+`@AppStorage` lets the `App` struct read them directly and re-render
+`MenuBarExtra` on change. Adding a SwiftData `@Model` would require a schema
+change to `ModelContainer` and cross-context reads — overkill here.
+
+Keys:
+
+| Key | Type | Default |
+|-----|------|---------|
+| `menuBar.iconVisible` | `Bool` | `true` |
+| `menuBar.iconName` | `String` | `door.left.hand.open` |
+
+The `iconName` default matches the current hardcoded value, so existing
+installs see no change.
+
+### Icon picker UI: horizontal swatch row
+
+Only ~6 door-themed icons are offered. A horizontal row of selectable icon
+buttons shows every option at once, which suits "pick an icon" better than a
+`.menu` Picker that hides options behind a click.
+
+### Re-access fallback when the icon is hidden
+
+When `menuBar.iconVisible` is `false`, the menu bar item disappears entirely.
+Because the app stays `.accessory` (no Dock icon), the user would otherwise
+have no way back into Settings.
+
+Fallback: implement `applicationShouldHandleReopen(_:hasVisibleWindows:)` in
+`AppDelegate`. Re-launching AnyDoor from Finder/Spotlight while it is already
+running — and has no visible window — re-opens the Settings window via the
+`showSettingsWindow:` action. The activation policy stays `.accessory`; no Dock
+icon is ever shown.
+
+## Components
+
+### `MenuBarIcon` (new, `Sources/AnyDoor/Models/`)
+
+A small value type that owns:
+
+- The `UserDefaults` key constants (`menuBar.iconVisible`, `menuBar.iconName`).
+- The default icon name (`door.left.hand.open`).
+- The ordered list of selectable icons (SF Symbol names).
+
+Icon set (system SF Symbols, door theme, on-brand with "AnyDoor"):
+
+```
+door.left.hand.open
+door.left.hand.closed
+door.right.hand.open
+door.sliding.right.hand.open
+door.garage.open
+door.french.open
+```
+
+This type is consumed only by `GeneralSettingsView` (for the picker) and
+referenced by `AnyDoorApp` (for the key/default constants).
+
+### `AnyDoorApp` (modified, `AnyDoor.swift`)
+
+- Add `@AppStorage` properties for `iconVisible` and `iconName`, using the
+  `MenuBarIcon` key constants and defaults.
+- Change the `MenuBarExtra` initializer to:
+
+  ```swift
+  MenuBarExtra("AnyDoor", systemImage: iconName, isInserted: $iconVisible)
+  ```
+
+  When the stored values change, the `App` body recomputes: `MenuBarExtra`
+  swaps its symbol and inserts/removes itself from the menu bar.
+
+### `GeneralSettingsView` (modified)
+
+Add a new `Section("菜单栏")` above the existing permissions section:
+
+- `Toggle("显示菜单栏图标", isOn:)` bound to `@AppStorage("menuBar.iconVisible")`.
+- A labeled row "菜单栏图标" containing the horizontal icon swatch row, bound to
+  `@AppStorage("menuBar.iconName")`. Each swatch is a tappable
+  `Image(systemName:)`; the selected swatch is highlighted (accent-tinted
+  background / border). The whole row is `.disabled` when the toggle is off.
+
+### `AppDelegate` (modified)
+
+Add:
+
+```swift
+func applicationShouldHandleReopen(_ sender: NSApplication,
+                                   hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+    return true
+}
+```
+
+This opens Settings whenever the app is re-launched with no visible window —
+the path back in after the menu bar icon is hidden.
+
+## Data Flow
+
+1. User toggles "显示菜单栏图标" or picks an icon in `GeneralSettingsView`.
+2. `@AppStorage` writes the value to `UserDefaults`.
+3. `AnyDoorApp`'s `@AppStorage` observes the change; the `App` body recomputes.
+4. `MenuBarExtra` updates its `systemImage` / `isInserted` state — the menu bar
+   icon changes or disappears immediately.
+
+## Error Handling
+
+- No failure paths: `UserDefaults` reads/writes do not throw.
+- Defaults guarantee a valid icon name and a visible icon on first launch and
+  if the stored value is ever missing.
+- If a stored `iconName` is somehow not in the offered set, the swatch row
+  simply shows no selection; the `MenuBarExtra` still renders whatever symbol
+  string is stored. (Not expected in practice — the picker only writes known
+  values.)
+
+## Testing
+
+Manual verification (no automated UI tests in this project):
+
+- Toggle off → menu bar icon disappears; toggle on → it returns.
+- Pick each icon → menu bar symbol updates immediately.
+- With the icon hidden, re-launch AnyDoor from Finder → Settings window opens.
+- Restart the app → chosen icon and visibility persist.
+- Fresh install (no stored values) → icon is visible and shows
+  `door.left.hand.open`.
+
+## Out of Scope
+
+- Custom / user-supplied images for the menu bar icon.
+- Showing a Dock icon as an alternative entry point.
+- Any change to the menu bar panel content or the Settings tab layout beyond
+  the new section.


### PR DESCRIPTION
## Summary

- Add a "菜单栏" section to the General settings tab with a "显示菜单栏图标" toggle and an icon picker (a horizontal row of door-themed SF Symbol swatches).
- Drive `MenuBarExtra` from two `@AppStorage` preferences (`menuBar.iconVisible`, `menuBar.iconName`) so visibility and icon update live; defaults preserve the previously hardcoded `door.left.hand.open` behavior.
- Add `applicationShouldHandleReopen` so re-launching AnyDoor re-opens Settings when the menu bar icon is hidden — the app keeps `.accessory` policy (no Dock icon).
- New `MenuBarIcon` enum centralizes the storage keys, default, and icon catalog; covered by `MenuBarIconTests`.

## Test Plan

- [x] `swift build` succeeds
- [x] `swift test` — all 69 tests pass (incl. 3 new `MenuBarIconTests`)
- [x] App launches without startup crash
- [x] Pick each icon swatch → menu bar icon updates immediately
- [x] Toggle "显示菜单栏图标" off → icon disappears and the swatch row disables; toggle on → icon returns
- [x] With the icon hidden and Settings closed, re-launch AnyDoor from Finder/Spotlight → Settings window re-opens
- [x] Quit and relaunch → chosen icon and visibility persist