### PR TITLE
Replace MenuBarExtra with a managed NSStatusItem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AnyDoor
+
+macOS 菜单栏应用，通过全局快捷键一键切换（打开/隐藏）指定应用程序。
+
+## 技术栈
+
+- Swift 6.2，严格并发模式 (`.swiftLanguageMode(.v6)`)
+- macOS 26+ (Tahoe)
+- SwiftUI (`MenuBarExtra` + `Settings`)
+- SwiftData 持久化
+- CGEvent tap 全局热键监听
+- SPM 构建
+
+## 构建和运行
+
+```bash
+# 构建
+swift build
+
+# 运行（开发模式，进程身份不带 Bundle ID）
+swift run AnyDoor
+
+# Release 构建
+swift build -c release
+
+# 安装为 /Applications/AnyDoor.app（写入 Info.plist，Bundle ID = dev.bybee.AnyDoor）
+make install
+
+# 卸载
+make uninstall
+
+# 热重载开发（需要 watchexec）
+make
+```
+
+运行需要 macOS 辅助功能权限（系统设置 → 隐私与安全性 → 辅助功能）。
+
+`swift run` 和 `make install` 后的 `.app` 是**两个不同的进程身份**，需要分别授权辅助功能。生产使用走 `make install`；日常开发用 `swift run`。SwiftData 存储路径已被固定，两种方式共享同一份数据（见下文）。
+
+## 项目结构
+
+```
+Sources/AnyDoor/
+├── AnyDoor.swift              # @main, MenuBarExtra + Settings Scene
+├── AppDelegate.swift           # ModelContainer, providers registry, HotkeyService bootstrap
+├── Models/
+│   ├── KeyBinding.swift        # App shortcut bindings (SwiftData)
+│   ├── BuiltinItem.swift       # Code-defined catalog of system toggle/action items
+│   ├── BuiltinPreference.swift # User customization (visibility / order / hotkey) for built-ins
+│   ├── PanelEntry.swift        # Unified view model + HotkeyDescriptor + PermissionStatus
+│   └── HotkeyAction.swift      # HotkeyAction enum + HotkeySnapshot
+├── Services/
+│   ├── HotkeyService.swift     # CGEvent tap, dispatches HotkeyAction via injected closure
+│   ├── PanelStore.swift        # @Observable, merges all three sources, owns provider registry
+│   ├── AppSwitcher.swift       # App launch/hide/activate
+│   ├── AppleScriptRunner.swift # NSAppleScript wrapper
+│   ├── ShellRunner.swift       # Process + timeout wrapper
+│   ├── BuiltinPreferenceSeeder.swift
+│   ├── KeyBindingOrderBackfill.swift
+│   └── Providers/
+│       ├── BuiltinProvider.swift
+│       ├── KeepAwakeProvider.swift
+│       ├── HideDesktopIconsProvider.swift
+│       ├── ShowHiddenFilesProvider.swift
+│       ├── MuteAudioProvider.swift
+│       ├── DarkModeProvider.swift
+│       ├── LockScreenProvider.swift
+│       └── EmptyTrashProvider.swift
+├── Utilities/
+│   └── KeyCodeMap.swift
+└── Views/
+    ├── MenuBarView.swift              # Menu bar panel root
+    ├── PanelRowView.swift             # Single row: toggle / action / submenu
+    ├── HoverPopover.swift             # NSWindow side popover + HoverGate timing
+    ├── AppShortcutsPopoverView.swift  # Popover content for app shortcuts
+    ├── HotkeyRecorder.swift           # Inline hotkey recording field
+    ├── SettingsView.swift             # TabView host
+    ├── PanelSettingsView.swift        # 面板 tab: drag / visibility / hotkey
+    └── GeneralSettingsView.swift      # 通用 tab (placeholder)
+```
+
+## 架构要点
+
+- **ModelContainer 共享**：在 `AppDelegate.init()` 中创建，通过 `.modelContainer()` 传递给所有 SwiftUI 视图。不要创建多个 ModelContainer 实例。
+- **固定存储路径**：ModelContainer 显式配置 `url: ~/Library/Application Support/dev.bybee.AnyDoor/AnyDoor.store`，避免 `swift run` 和 `.app` 因 Bundle ID 差异写入不同位置。`AppDelegate` 启动时会一次性从遗留 `default.store` 迁移并清理（见 `migrateLegacyStore`）。**修改 ModelConfiguration 时必须保留这条路径**，否则用户数据会"丢失"。
+- **CGEvent 回调并发安全**：回调函数是 C 风格的自由函数，不在 `@MainActor` 上。使用 `HotkeySnapshot`（Sendable 值类型，含 `HotkeyAction`）+ `nonisolated(unsafe)` 存储来安全传递数据。
+- **CGEvent tap 超时与 watchdog**：系统对 tap 回调有 ~1 秒预算，超时会触发 `.tapDisabledByTimeout` 自动禁用 tap。当前防御方式：
+  - 回调只做按键匹配，实际工作 `DispatchQueue.main.async` 派发
+  - 收到 `tapDisabledBy*` 时回调内 inline 重新启用
+  - 2 秒 watchdog 检测 `CGEvent.tapIsEnabled`，必要时 `restart()`（销毁并重建 tap）
+  - **绝不要在回调里做同步耗时工作**（I/O、SwiftData fetch、模态弹窗等）
+- **修饰键对齐**：录入和检测都使用 `CGEventFlags` 位掩码（`maskCommand | maskControl | maskAlternate | maskShift`），不要用 `NSEvent.ModifierFlags`。
+- **录入时暂停监听**：录入快捷键时调用 `HotkeyService.suspend()`，完成后 `resume()`，避免录入触发已有绑定。watchdog 通过 `isSuspended` 跳过自动重启。
+- **数据变更通知**：增删绑定后显式调用 `modelContext.save()` 和 `AppDelegate.refreshBindings()` 刷新 HotkeyService。
+- **切换语义**：`AppSwitcher.toggle` 用 `app.isActive`（最前应用判定）而非 `app.isHidden`。当目标已是最前则 `hide()`，否则 `activate()`；未运行则 `openApplication`。改判定条件会改变交互语义。
+- **PanelStore 是单一真相源**：三路数据（BuiltinItem 静态清单 + BuiltinPreference 偏好 + KeyBinding 应用快捷键）在 `PanelStore` 合并；视图只读 `topLevelEntries` 与 `appShortcutChildren`。**写入路径都要经过 PanelStore 的 mutation 方法**（setBuiltinVisibility、setBuiltinHotkey、reorderTopLevel 等），它们会自动 save SwiftData、rebuild 视图状态、并 `rebuildHotkeySnapshots()` 推到 HotkeyService。
+- **HotkeyAction 派发**：HotkeyService 的回调使用注入的 `dispatcher` 闭包，在 `AppDelegate.applicationDidFinishLaunching` 中绑定到 `PanelStore.shared.dispatch`；不要直接在 HotkeyService 内引用 PanelStore，保持 HotkeyService 与具体业务解耦。
+- **Provider 隔离**：每个 ToggleProvider / ActionProvider 是独立 actor，setState 在自己的 actor 上串行；`PanelStore` 是 `@MainActor`，跨 Provider 的写操作通过 `Task { await … }` 在 MainActor 调度。
+
+## 相关 Skills
+
+以下 skills 已安装，在相关任务中应主动使用：
+
+- **macos-design-guidelines** — Apple HIG for Mac。构建 macOS UI、菜单栏、工具栏、窗口管理、键盘快捷键时使用。
+- **axiom-swiftdata** — SwiftData 模式，@Model、@Query、@Relationship、ModelContext 模式、Swift 6 并发时使用。
+- **axiom-swiftui-26-ref** — iOS/macOS 26 SwiftUI 新特性，Liquid Glass 设计系统、@Animatable 宏等。
+- **swiftui-liquid-glass** — Liquid Glass API 实现和审查。
+- **axiom-swift-concurrency** — Swift 并发模式，@MainActor、Sendable、nonisolated(unsafe)、Task、Actor 等并发安全模式。
+- **swift-expert** — Swift 语言专家知识，覆盖语言特性和最佳实践。
+- **macos-developer** — macOS 应用开发，CGEvent、NSWorkspace、辅助功能权限等底层 API。
+
+## 注意事项
+
+- 应用使用 `.accessory` 激活策略，不显示 Dock 图标
+- 事件 tap 使用 `.cghidEventTap` 确保最高优先级
+- `displayKey` 是 `@Transient` 计算属性，不持久化
+- 界面语言为中文
+
+## Code Conventions
+
+- **All code comments must be written in English.**
+- **All commit messages must be written in English.**
+- **All PR titles and descriptions must be written in English.**
+- UI-facing strings (labels, messages shown to the user) remain in Chinese.

--- a/Sources/AnyDoor/AnyDoor.swift
+++ b/Sources/AnyDoor/AnyDoor.swift
@@ -5,16 +5,9 @@ import SwiftData
 struct AnyDoorApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-    @AppStorage(MenuBarIcon.visibilityKey) private var iconVisible = true
-    @AppStorage(MenuBarIcon.nameKey) private var iconName = MenuBarIcon.defaultName
-
     var body: some Scene {
-        MenuBarExtra("AnyDoor", systemImage: iconName, isInserted: $iconVisible) {
-            MenuBarView()
-                .modelContainer(appDelegate.modelContainer)
-        }
-        .menuBarExtraStyle(.window)
-
+        // The menu bar item is owned by `MenuBarController` (see AppDelegate),
+        // not a SwiftUI `MenuBarExtra`. Only the Settings scene lives here.
         Settings {
             SettingsView()
                 .modelContainer(appDelegate.modelContainer)

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -7,6 +7,8 @@ private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "persisten
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let modelContainer: ModelContainer
+    private var menuBarController: MenuBarController?
+    private var defaultsObserver: NSObjectProtocol?
 
     override init() {
         do {
@@ -75,6 +77,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         HotkeyService.shared.start()
         PanelStore.shared.rebuildHotkeySnapshots()
+
+        // Menu bar status item. Replaces SwiftUI `MenuBarExtra`, whose
+        // `isInserted: false` state infinite-loops the scene graph on macOS 26.
+        let menuBar = MenuBarController(modelContainer: modelContainer)
+        menuBar.install()
+        menuBarController = menuBar
+        defaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak menuBar] _ in
+            MainActor.assumeIsolated { menuBar?.syncFromPreferences() }
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/AnyDoor/Models/MenuBarIcon.swift
+++ b/Sources/AnyDoor/Models/MenuBarIcon.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Storage keys, default value, and the catalog of SF Symbols offered for the
 /// menu bar icon. Consumed by `AnyDoorApp` (keys + default) and
 /// `GeneralSettingsView` (the picker).
@@ -21,4 +23,15 @@ enum MenuBarIcon {
         "door.garage.open",
         "door.french.open",
     ]
+
+    /// Current visibility preference. Returns `true` when the key is unset so
+    /// fresh installs show the icon — mirrors the `@AppStorage` default.
+    static var isVisible: Bool {
+        UserDefaults.standard.object(forKey: visibilityKey) as? Bool ?? true
+    }
+
+    /// Current icon SF Symbol name, falling back to `defaultName` when unset.
+    static var currentName: String {
+        UserDefaults.standard.string(forKey: nameKey) ?? defaultName
+    }
 }

--- a/Sources/AnyDoor/Models/MenuBarIcon.swift
+++ b/Sources/AnyDoor/Models/MenuBarIcon.swift
@@ -4,6 +4,11 @@ import Foundation
 /// menu bar icon. Consumed by `AnyDoorApp` (keys + default) and
 /// `GeneralSettingsView` (the picker).
 enum MenuBarIcon {
+    struct Choice: Equatable, Sendable {
+        let name: String
+        let title: String
+    }
+
     /// UserDefaults key for whether the menu bar item is shown.
     static let visibilityKey = "menuBar.iconVisible"
 
@@ -13,16 +18,27 @@ enum MenuBarIcon {
     /// Default icon — matches the symbol the app originally shipped with.
     static let defaultName = "door.left.hand.open"
 
-    /// Ordered SF Symbol names offered in the picker. Door theme, on-brand
-    /// with the "AnyDoor" name.
-    static let options: [String] = [
-        "door.left.hand.open",
-        "door.left.hand.closed",
-        "door.right.hand.open",
-        "door.sliding.right.hand.open",
-        "door.garage.open",
-        "door.french.open",
+    /// Ordered SF Symbol choices offered in the picker.
+    static let choices: [Choice] = [
+        Choice(name: "door.left.hand.open", title: "左开门"),
+        Choice(name: "sparkles", title: "闪光"),
+        Choice(name: "wand.and.sparkles", title: "魔杖"),
+        Choice(name: "bolt.fill", title: "闪电"),
+        Choice(name: "command", title: "Command"),
+        Choice(name: "switch.2", title: "切换"),
+        Choice(name: "square.grid.2x2", title: "网格"),
+        Choice(name: "circle.grid.3x3.fill", title: "九宫格"),
+        Choice(name: "point.3.connected.trianglepath.dotted", title: "连接点"),
+        Choice(name: "app.connected.to.app.below.fill", title: "应用连接"),
+        Choice(name: "arrow.trianglehead.2.clockwise", title: "循环"),
+        Choice(name: "link", title: "链接"),
+        Choice(name: "network", title: "网络"),
+        Choice(name: "globe", title: "地球"),
     ]
+
+    /// Ordered SF Symbol names offered in the picker. Kept for storage and tests
+    /// that only need the raw symbol names.
+    static let options: [String] = choices.map(\.name)
 
     /// Current visibility preference. Returns `true` when the key is unset so
     /// fresh installs show the icon — mirrors the `@AppStorage` default.
@@ -33,5 +49,9 @@ enum MenuBarIcon {
     /// Current icon SF Symbol name, falling back to `defaultName` when unset.
     static var currentName: String {
         UserDefaults.standard.string(forKey: nameKey) ?? defaultName
+    }
+
+    static func title(for name: String) -> String {
+        choices.first { $0.name == name }?.title ?? name
     }
 }

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -113,23 +113,34 @@ final class MenuBarController {
         hostingView = nil
     }
 
-    /// Anchor the panel's top-right corner just below the status item.
+    /// Anchor the panel's leading edge directly below the status item.
     private func positionPanel(_ panel: NSPanel, under button: NSStatusBarButton) {
         guard let buttonWindow = button.window else { return }
         let buttonInScreen = buttonWindow.convertToScreen(
             button.convert(button.bounds, to: nil)
         )
-        let size = panel.frame.size
-        var origin = NSPoint(
-            x: buttonInScreen.maxX - size.width,
-            y: buttonInScreen.minY - size.height - 4
+        let origin = Self.panelOrigin(
+            forStatusItemFrame: buttonInScreen,
+            panelSize: panel.frame.size,
+            visibleFrame: buttonWindow.screen?.visibleFrame
         )
-        if let screen = buttonWindow.screen {
-            let visible = screen.visibleFrame
-            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
+        panel.setFrameOrigin(origin)
+    }
+
+    static func panelOrigin(
+        forStatusItemFrame statusItemFrame: NSRect,
+        panelSize: NSSize,
+        visibleFrame: NSRect?
+    ) -> NSPoint {
+        var origin = NSPoint(
+            x: statusItemFrame.minX,
+            y: statusItemFrame.minY - panelSize.height - 4
+        )
+        if let visible = visibleFrame {
+            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - panelSize.width - 4)
             origin.y = max(origin.y, visible.minY + 4)
         }
-        panel.setFrameOrigin(origin)
+        return origin
     }
 
     // MARK: - Outside-click dismissal

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -14,7 +14,7 @@ final class MenuBarController {
 
     private var statusItem: NSStatusItem?
     private var panel: NSPanel?
-    private var hostingController: NSHostingController<AnyView>?
+    private var hostingView: NSHostingView<AnyView>?
     private var globalClickMonitor: Any?
     private var localClickMonitor: Any?
 
@@ -56,23 +56,38 @@ final class MenuBarController {
     private func showPanel() {
         guard let button = statusItem?.button else { return }
 
-        let hosting = NSHostingController(
+        let hostingView = NSHostingView(
             rootView: AnyView(
                 MenuBarView(onRequestClose: { [weak self] in self?.hidePanel() })
                     .modelContainer(modelContainer)
                     .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
             )
         )
-        hosting.sizingOptions = [.preferredContentSize]
-        hostingController = hosting
+        // Measure the SwiftUI content once, then DETACH the hosting view from
+        // window sizing. With sizing enabled NSHostingView resizes its window
+        // from within layout, which recurses straight back into window layout
+        // — that pegs the CPU and overflows the stack.
+        hostingView.sizingOptions = .intrinsicContentSize
+        hostingView.layoutSubtreeIfNeeded()
+        var size = hostingView.fittingSize
+        if size.width < 1 || size.height < 1 {
+            size = NSSize(width: 260, height: 320)
+        }
+        hostingView.sizingOptions = []
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
 
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 260, height: 120),
+            contentRect: NSRect(origin: .zero, size: size),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        panel.contentViewController = hosting
+        // A plain NSView container keeps the hosting view out of the window's
+        // constraint-based layout, so nothing can drive a window resize.
+        let container = NSView(frame: NSRect(origin: .zero, size: size))
+        container.addSubview(hostingView)
+        panel.contentView = container
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -81,13 +96,7 @@ final class MenuBarController {
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
         self.panel = panel
-
-        // Size to the SwiftUI content before showing to avoid a resize flash.
-        hosting.view.layoutSubtreeIfNeeded()
-        let fitting = hosting.view.fittingSize
-        if fitting.width > 0, fitting.height > 0 {
-            panel.setContentSize(fitting)
-        }
+        self.hostingView = hostingView
 
         positionPanel(panel, under: button)
         panel.orderFrontRegardless()
@@ -99,9 +108,9 @@ final class MenuBarController {
         removeClickMonitors()
         statusItem?.button?.highlight(false)
         panel?.orderOut(nil)
-        panel?.contentViewController = nil
+        panel?.contentView = nil
         panel = nil
-        hostingController = nil
+        hostingView = nil
     }
 
     /// Anchor the panel's top-right corner just below the status item.

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -1,0 +1,170 @@
+import AppKit
+import SwiftData
+import SwiftUI
+
+/// Owns the menu bar status item and the click-to-open panel.
+///
+/// Replaces SwiftUI's `MenuBarExtra`: binding `MenuBarExtra(isInserted:)` to a
+/// `false` value drives an infinite `scenesDidChange` transaction storm on
+/// macOS 26 that pegs the main thread. Driving `NSStatusItem.isVisible`
+/// directly toggles the icon with no scene-graph involvement.
+@MainActor
+final class MenuBarController {
+    private let modelContainer: ModelContainer
+
+    private var statusItem: NSStatusItem?
+    private var panel: NSPanel?
+    private var hostingController: NSHostingController<AnyView>?
+    private var globalClickMonitor: Any?
+    private var localClickMonitor: Any?
+
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
+
+    /// Create the status item. Call once, after launch.
+    func install() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = item.button {
+            button.image = Self.iconImage(named: MenuBarIcon.currentName)
+            button.target = self
+            button.action = #selector(statusItemClicked)
+        }
+        item.isVisible = MenuBarIcon.isVisible
+        statusItem = item
+    }
+
+    /// Re-read the icon preferences and update the status item. Cheap enough to
+    /// call on every `UserDefaults.didChangeNotification`.
+    func syncFromPreferences() {
+        guard let statusItem else { return }
+        statusItem.isVisible = MenuBarIcon.isVisible
+        statusItem.button?.image = Self.iconImage(named: MenuBarIcon.currentName)
+        if !MenuBarIcon.isVisible { hidePanel() }
+    }
+
+    // MARK: - Panel
+
+    @objc private func statusItemClicked() {
+        if panel?.isVisible == true {
+            hidePanel()
+        } else {
+            showPanel()
+        }
+    }
+
+    private func showPanel() {
+        guard let button = statusItem?.button else { return }
+
+        let hosting = NSHostingController(
+            rootView: AnyView(
+                MenuBarView(onRequestClose: { [weak self] in self?.hidePanel() })
+                    .modelContainer(modelContainer)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            )
+        )
+        hosting.sizingOptions = [.preferredContentSize]
+        hostingController = hosting
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 120),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentViewController = hosting
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        self.panel = panel
+
+        // Size to the SwiftUI content before showing to avoid a resize flash.
+        hosting.view.layoutSubtreeIfNeeded()
+        let fitting = hosting.view.fittingSize
+        if fitting.width > 0, fitting.height > 0 {
+            panel.setContentSize(fitting)
+        }
+
+        positionPanel(panel, under: button)
+        panel.orderFrontRegardless()
+        button.highlight(true)
+        installClickMonitors()
+    }
+
+    private func hidePanel() {
+        removeClickMonitors()
+        statusItem?.button?.highlight(false)
+        panel?.orderOut(nil)
+        panel?.contentViewController = nil
+        panel = nil
+        hostingController = nil
+    }
+
+    /// Anchor the panel's top-right corner just below the status item.
+    private func positionPanel(_ panel: NSPanel, under button: NSStatusBarButton) {
+        guard let buttonWindow = button.window else { return }
+        let buttonInScreen = buttonWindow.convertToScreen(
+            button.convert(button.bounds, to: nil)
+        )
+        let size = panel.frame.size
+        var origin = NSPoint(
+            x: buttonInScreen.maxX - size.width,
+            y: buttonInScreen.minY - size.height - 4
+        )
+        if let screen = buttonWindow.screen {
+            let visible = screen.visibleFrame
+            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
+            origin.y = max(origin.y, visible.minY + 4)
+        }
+        panel.setFrameOrigin(origin)
+    }
+
+    // MARK: - Outside-click dismissal
+
+    private func installClickMonitors() {
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.hidePanel() }
+        }
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            // `windowNumber` is Sendable; `NSEvent`/`NSWindow` are not, so the
+            // clicked window is reduced to an Int before hopping to the actor.
+            let clickWindowNumber = event.window?.windowNumber
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                // Keep the panel open for clicks inside it, inside a hover
+                // side-popover, or on the status item (its action toggles).
+                if clickWindowNumber == self.panel?.windowNumber { return }
+                if clickWindowNumber == self.statusItem?.button?.window?.windowNumber { return }
+                if let n = clickWindowNumber,
+                   NSApp.windows.contains(where: { $0.windowNumber == n && $0 is KeyableHoverPanel }) {
+                    return
+                }
+                self.hidePanel()
+            }
+            return event
+        }
+    }
+
+    private func removeClickMonitors() {
+        if let globalClickMonitor { NSEvent.removeMonitor(globalClickMonitor) }
+        if let localClickMonitor { NSEvent.removeMonitor(localClickMonitor) }
+        globalClickMonitor = nil
+        localClickMonitor = nil
+    }
+
+    // MARK: - Icon image
+
+    private static func iconImage(named name: String) -> NSImage? {
+        let image = NSImage(systemSymbolName: name, accessibilityDescription: "AnyDoor")
+        image?.isTemplate = true
+        return image
+    }
+}

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -25,6 +25,8 @@ final class PortInventory {
 
     private let scanner: any PortScanning
     private let defaults: UserDefaults
+    private let cacheDuration: TimeInterval
+    private let now: () -> Date
     private static let viewModeKey = "PortInventory.viewMode"
     private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "PortInventory")
 
@@ -32,6 +34,7 @@ final class PortInventory {
 
     private var refreshGeneration: UInt64 = 0
     private var inflightCount: Int = 0
+    private var lastSuccessfulRefreshAt: Date?
 
     // MARK: - Lifecycle
 
@@ -39,17 +42,25 @@ final class PortInventory {
 
     init(
         scanner: any PortScanning = PortScanner(),
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        cacheDuration: TimeInterval = 10,
+        now: @escaping () -> Date = Date.init
     ) {
         self.scanner = scanner
         self.defaults = defaults
+        self.cacheDuration = cacheDuration
+        self.now = now
         let raw = defaults.string(forKey: Self.viewModeKey)
         self.viewMode = raw.flatMap(ViewMode.init(rawValue:)) ?? .list
     }
 
     // Placeholder methods — real implementations land in Task 10 and Task 11.
 
-    func refresh() async {
+    func refresh(force: Bool = false) async {
+        if !force, isCacheFresh {
+            return
+        }
+
         refreshGeneration &+= 1
         let myGen = refreshGeneration
         inflightCount += 1
@@ -61,6 +72,7 @@ final class PortInventory {
             if myGen == refreshGeneration {
                 records = scanned
                 lastError = nil
+                lastSuccessfulRefreshAt = now()
             } else {
                 Self.logger.debug("dropping stale scan result (gen \(myGen), now \(self.refreshGeneration))")
             }
@@ -78,6 +90,12 @@ final class PortInventory {
         }
     }
 
+    private var isCacheFresh: Bool {
+        guard lastError == nil,
+              let lastSuccessfulRefreshAt else { return false }
+        return now().timeIntervalSince(lastSuccessfulRefreshAt) < cacheDuration
+    }
+
     func kill(pid: pid_t) async {
         killingPIDs.insert(pid)
 
@@ -85,7 +103,7 @@ final class PortInventory {
         switch scanner.kill(pid: pid, signal: SIGTERM) {
         case .failure(.ESRCH):
             // Process already gone — treat as success.
-            await refresh()
+            await refresh(force: true)
             killingPIDs.remove(pid)
             return
         case .failure(let code):
@@ -101,16 +119,16 @@ final class PortInventory {
 
         // Step 2: give the process time to handle SIGTERM, then re-scan.
         try? await Task.sleep(for: .milliseconds(500))
-        await refresh()
+        await refresh(force: true)
 
         // Step 3: if still alive, escalate.
         if records.contains(where: { $0.pid == pid }) {
             switch scanner.kill(pid: pid, signal: SIGKILL) {
             case .success:
                 try? await Task.sleep(for: .milliseconds(200))
-                await refresh()
+                await refresh(force: true)
             case .failure(.ESRCH):
-                await refresh()
+                await refresh(force: true)
             case .failure(let code):
                 let reason: KillFailure.Reason =
                     (code == .EPERM) ? .permissionDenied : .other(code.rawValue)

--- a/Sources/AnyDoor/Services/PortInventory.swift
+++ b/Sources/AnyDoor/Services/PortInventory.swift
@@ -65,6 +65,9 @@ final class PortInventory {
                 Self.logger.debug("dropping stale scan result (gen \(myGen), now \(self.refreshGeneration))")
             }
             isRefreshing = inflightCount > 0
+        } catch is CancellationError {
+            inflightCount -= 1
+            isRefreshing = inflightCount > 0
         } catch {
             inflightCount -= 1
             if myGen == refreshGeneration {

--- a/Sources/AnyDoor/Services/PortScanner.swift
+++ b/Sources/AnyDoor/Services/PortScanner.swift
@@ -109,14 +109,16 @@ struct LsofRunner: SubprocessRunning {
         process.standardOutput = outPipe
         process.standardError = errPipe
 
+        try Task.checkCancellation()
         do { try process.run() }
         catch { throw SubprocessError.spawnFailed("\(error)") }
 
         // OSAllocatedUnfairLock<Bool> — no new dependency, watchdog and
         // result-builder both read/write through .withLock.
         let timedOut = OSAllocatedUnfairLock<Bool>(initialState: false)
+        let cancelledByTask = OSAllocatedUnfairLock<Bool>(initialState: false)
 
-        return await withTaskCancellationHandler {
+        return try await withTaskCancellationHandler {
             // Drain pipes concurrently so the kernel buffer never fills.
             async let outData: Data = readAll(outPipe.fileHandleForReading)
             async let errData: Data = readAll(errPipe.fileHandleForReading)
@@ -134,6 +136,9 @@ struct LsofRunner: SubprocessRunning {
             watchdog.cancel()
             process.waitUntilExit()
 
+            if cancelledByTask.withLock({ $0 }) || Task.isCancelled {
+                throw CancellationError()
+            }
             return SubprocessResult(
                 stdout: String(data: out, encoding: .utf8) ?? "",
                 stderr: String(data: err, encoding: .utf8) ?? "",
@@ -141,6 +146,7 @@ struct LsofRunner: SubprocessRunning {
                 timedOut: timedOut.withLock { $0 }
             )
         } onCancel: {
+            cancelledByTask.withLock { $0 = true }
             if process.isRunning { process.terminate() }
         }
     }

--- a/Sources/AnyDoor/Views/GeneralSettingsView.swift
+++ b/Sources/AnyDoor/Views/GeneralSettingsView.swift
@@ -36,11 +36,7 @@ struct GeneralSettingsView: View {
                 Toggle("显示菜单栏图标", isOn: $menuBarIconVisible)
 
                 LabeledContent("菜单栏图标") {
-                    HStack(spacing: 8) {
-                        ForEach(MenuBarIcon.options, id: \.self) { name in
-                            iconSwatch(name)
-                        }
-                    }
+                    menuBarIconPicker
                 }
                 .disabled(!menuBarIconVisible)
             }
@@ -108,29 +104,22 @@ struct GeneralSettingsView: View {
         }
     }
 
-    private func iconSwatch(_ name: String) -> some View {
-        let isSelected = menuBarIconName == name
-        return Button {
-            menuBarIconName = name
-        } label: {
-            Image(systemName: name)
-                .font(.system(size: 16))
-                .frame(width: 32, height: 32)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(
-                            isSelected ? Color.accentColor : Color.secondary.opacity(0.3),
-                            lineWidth: isSelected ? 2 : 1
-                        )
-                )
-                .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+    private var menuBarIconPicker: some View {
+        Picker("菜单栏图标", selection: $menuBarIconName) {
+            ForEach(MenuBarIcon.choices, id: \.name) { choice in
+                Image(systemName: choice.name)
+                    .tag(choice.name)
+                    .accessibilityLabel(choice.title)
+            }
         }
-        .buttonStyle(.plain)
-        .help(name)
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .frame(width: 56)
+        .help(MenuBarIcon.title(for: selectedMenuBarIconName))
+    }
+
+    private var selectedMenuBarIconName: String {
+        MenuBarIcon.options.contains(menuBarIconName) ? menuBarIconName : MenuBarIcon.defaultName
     }
 
     private func openAccessibilitySettings() {

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -183,10 +183,9 @@ final class HoverGate {
 
     func showImmediately() {
         showTask?.cancel()
-        if !isShown {
-            isShown = true
-            onShow()
-        }
+        hideTask?.cancel()
+        if !isShown { isShown = true }
+        onShow()
     }
 
     /// Forcibly reset all tracked hover state. Used by the port-manager ESC
@@ -205,8 +204,11 @@ final class HoverGate {
     }
 
     private func scheduleShow() {
-        guard !isShown else { return }
         hideTask?.cancel()
+        if isShown {
+            onShow()
+            return
+        }
         showTask?.cancel()
         showTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 400_000_000)

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -20,11 +20,12 @@ final class HoverPopover {
     private(set) var isHoldingFocus: Bool = false
 
     private let panel: KeyableHoverPanel
-    private let hostingController: NSHostingController<AnyView>
+    private let containerView: NSView
+    private let hostingView: NSHostingView<AnyView>
     private var hideTask: Task<Void, Never>?
-    // nonisolated(unsafe) so deinit can access them without MainActor hop.
-    nonisolated(unsafe) private var keyObserver: NSObjectProtocol?
-    nonisolated(unsafe) private var resignObserver: NSObjectProtocol?
+    // nonisolated(unsafe) so deinit can remove observers without a MainActor hop.
+    @ObservationIgnored nonisolated(unsafe) private var keyObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var resignObserver: NSObjectProtocol?
 
     /// Set to `true` for popovers whose SwiftUI content needs first-responder focus
     /// (e.g. TextField). Leave `false` for read-only popovers — they keep the
@@ -34,12 +35,20 @@ final class HoverPopover {
     }
 
     init<Content: View>(@ViewBuilder content: () -> Content) {
-        let controller = NSHostingController(rootView: AnyView(content()))
-        controller.sizingOptions = [.preferredContentSize]
-        self.hostingController = controller
+        let rootView = AnyView(content())
+        let initialSize = Self.fittingSize(for: rootView, fallback: NSSize(width: 240, height: 200))
+        let hostingView = NSHostingView(rootView: rootView)
+        hostingView.sizingOptions = []
+        hostingView.frame = NSRect(origin: .zero, size: initialSize)
+        hostingView.autoresizingMask = [.width, .height]
+
+        let containerView = NSView(frame: NSRect(origin: .zero, size: initialSize))
+        containerView.addSubview(hostingView)
+        self.containerView = containerView
+        self.hostingView = hostingView
 
         let panel = KeyableHoverPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 240, height: 200),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -49,7 +58,7 @@ final class HoverPopover {
         panel.hasShadow = true
         panel.level = .floating
         panel.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
-        panel.contentViewController = controller
+        panel.contentView = containerView
         panel.becomesKeyOnlyIfNeeded = true
         panel.hidesOnDeactivate = false
         self.panel = panel
@@ -73,12 +82,10 @@ final class HoverPopover {
     }
 
     func updateContent<Content: View>(@ViewBuilder content: () -> Content) {
-        hostingController.rootView = AnyView(content())
-        hostingController.view.layoutSubtreeIfNeeded()
-        let fitting = hostingController.view.fittingSize
-        if fitting.width > 0 && fitting.height > 0 {
-            panel.setContentSize(fitting)
-        }
+        let rootView = AnyView(content())
+        hostingView.rootView = rootView
+        hostingView.layoutSubtreeIfNeeded()
+        resizePanel(to: Self.fittingSize(for: rootView, fallback: panel.frame.size))
     }
 
     /// Show the popover anchored to the right side of `referenceFrame` (screen coordinates).
@@ -122,6 +129,22 @@ final class HoverPopover {
         hideTask?.cancel()
         hideTask = nil
         panel.orderOut(nil)
+    }
+
+    private func resizePanel(to size: NSSize) {
+        guard size.width > 0 && size.height > 0 else { return }
+        panel.setContentSize(size)
+        containerView.frame = NSRect(origin: .zero, size: size)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+    }
+
+    private static func fittingSize(for rootView: AnyView, fallback: NSSize) -> NSSize {
+        let measuringView = NSHostingView(rootView: rootView)
+        measuringView.sizingOptions = .intrinsicContentSize
+        measuringView.layoutSubtreeIfNeeded()
+        let fitting = measuringView.fittingSize
+        if fitting.width > 0 && fitting.height > 0 { return fitting }
+        return fallback
     }
 }
 

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -6,6 +6,7 @@ struct MenuBarView: View {
     /// the panel before the Settings window opens.
     let onRequestClose: () -> Void
 
+    @Environment(\.openSettings) private var openSettings
     @State private var panel = PanelStore.shared
     @State private var popover: HoverPopover?
     @State private var gate = HoverGate()
@@ -40,17 +41,14 @@ struct MenuBarView: View {
 
             // Footer
             HStack(spacing: 8) {
-                Button {
-                    onRequestClose()
+                footerButton("设置", systemImage: "gear") {
                     NSApp.activate()
-                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-                } label: {
-                    Label("设置", systemImage: "gear")
+                    openSettings()
+                    onRequestClose()
                 }
-                .buttonStyle(.glass)
-                Button { NSApplication.shared.terminate(nil) } label: {
-                    Label("退出", systemImage: "power")
-                }.buttonStyle(.glass)
+                footerButton("退出", systemImage: "power") {
+                    NSApplication.shared.terminate(nil)
+                }
                 Spacer()
             }
             .focusEffectDisabled()
@@ -73,6 +71,23 @@ struct MenuBarView: View {
         }
     }
 
+    private func footerButton(
+        _ title: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 10)
+                .frame(height: 24)
+                .contentShape(Rectangle())
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+
     @ViewBuilder
     private func rowView(for entry: PanelEntry) -> some View {
         if case let .builtin(item) = entry.source, item.kind == .submenu {
@@ -84,12 +99,8 @@ struct MenuBarView: View {
                 onPermission: openPermissionsSettings
             )
             .background(
-                GeometryReader { proxy in
-                    Color.clear.onAppear {
-                        triggerFrames[item] = proxy.frame(in: .global)
-                    }.onChange(of: proxy.frame(in: .global)) { _, new in
-                        triggerFrames[item] = new
-                    }
+                ScreenFrameReader { frame in
+                    triggerFrames[item] = frame
                 }
             )
             .onHover { hovered in
@@ -179,23 +190,9 @@ struct MenuBarView: View {
         return created
     }
 
-    /// Convert the panel-local rect (SwiftUI `.global`, top-left origin) to
-    /// screen coordinates. SwiftUI's Y increases downward while NSWindow uses
-    /// bottom-left origin, so we flip Y against the window's content height
-    /// before letting AppKit convert to screen space. The popover panel is
-    /// excluded from the lookup so a second hover doesn't accidentally anchor
-    /// against the already-open popover window.
+    /// Returns the submenu row frame in AppKit screen coordinates.
     private func convertedTriggerFrame(for item: BuiltinItem) -> NSRect {
-        let local = triggerFrames[item] ?? .zero
-        guard let window = menuBarPanelWindow() else { return local }
-        let panelHeight = window.frame.height
-        let flipped = NSRect(
-            x: local.origin.x,
-            y: panelHeight - local.origin.y - local.size.height,
-            width: local.size.width,
-            height: local.size.height
-        )
-        return window.convertToScreen(flipped)
+        triggerFrames[item] ?? menuBarPanelWindow()?.frame ?? .zero
     }
 
     private func menuBarPanelWindow() -> NSWindow? {
@@ -212,6 +209,55 @@ struct MenuBarView: View {
     private func openPermissionsSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {
             NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+private struct ScreenFrameReader: NSViewRepresentable {
+    var onChange: (NSRect) -> Void
+
+    func makeNSView(context: Context) -> FrameReportingView {
+        let view = FrameReportingView()
+        view.onChange = onChange
+        return view
+    }
+
+    func updateNSView(_ nsView: FrameReportingView, context: Context) {
+        nsView.onChange = onChange
+    }
+
+    final class FrameReportingView: NSView {
+        var onChange: ((NSRect) -> Void)?
+        private var lastFrame: NSRect = .zero
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            reportFrame()
+        }
+
+        override func setFrameSize(_ newSize: NSSize) {
+            super.setFrameSize(newSize)
+            reportFrame()
+        }
+
+        override func setFrameOrigin(_ newOrigin: NSPoint) {
+            super.setFrameOrigin(newOrigin)
+            reportFrame()
+        }
+
+        override func layout() {
+            super.layout()
+            reportFrame()
+        }
+
+        private func reportFrame() {
+            guard let window else { return }
+            let frame = window.convertToScreen(convert(bounds, to: nil))
+            guard frame != lastFrame else { return }
+            lastFrame = frame
+            RunLoop.main.perform { [weak self] in
+                self?.onChange?(frame)
+            }
         }
     }
 }

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 import AppKit
 
 struct MenuBarView: View {
+    /// Invoked by the footer's Settings button so the controller can dismiss
+    /// the panel before the Settings window opens.
+    let onRequestClose: () -> Void
+
     @State private var panel = PanelStore.shared
     @State private var popover = HoverPopover { EmptyView() }
     @State private var gate = HoverGate()
@@ -36,11 +40,14 @@ struct MenuBarView: View {
 
             // Footer
             HStack(spacing: 8) {
-                SettingsLink { Label("设置", systemImage: "gear") }
-                    .buttonStyle(.glass)
-                    .simultaneousGesture(TapGesture().onEnded {
-                        NSApplication.shared.activate()
-                    })
+                Button {
+                    onRequestClose()
+                    NSApp.activate()
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                } label: {
+                    Label("设置", systemImage: "gear")
+                }
+                .buttonStyle(.glass)
                 Button { NSApplication.shared.terminate(nil) } label: {
                     Label("退出", systemImage: "power")
                 }.buttonStyle(.glass)

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -7,7 +7,7 @@ struct MenuBarView: View {
     let onRequestClose: () -> Void
 
     @State private var panel = PanelStore.shared
-    @State private var popover = HoverPopover { EmptyView() }
+    @State private var popover: HoverPopover?
     @State private var gate = HoverGate()
     // One trigger frame per submenu builtin so hover-anchored popovers can be
     // mounted from any `.submenu`-kind row, not just App Shortcuts.
@@ -62,11 +62,14 @@ struct MenuBarView: View {
         .task {
             await panel.refreshAll()
         }
-        .onAppear { wireGate() }
+        .onAppear {
+            _ = ensurePopover()
+            wireGate()
+        }
         .onDisappear {
             // Don't hide if the popover took key focus deliberately (port-manager
             // search field). Otherwise hide as before.
-            if !popover.isHoldingFocus { popover.hide() }
+            if popover?.isHoldingFocus != true { popover?.hide() }
         }
     }
 
@@ -116,17 +119,18 @@ struct MenuBarView: View {
         gate.onShow = {
             guard let item = activeSubmenu else { return }
             mountPopoverContent(for: item)
-            popover.show(anchoredTo: convertedTriggerFrame(for: item))
+            popover?.show(anchoredTo: convertedTriggerFrame(for: item))
         }
         gate.onHide = {
-            popover.scheduleHide()
-            popover.needsKeyFocus = false
+            popover?.scheduleHide()
+            popover?.needsKeyFocus = false
         }
     }
 
     /// Mount the SwiftUI content appropriate for `item` and toggle the
     /// popover's `needsKeyFocus` flag for views that need first-responder.
     private func mountPopoverContent(for item: BuiltinItem) {
+        let popover = ensurePopover()
         switch item {
         case .appShortcuts:
             popover.needsKeyFocus = false
@@ -166,6 +170,13 @@ struct MenuBarView: View {
         default:
             break
         }
+    }
+
+    private func ensurePopover() -> HoverPopover {
+        if let popover { return popover }
+        let created = HoverPopover { EmptyView() }
+        popover = created
+        return created
     }
 
     /// Convert the panel-local rect (SwiftUI `.global`, top-left origin) to

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -178,6 +178,7 @@ struct MenuBarView: View {
                     }
                 )
             }
+            Task { await PortInventory.shared.refresh() }
         default:
             break
         }

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -41,6 +41,7 @@ struct MenuBarView: View {
 
             // Footer
             HStack(spacing: 8) {
+                Spacer()
                 footerButton("设置", systemImage: "gear") {
                     NSApp.activate()
                     openSettings()
@@ -49,7 +50,6 @@ struct MenuBarView: View {
                 footerButton("退出", systemImage: "power") {
                     NSApplication.shared.terminate(nil)
                 }
-                Spacer()
             }
             .focusEffectDisabled()
             .padding(.horizontal, 8).padding(.bottom, 4)

--- a/Sources/AnyDoor/Views/PanelRowView.swift
+++ b/Sources/AnyDoor/Views/PanelRowView.swift
@@ -83,8 +83,19 @@ struct PanelRowView: View {
             ))
             .toggleStyle(.switch)
             .controlSize(.small)
+            .tint(.accentColor)
+            .environment(\.appearsActive, true)
             .labelsHidden()
             .disabled(needsPermission)
+            .opacity(0.01)
+            .overlay {
+                PanelSwitchIndicator(
+                    isOn: entry.toggleState ?? false,
+                    isEnabled: !needsPermission
+                )
+                .allowsHitTesting(false)
+            }
+            .frame(width: 42, height: 24)
         case .action:
             if let hk = entry.hotkey {
                 HotkeyLabel(hotkey: hk)
@@ -94,5 +105,29 @@ struct PanelRowView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         }
+    }
+}
+
+private struct PanelSwitchIndicator: View {
+    let isOn: Bool
+    let isEnabled: Bool
+
+    var body: some View {
+        ZStack(alignment: isOn ? .trailing : .leading) {
+            Capsule()
+                .fill(trackColor)
+            Circle()
+                .fill(.white)
+                .shadow(color: .black.opacity(0.18), radius: 1, y: 1)
+                .padding(2)
+        }
+        .frame(width: 42, height: 24)
+        .opacity(isEnabled ? 1 : 0.45)
+        .animation(.snappy(duration: 0.16), value: isOn)
+    }
+
+    private var trackColor: Color {
+        if isOn { return .accentColor }
+        return .secondary.opacity(0.28)
     }
 }

--- a/Sources/AnyDoor/Views/PortListView.swift
+++ b/Sources/AnyDoor/Views/PortListView.swift
@@ -8,10 +8,6 @@ struct PortListView: View {
             LazyVStack(spacing: 0) {
                 ForEach(inventory.filteredRecords) { record in
                     PortRowView(record: record, inventory: inventory)
-                    // Skip the trailing divider after the last row to avoid a dangling line.
-                    if record.id != inventory.filteredRecords.last?.id {
-                        Divider()
-                    }
                 }
             }
         }
@@ -50,13 +46,14 @@ struct PortRowView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        // Interactive Liquid Glass styling matches PanelRowView / AppShortcutsPopoverView.
-        // `.interactive()` handles its own hover affordance, replacing the previous
-        // hardcoded white tint that was invisible in Light Mode.
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
         .contentShape(Rectangle())
+        .background(rowBackground, in: .rect(cornerRadius: 6))
         .onHover { isHovered = $0 }
         .help(tooltipText)
+    }
+
+    private var rowBackground: Color {
+        isHovered ? Color.primary.opacity(0.06) : .clear
     }
 
     @ViewBuilder

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -23,6 +23,7 @@ struct PortManagerPopoverView: View {
                 inventory: inventory,
                 searchFocused: $searchFocused
             )
+            Divider()
             if let err = inventory.lastError {
                 PortScanErrorBanner(error: err) {
                     Task { await inventory.refresh(force: true) }

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -33,8 +33,7 @@ struct PortManagerPopoverView: View {
         .frame(minHeight: 280, maxHeight: 560)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .task {
-            await inventory.refresh()
+        .onAppear {
             searchFocused = true
         }
         .onHover(perform: onHoverChange)

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -9,6 +9,9 @@ import AppKit
 /// helper is mounted as a background view so ⌘R / ⌘T / ESC work while the
 /// popover holds key focus.
 struct PortManagerPopoverView: View {
+    private static let popoverWidth: CGFloat = 340
+    private static let popoverHeight: CGFloat = 560
+
     @Bindable var inventory: PortInventory
     var onHoverChange: (Bool) -> Void
     var onClose: () -> Void
@@ -29,8 +32,7 @@ struct PortManagerPopoverView: View {
             Divider()
             PortManagerToolbar(inventory: inventory)
         }
-        .frame(width: 340)
-        .frame(minHeight: 280, maxHeight: 560)
+        .frame(width: Self.popoverWidth, height: Self.popoverHeight)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .onAppear {

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -25,7 +25,7 @@ struct PortManagerPopoverView: View {
             )
             if let err = inventory.lastError {
                 PortScanErrorBanner(error: err) {
-                    Task { await inventory.refresh() }
+                    Task { await inventory.refresh(force: true) }
                 }
             }
             content
@@ -101,7 +101,7 @@ private struct PortManagerToolbar: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             toolbarButton(
-                action: { Task { await inventory.refresh() } },
+                action: { Task { await inventory.refresh(force: true) } },
                 label: "刷新",
                 systemImage: "arrow.clockwise",
                 shortcut: "⌘R"
@@ -236,7 +236,7 @@ private struct KeyboardMonitor: NSViewRepresentable {
                 let consumed: Bool = MainActor.assumeIsolated {
                     guard let self else { return false }
                     if cmd && chars == "r" {
-                        Task { await self.inventory.refresh() }
+                        Task { await self.inventory.refresh(force: true) }
                         return true
                     }
                     if cmd && chars == "t" {

--- a/Sources/AnyDoor/Views/PortTreeView.swift
+++ b/Sources/AnyDoor/Views/PortTreeView.swift
@@ -8,10 +8,6 @@ struct PortTreeView: View {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(inventory.groupedByProcess) { group in
                     PortProcessGroupRow(group: group, inventory: inventory)
-                    // Skip the trailing divider after the last row to avoid a dangling line.
-                    if group.id != inventory.groupedByProcess.last?.id {
-                        Divider()
-                    }
                 }
             }
         }
@@ -75,14 +71,13 @@ private struct PortProcessGroupRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        // `contentShape` before `glassEffect` ensures the entire header row remains
-        // hit-testable (chevron button + hover detection) even with the glass overlay.
         .contentShape(Rectangle())
-        // Interactive Liquid Glass styling matches PortListView / PanelRowView /
-        // AppShortcutsPopoverView. `.interactive()` provides its own hover affordance,
-        // replacing the previous hardcoded white tint that was invisible in Light Mode.
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        .background(headerBackground, in: .rect(cornerRadius: 6))
         .onHover { isHeaderHovered = $0 }
+    }
+
+    private var headerBackground: Color {
+        isHeaderHovered ? Color.primary.opacity(0.06) : .clear
     }
 
     @ViewBuilder

--- a/Sources/AnyDoor/Views/ToastPresenter.swift
+++ b/Sources/AnyDoor/Views/ToastPresenter.swift
@@ -8,16 +8,25 @@ final class ToastPresenter {
     static let shared = ToastPresenter()
 
     private let panel: ToastPanel
-    private let hostingController: NSHostingController<ToastView>
+    private let containerView: NSView
+    private let hostingView: NSHostingView<ToastView>
     private var dismissTask: Task<Void, Never>?
 
     private init() {
-        let controller = NSHostingController(rootView: ToastView(style: .success("")))
-        controller.sizingOptions = [.preferredContentSize]
-        self.hostingController = controller
+        let initialView = ToastView(style: .success(""))
+        let initialSize = Self.fittingSize(for: initialView, fallback: NSSize(width: 200, height: 44))
+        let hostingView = NSHostingView(rootView: initialView)
+        hostingView.sizingOptions = []
+        hostingView.frame = NSRect(origin: .zero, size: initialSize)
+        hostingView.autoresizingMask = [.width, .height]
+        self.hostingView = hostingView
+
+        let containerView = NSView(frame: NSRect(origin: .zero, size: initialSize))
+        containerView.addSubview(hostingView)
+        self.containerView = containerView
 
         let panel = ToastPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 200, height: 44),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -29,7 +38,7 @@ final class ToastPresenter {
         panel.level = .statusBar
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         panel.hidesOnDeactivate = false
-        panel.contentViewController = controller
+        panel.contentView = containerView
         self.panel = panel
     }
 
@@ -37,12 +46,9 @@ final class ToastPresenter {
     func show(_ style: ToastStyle) {
         dismissTask?.cancel()
 
-        hostingController.rootView = ToastView(style: style)
-        hostingController.view.layoutSubtreeIfNeeded()
-        let size = hostingController.view.fittingSize
-        if size.width > 0 && size.height > 0 {
-            panel.setContentSize(size)
-        }
+        let toastView = ToastView(style: style)
+        hostingView.rootView = toastView
+        resizePanel(to: Self.fittingSize(for: toastView, fallback: panel.frame.size))
         positionPanel(size: panel.frame.size)
 
         panel.alphaValue = 0
@@ -66,6 +72,22 @@ final class ToastPresenter {
         } completionHandler: { [panel] in
             panel.orderOut(nil)
         }
+    }
+
+    private func resizePanel(to size: NSSize) {
+        guard size.width > 0 && size.height > 0 else { return }
+        panel.setContentSize(size)
+        containerView.frame = NSRect(origin: .zero, size: size)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+    }
+
+    private static func fittingSize(for rootView: ToastView, fallback: NSSize) -> NSSize {
+        let measuringView = NSHostingView(rootView: rootView)
+        measuringView.sizingOptions = .intrinsicContentSize
+        measuringView.layoutSubtreeIfNeeded()
+        let fitting = measuringView.fittingSize
+        if fitting.width > 0 && fitting.height > 0 { return fitting }
+        return fallback
     }
 
     /// Bottom-center of the screen containing the mouse cursor (fallback: main screen),

--- a/Tests/AnyDoorTests/HoverGateTests.swift
+++ b/Tests/AnyDoorTests/HoverGateTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import AnyDoor
+
+final class HoverGateTests: XCTestCase {
+    @MainActor
+    func testTriggerHoverRefreshesContentWhenPopoverIsAlreadyShown() {
+        let gate = HoverGate()
+        var showCount = 0
+        gate.onShow = { showCount += 1 }
+
+        gate.showImmediately()
+        gate.triggerHover(true)
+
+        XCTAssertEqual(showCount, 2)
+    }
+
+    @MainActor
+    func testShowImmediatelyRefreshesContentWhenPopoverIsAlreadyShown() {
+        let gate = HoverGate()
+        var showCount = 0
+        gate.onShow = { showCount += 1 }
+
+        gate.showImmediately()
+        gate.showImmediately()
+
+        XCTAssertEqual(showCount, 2)
+    }
+}

--- a/Tests/AnyDoorTests/HoverPopoverTests.swift
+++ b/Tests/AnyDoorTests/HoverPopoverTests.swift
@@ -1,0 +1,22 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import AnyDoor
+
+final class HoverPopoverTests: XCTestCase {
+    @MainActor
+    func testPopoverDoesNotLetHostingViewResizeItsWindow() throws {
+        let popover = HoverPopover {
+            Text("Popover")
+        }
+
+        let panel = try XCTUnwrap(
+            Mirror(reflecting: popover).children.first { $0.label == "panel" }?.value as? KeyableHoverPanel
+        )
+        XCTAssertNil(panel.contentViewController)
+
+        let contentView = try XCTUnwrap(panel.contentView)
+        let hostingView = try XCTUnwrap(contentView.subviews.first as? NSHostingView<AnyView>)
+        XCTAssertTrue(hostingView.sizingOptions.isEmpty)
+    }
+}

--- a/Tests/AnyDoorTests/MenuBarControllerTests.swift
+++ b/Tests/AnyDoorTests/MenuBarControllerTests.swift
@@ -1,0 +1,21 @@
+import AppKit
+import XCTest
+@testable import AnyDoor
+
+final class MenuBarControllerTests: XCTestCase {
+    @MainActor
+    func testPanelOriginStartsDirectlyBelowStatusItemWhenThereIsRoomOnRight() {
+        let statusItemFrame = NSRect(x: 1052, y: 900, width: 31, height: 24)
+        let panelSize = NSSize(width: 260, height: 400)
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1512, height: 944)
+
+        let origin = MenuBarController.panelOrigin(
+            forStatusItemFrame: statusItemFrame,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(origin.x, statusItemFrame.minX)
+        XCTAssertEqual(origin.y, statusItemFrame.minY - panelSize.height - 4)
+    }
+}

--- a/Tests/AnyDoorTests/MenuBarIconTests.swift
+++ b/Tests/AnyDoorTests/MenuBarIconTests.swift
@@ -17,6 +17,27 @@ final class MenuBarIconTests: XCTestCase {
         )
     }
 
+    func testDropdownChoicesStayAlignedWithOptions() {
+        XCTAssertEqual(MenuBarIcon.choices.map(\.name), MenuBarIcon.options)
+        XCTAssertTrue(MenuBarIcon.choices.allSatisfy { !$0.title.isEmpty })
+    }
+
+    func testOffersExpandedIconCatalog() {
+        XCTAssertGreaterThanOrEqual(MenuBarIcon.options.count, 12)
+    }
+
+    func testOnlyDefaultDoorIconIsOffered() {
+        XCTAssertEqual(
+            MenuBarIcon.options.filter { $0.hasPrefix("door.") },
+            [MenuBarIcon.defaultName]
+        )
+    }
+
+    func testKeyboardAndPowerIconsAreNotOffered() {
+        XCTAssertFalse(MenuBarIcon.options.contains("keyboard"))
+        XCTAssertFalse(MenuBarIcon.options.contains("power"))
+    }
+
     func testStorageKeysAreDistinct() {
         XCTAssertNotEqual(MenuBarIcon.visibilityKey, MenuBarIcon.nameKey)
         XCTAssertEqual(MenuBarIcon.visibilityKey, "menuBar.iconVisible")

--- a/Tests/AnyDoorTests/MenuBarIconTests.swift
+++ b/Tests/AnyDoorTests/MenuBarIconTests.swift
@@ -22,4 +22,22 @@ final class MenuBarIconTests: XCTestCase {
         XCTAssertEqual(MenuBarIcon.visibilityKey, "menuBar.iconVisible")
         XCTAssertEqual(MenuBarIcon.nameKey, "menuBar.iconName")
     }
+
+    func testIsVisibleDefaultsToTrueWhenUnset() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: MenuBarIcon.visibilityKey)
+        defaults.removeObject(forKey: MenuBarIcon.visibilityKey)
+        defer { if let original { defaults.set(original, forKey: MenuBarIcon.visibilityKey) } }
+
+        XCTAssertTrue(MenuBarIcon.isVisible, "Unset visibility must read as true")
+    }
+
+    func testCurrentNameFallsBackToDefaultWhenUnset() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: MenuBarIcon.nameKey)
+        defaults.removeObject(forKey: MenuBarIcon.nameKey)
+        defer { if let original { defaults.set(original, forKey: MenuBarIcon.nameKey) } }
+
+        XCTAssertEqual(MenuBarIcon.currentName, MenuBarIcon.defaultName)
+    }
 }

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -151,6 +151,77 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertFalse(inv.isRefreshing)
     }
 
+    @MainActor
+    func testRefreshReusesRecentSuccessfulScan() async {
+        let scanner = CountingScanner(records: [
+            PortRecord(port: 3000, pid: 1, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+
+        await inv.refresh()
+        await inv.refresh()
+
+        XCTAssertEqual(scanner.scanCalls, 1)
+        XCTAssertEqual(inv.records.map(\.port), [3000])
+    }
+
+    @MainActor
+    func testRefreshCachesEmptySuccessfulScan() async {
+        let scanner = CountingScanner(records: [])
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+
+        await inv.refresh()
+        await inv.refresh()
+
+        XCTAssertEqual(scanner.scanCalls, 1)
+        XCTAssertTrue(inv.records.isEmpty)
+    }
+
+    @MainActor
+    func testForcedRefreshBypassesRecentCache() async {
+        let scanner = CountingScanner(records: [
+            PortRecord(port: 3000, pid: 1, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        let inv = PortInventory(scanner: scanner, defaults: isolatedDefaults())
+
+        await inv.refresh()
+        scanner.records = [
+            PortRecord(port: 4000, pid: 2, processName: "ruby",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ]
+        await inv.refresh(force: true)
+
+        XCTAssertEqual(scanner.scanCalls, 2)
+        XCTAssertEqual(inv.records.map(\.port), [4000])
+    }
+
+    @MainActor
+    func testRefreshScansAgainAfterCacheExpires() async {
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        let scanner = CountingScanner(records: [
+            PortRecord(port: 3000, pid: 1, processName: "node",
+                       executablePath: nil, commandLine: nil,
+                       binds: [PortBind(address: "*", family: .ipv4)])
+        ])
+        let inv = PortInventory(
+            scanner: scanner,
+            defaults: isolatedDefaults(),
+            cacheDuration: 10,
+            now: { currentDate }
+        )
+
+        await inv.refresh()
+        currentDate = currentDate.addingTimeInterval(11)
+        await inv.refresh()
+
+        XCTAssertEqual(scanner.scanCalls, 2)
+    }
+
     /// Records every kill call and lets the test choose what `SignalResult` to return.
     private final class RecordingKillScanner: PortScanning, @unchecked Sendable {
         var records: [PortRecord]
@@ -165,6 +236,22 @@ final class PortInventoryTests: XCTestCase {
             killCalls.append((pid, signal))
             return killHandler(pid, signal)
         }
+    }
+
+    private final class CountingScanner: PortScanning, @unchecked Sendable {
+        var records: [PortRecord]
+        private(set) var scanCalls = 0
+
+        init(records: [PortRecord]) {
+            self.records = records
+        }
+
+        func scanTCPListening() async throws -> [PortRecord] {
+            scanCalls += 1
+            return records
+        }
+
+        func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
     }
 
     @MainActor

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -135,6 +135,22 @@ final class PortInventoryTests: XCTestCase {
         XCTAssertFalse(inv.isRefreshing)
     }
 
+    @MainActor
+    func testRefreshCancellationDoesNotSurfaceAsScanError() async {
+        struct CancellingScanner: PortScanning {
+            func scanTCPListening() async throws -> [PortRecord] {
+                throw CancellationError()
+            }
+            func kill(pid: pid_t, signal: Int32) -> SignalResult { .success }
+        }
+        let inv = PortInventory(scanner: CancellingScanner(), defaults: isolatedDefaults())
+
+        await inv.refresh()
+
+        XCTAssertNil(inv.lastError)
+        XCTAssertFalse(inv.isRefreshing)
+    }
+
     /// Records every kill call and lets the test choose what `SignalResult` to return.
     private final class RecordingKillScanner: PortScanning, @unchecked Sendable {
         var records: [PortRecord]

--- a/Tests/AnyDoorTests/PortManagerPopoverViewTests.swift
+++ b/Tests/AnyDoorTests/PortManagerPopoverViewTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import AnyDoor
+
+final class PortManagerPopoverViewTests: XCTestCase {
+    @MainActor
+    func testPortManagerPopoverUsesFixedHeightAcrossContentStates() async {
+        let emptyInventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: isolatedDefaults()
+        )
+
+        let populatedInventory = PortInventory(
+            scanner: StubScanner(records: sampleRecords(count: 16)),
+            defaults: isolatedDefaults()
+        )
+        await populatedInventory.refresh()
+
+        XCTAssertEqual(
+            fittingSize(for: emptyInventory).height,
+            560,
+            accuracy: 0.5
+        )
+        XCTAssertEqual(
+            fittingSize(for: populatedInventory).height,
+            560,
+            accuracy: 0.5
+        )
+    }
+
+    @MainActor
+    private func fittingSize(for inventory: PortInventory) -> NSSize {
+        let view = PortManagerPopoverView(
+            inventory: inventory,
+            onHoverChange: { _ in },
+            onClose: {}
+        )
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.sizingOptions = .intrinsicContentSize
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView.fittingSize
+    }
+
+    private struct StubScanner: PortScanning {
+        let records: [PortRecord]
+
+        func scanTCPListening() async throws -> [PortRecord] {
+            records
+        }
+
+        func kill(pid: pid_t, signal: Int32) -> SignalResult {
+            .success
+        }
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "PortManagerPopoverViewTests-\(UUID().uuidString)")!
+    }
+
+    private func sampleRecords(count: Int) -> [PortRecord] {
+        (0..<count).map { index in
+            PortRecord(
+                port: UInt16(3000 + index),
+                pid: pid_t(100 + index),
+                processName: "process-\(index)",
+                executablePath: nil,
+                commandLine: nil,
+                binds: [PortBind(address: "*", family: .ipv4)]
+            )
+        }
+    }
+}

--- a/Tests/AnyDoorTests/PortManagerPopoverViewTests.swift
+++ b/Tests/AnyDoorTests/PortManagerPopoverViewTests.swift
@@ -5,6 +5,22 @@ import XCTest
 
 final class PortManagerPopoverViewTests: XCTestCase {
     @MainActor
+    func testPortManagerPopoverSeparatesSearchHeaderFromContent() {
+        let inventory = PortInventory(
+            scanner: StubScanner(records: []),
+            defaults: isolatedDefaults()
+        )
+        let view = PortManagerPopoverView(
+            inventory: inventory,
+            onHoverChange: { _ in },
+            onClose: {}
+        )
+        let bodyType = String(reflecting: type(of: view.body))
+
+        XCTAssertGreaterThanOrEqual(bodyType.occurrences(of: "Divider"), 2, bodyType)
+    }
+
+    @MainActor
     func testPortManagerPopoverUsesFixedHeightAcrossContentStates() async {
         let emptyInventory = PortInventory(
             scanner: StubScanner(records: []),
@@ -69,5 +85,11 @@ final class PortManagerPopoverViewTests: XCTestCase {
                 binds: [PortBind(address: "*", family: .ipv4)]
             )
         }
+    }
+}
+
+private extension String {
+    func occurrences(of needle: String) -> Int {
+        components(separatedBy: needle).count - 1
     }
 }

--- a/Tests/AnyDoorTests/PortPopoverChromeTests.swift
+++ b/Tests/AnyDoorTests/PortPopoverChromeTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import AnyDoor
+
+final class PortPopoverChromeTests: XCTestCase {
+    @MainActor
+    func testPortRowsDoNotRenderAsIndividualGlassCards() async {
+        let inventory = PortInventory(
+            scanner: StubScanner(records: sampleRecords(count: 1)),
+            defaults: isolatedDefaults()
+        )
+        await inventory.refresh()
+
+        let row = PortRowView(record: inventory.filteredRecords[0], inventory: inventory)
+        let bodyType = String(reflecting: type(of: row.body))
+
+        XCTAssertFalse(bodyType.contains("GlassEffect"), bodyType)
+    }
+
+    @MainActor
+    func testPortListRowsDoNotInstallSeparateDividersBetweenGlassRows() async {
+        let inventory = PortInventory(
+            scanner: StubScanner(records: sampleRecords(count: 2)),
+            defaults: isolatedDefaults()
+        )
+        await inventory.refresh()
+
+        let bodyType = String(reflecting: type(of: PortListView(inventory: inventory).body))
+
+        XCTAssertFalse(bodyType.contains("Divider"), bodyType)
+    }
+
+    @MainActor
+    func testPortTreeGroupsDoNotInstallSeparateDividersBetweenGlassRows() async {
+        let inventory = PortInventory(
+            scanner: StubScanner(records: sampleRecords(count: 2)),
+            defaults: isolatedDefaults()
+        )
+        await inventory.refresh()
+
+        let bodyType = String(reflecting: type(of: PortTreeView(inventory: inventory).body))
+
+        XCTAssertFalse(bodyType.contains("Divider"), bodyType)
+    }
+
+    private struct StubScanner: PortScanning {
+        let records: [PortRecord]
+
+        func scanTCPListening() async throws -> [PortRecord] {
+            records
+        }
+
+        func kill(pid: pid_t, signal: Int32) -> SignalResult {
+            .success
+        }
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "PortPopoverChromeTests-\(UUID().uuidString)")!
+    }
+
+    private func sampleRecords(count: Int) -> [PortRecord] {
+        (0..<count).map { index in
+            PortRecord(
+                port: UInt16(3000 + index),
+                pid: pid_t(100 + index),
+                processName: "process-\(index)",
+                executablePath: nil,
+                commandLine: nil,
+                binds: [PortBind(address: "*", family: .ipv4)]
+            )
+        }
+    }
+}

--- a/Tests/AnyDoorTests/PortScannerTests.swift
+++ b/Tests/AnyDoorTests/PortScannerTests.swift
@@ -120,6 +120,24 @@ final class PortScannerTests: XCTestCase {
         }
     }
 
+    func testLsofRunnerThrowsCancellationInsteadOfExit15WhenTaskIsCancelled() async {
+        let runner = LsofRunner()
+        let task = Task {
+            try await runner.run(path: "/bin/sleep", args: ["5"], timeout: .seconds(10))
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func testScanSuccessfulParse() async throws {
         let raw = try fixture("lsof-single-ipv4")
         let scanner = PortScanner(runner: StubRunner(

--- a/Tests/AnyDoorTests/ToastPresenterTests.swift
+++ b/Tests/AnyDoorTests/ToastPresenterTests.swift
@@ -1,0 +1,20 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import AnyDoor
+
+final class ToastPresenterTests: XCTestCase {
+    @MainActor
+    func testToastDoesNotLetHostingViewResizeItsWindow() throws {
+        let presenter = ToastPresenter.shared
+
+        let panel = try XCTUnwrap(
+            Mirror(reflecting: presenter).children.first { $0.label == "panel" }?.value as? NSPanel
+        )
+        XCTAssertNil(panel.contentViewController)
+
+        let contentView = try XCTUnwrap(panel.contentView)
+        let hostingView = try XCTUnwrap(contentView.subviews.first as? NSHostingView<ToastView>)
+        XCTAssertTrue(hostingView.sizingOptions.isEmpty)
+    }
+}

--- a/docs/superpowers/plans/2026-05-22-menu-bar-statusitem-fix.md
+++ b/docs/superpowers/plans/2026-05-22-menu-bar-statusitem-fix.md
@@ -1,0 +1,486 @@
+# Menu Bar Status Item Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the startup freeze by replacing SwiftUI's `MenuBarExtra` with a hand-managed `NSStatusItem`, while keeping the show/hide-icon and icon-picker features working.
+
+**Architecture:** Binding `MenuBarExtra(isInserted:)` to a `false` value drives an infinite `scenesDidChange → makeMainMenu → invalidateProperties` transaction storm on macOS 26 that pegs the main thread at ~100% CPU (proven by `sample` + a content-independent bisection). `SceneBuilder` does not support `if`, so the `MenuBarExtra` scene cannot be conditionally omitted. The fix: drop `MenuBarExtra` entirely, leave only the `Settings` scene, and let a new `@MainActor` `MenuBarController` own an `NSStatusItem` plus a borderless `NSPanel` that hosts `MenuBarView`. `NSStatusItem.isVisible` toggles the icon with no scene-graph involvement.
+
+**Tech Stack:** Swift 6.2 (strict concurrency), SwiftUI (`Settings` scene, `NSHostingController`), AppKit (`NSStatusItem`, `NSPanel`, `NSEvent` monitors), SwiftData, SPM.
+
+---
+
+## File Structure
+
+- **Modify** `Sources/AnyDoor/Models/MenuBarIcon.swift` — add self-contained `isVisible` / `currentName` accessors that read `UserDefaults` for non-SwiftUI consumers.
+- **Create** `Sources/AnyDoor/Services/MenuBarController.swift` — owns the `NSStatusItem` and the click-to-open panel; outside-click dismissal.
+- **Modify** `Sources/AnyDoor/Views/MenuBarView.swift` — add an `onRequestClose` callback; replace `SettingsLink` (scene-only API) with a plain button.
+- **Modify** `Sources/AnyDoor/AnyDoor.swift` — reduce `App.body` to just the `Settings` scene.
+- **Modify** `Sources/AnyDoor/AppDelegate.swift` — instantiate `MenuBarController`, observe `UserDefaults` changes to keep the status item synced.
+- **Modify** `Tests/AnyDoorTests/MenuBarIconTests.swift` — cover the new accessors.
+
+**Out of scope (follow-up):** `MenuBarView.swift:6` `@State private var popover = HoverPopover { ... }` allocates an `NSWindow` inside a `@State` initializer (a SwiftUI anti-pattern — the initializer expression re-runs on every `MenuBarView.init`). It is an amplifier of the old freeze, not its cause, and is left for a separate change.
+
+---
+
+## Task 1: `MenuBarIcon` preference accessors
+
+`MenuBarController` is not a SwiftUI view, so it cannot use `@AppStorage`. Give `MenuBarIcon` plain accessors that read `UserDefaults` and encapsulate the same defaults `@AppStorage` uses (`true` / `defaultName`).
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/MenuBarIcon.swift`
+- Test: `Tests/AnyDoorTests/MenuBarIconTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/AnyDoorTests/MenuBarIconTests.swift`, add these two methods inside the `MenuBarIconTests` class (after the existing `testStorageKeysAreDistinct`):
+
+```swift
+    func testIsVisibleDefaultsToTrueWhenUnset() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: MenuBarIcon.visibilityKey)
+        defaults.removeObject(forKey: MenuBarIcon.visibilityKey)
+        defer { if let original { defaults.set(original, forKey: MenuBarIcon.visibilityKey) } }
+
+        XCTAssertTrue(MenuBarIcon.isVisible, "Unset visibility must read as true")
+    }
+
+    func testCurrentNameFallsBackToDefaultWhenUnset() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: MenuBarIcon.nameKey)
+        defaults.removeObject(forKey: MenuBarIcon.nameKey)
+        defer { if let original { defaults.set(original, forKey: MenuBarIcon.nameKey) } }
+
+        XCTAssertEqual(MenuBarIcon.currentName, MenuBarIcon.defaultName)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter MenuBarIconTests`
+Expected: FAIL — compile error, `type 'MenuBarIcon' has no member 'isVisible'`.
+
+- [ ] **Step 3: Add the accessors**
+
+In `Sources/AnyDoor/Models/MenuBarIcon.swift`, add `import Foundation` as the first line (the file currently has no import), then add these computed properties inside the `enum MenuBarIcon`, after the `options` array:
+
+```swift
+    /// Current visibility preference. Returns `true` when the key is unset so
+    /// fresh installs show the icon — mirrors the `@AppStorage` default.
+    static var isVisible: Bool {
+        UserDefaults.standard.object(forKey: visibilityKey) as? Bool ?? true
+    }
+
+    /// Current icon SF Symbol name, falling back to `defaultName` when unset.
+    static var currentName: String {
+        UserDefaults.standard.string(forKey: nameKey) ?? defaultName
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter MenuBarIconTests`
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/MenuBarIcon.swift Tests/AnyDoorTests/MenuBarIconTests.swift
+git commit -m "feat(menubar): add UserDefaults accessors to MenuBarIcon"
+```
+
+---
+
+## Task 2: Replace `MenuBarExtra` with `MenuBarController`
+
+This is the atomic refactor: four files change together and the build is verified once at the end.
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/MenuBarController.swift`
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift`
+- Modify: `Sources/AnyDoor/AnyDoor.swift`
+- Modify: `Sources/AnyDoor/AppDelegate.swift`
+
+- [ ] **Step 1: Create `MenuBarController`**
+
+Create `Sources/AnyDoor/Services/MenuBarController.swift`:
+
+```swift
+import AppKit
+import SwiftData
+import SwiftUI
+
+/// Owns the menu bar status item and the click-to-open panel.
+///
+/// Replaces SwiftUI's `MenuBarExtra`: binding `MenuBarExtra(isInserted:)` to a
+/// `false` value drives an infinite `scenesDidChange` transaction storm on
+/// macOS 26 that pegs the main thread. Driving `NSStatusItem.isVisible`
+/// directly toggles the icon with no scene-graph involvement.
+@MainActor
+final class MenuBarController {
+    private let modelContainer: ModelContainer
+
+    private var statusItem: NSStatusItem?
+    private var panel: NSPanel?
+    private var hostingController: NSHostingController<AnyView>?
+    private var globalClickMonitor: Any?
+    private var localClickMonitor: Any?
+
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
+
+    /// Create the status item. Call once, after launch.
+    func install() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = item.button {
+            button.image = Self.iconImage(named: MenuBarIcon.currentName)
+            button.target = self
+            button.action = #selector(statusItemClicked)
+        }
+        item.isVisible = MenuBarIcon.isVisible
+        statusItem = item
+    }
+
+    /// Re-read the icon preferences and update the status item. Cheap enough to
+    /// call on every `UserDefaults.didChangeNotification`.
+    func syncFromPreferences() {
+        guard let statusItem else { return }
+        statusItem.isVisible = MenuBarIcon.isVisible
+        statusItem.button?.image = Self.iconImage(named: MenuBarIcon.currentName)
+        if !MenuBarIcon.isVisible { hidePanel() }
+    }
+
+    // MARK: - Panel
+
+    @objc private func statusItemClicked() {
+        if panel?.isVisible == true {
+            hidePanel()
+        } else {
+            showPanel()
+        }
+    }
+
+    private func showPanel() {
+        guard let button = statusItem?.button else { return }
+
+        let hosting = NSHostingController(
+            rootView: AnyView(
+                MenuBarView(onRequestClose: { [weak self] in self?.hidePanel() })
+                    .modelContainer(modelContainer)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            )
+        )
+        hosting.sizingOptions = [.preferredContentSize]
+        hostingController = hosting
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 120),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentViewController = hosting
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        self.panel = panel
+
+        // Size to the SwiftUI content before showing to avoid a resize flash.
+        hosting.view.layoutSubtreeIfNeeded()
+        let fitting = hosting.view.fittingSize
+        if fitting.width > 0, fitting.height > 0 {
+            panel.setContentSize(fitting)
+        }
+
+        positionPanel(panel, under: button)
+        panel.orderFrontRegardless()
+        button.highlight(true)
+        installClickMonitors()
+    }
+
+    private func hidePanel() {
+        removeClickMonitors()
+        statusItem?.button?.highlight(false)
+        panel?.orderOut(nil)
+        panel?.contentViewController = nil
+        panel = nil
+        hostingController = nil
+    }
+
+    /// Anchor the panel's top-right corner just below the status item.
+    private func positionPanel(_ panel: NSPanel, under button: NSStatusBarButton) {
+        guard let buttonWindow = button.window else { return }
+        let buttonInScreen = buttonWindow.convertToScreen(
+            button.convert(button.bounds, to: nil)
+        )
+        let size = panel.frame.size
+        var origin = NSPoint(
+            x: buttonInScreen.maxX - size.width,
+            y: buttonInScreen.minY - size.height - 4
+        )
+        if let screen = buttonWindow.screen {
+            let visible = screen.visibleFrame
+            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
+            origin.y = max(origin.y, visible.minY + 4)
+        }
+        panel.setFrameOrigin(origin)
+    }
+
+    // MARK: - Outside-click dismissal
+
+    private func installClickMonitors() {
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.hidePanel() }
+        }
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            MainActor.assumeIsolated {
+                guard let self else { return event }
+                let clickWindow = event.window
+                // Keep the panel open for clicks inside it, inside a hover
+                // side-popover, or on the status item (its action toggles).
+                if clickWindow == self.panel
+                    || clickWindow is KeyableHoverPanel
+                    || clickWindow == self.statusItem?.button?.window {
+                    return event
+                }
+                self.hidePanel()
+                return event
+            }
+        }
+    }
+
+    private func removeClickMonitors() {
+        if let globalClickMonitor { NSEvent.removeMonitor(globalClickMonitor) }
+        if let localClickMonitor { NSEvent.removeMonitor(localClickMonitor) }
+        globalClickMonitor = nil
+        localClickMonitor = nil
+    }
+
+    // MARK: - Icon image
+
+    private static func iconImage(named name: String) -> NSImage? {
+        let image = NSImage(systemSymbolName: name, accessibilityDescription: "AnyDoor")
+        image?.isTemplate = true
+        return image
+    }
+}
+```
+
+- [ ] **Step 2: Add the `onRequestClose` callback to `MenuBarView`**
+
+In `Sources/AnyDoor/Views/MenuBarView.swift`, add a stored property as the first member of the struct. The struct currently begins:
+
+```swift
+struct MenuBarView: View {
+    @State private var panel = PanelStore.shared
+```
+
+Change it to:
+
+```swift
+struct MenuBarView: View {
+    /// Invoked by the footer's Settings button so the controller can dismiss
+    /// the panel before the Settings window opens.
+    let onRequestClose: () -> Void
+
+    @State private var panel = PanelStore.shared
+```
+
+- [ ] **Step 3: Replace `SettingsLink` in the `MenuBarView` footer**
+
+`SettingsLink` only resolves inside a SwiftUI scene; `MenuBarView` is now hosted in a plain `NSHostingController`, so it must open Settings imperatively. In the same file, the footer currently reads:
+
+```swift
+            // Footer
+            HStack(spacing: 8) {
+                SettingsLink { Label("设置", systemImage: "gear") }
+                    .buttonStyle(.glass)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        NSApplication.shared.activate()
+                    })
+                Button { NSApplication.shared.terminate(nil) } label: {
+                    Label("退出", systemImage: "power")
+                }.buttonStyle(.glass)
+                Spacer()
+            }
+```
+
+Replace that exact block with:
+
+```swift
+            // Footer
+            HStack(spacing: 8) {
+                Button {
+                    onRequestClose()
+                    NSApp.activate()
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                } label: {
+                    Label("设置", systemImage: "gear")
+                }
+                .buttonStyle(.glass)
+                Button { NSApplication.shared.terminate(nil) } label: {
+                    Label("退出", systemImage: "power")
+                }.buttonStyle(.glass)
+                Spacer()
+            }
+```
+
+- [ ] **Step 4: Reduce `AnyDoorApp` to the `Settings` scene**
+
+Overwrite `Sources/AnyDoor/AnyDoor.swift` with:
+
+```swift
+import SwiftUI
+import SwiftData
+
+@main
+struct AnyDoorApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        // The menu bar item is owned by `MenuBarController` (see AppDelegate),
+        // not a SwiftUI `MenuBarExtra`. Only the Settings scene lives here.
+        Settings {
+            SettingsView()
+                .modelContainer(appDelegate.modelContainer)
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Wire `MenuBarController` into `AppDelegate`**
+
+In `Sources/AnyDoor/AppDelegate.swift`, add two stored properties. The class currently begins:
+
+```swift
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let modelContainer: ModelContainer
+```
+
+Change it to:
+
+```swift
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let modelContainer: ModelContainer
+    private var menuBarController: MenuBarController?
+    private var defaultsObserver: NSObjectProtocol?
+```
+
+Then, in `applicationDidFinishLaunching(_:)`, the method currently ends:
+
+```swift
+        HotkeyService.shared.start()
+        PanelStore.shared.rebuildHotkeySnapshots()
+    }
+```
+
+Replace that exact text with:
+
+```swift
+        HotkeyService.shared.start()
+        PanelStore.shared.rebuildHotkeySnapshots()
+
+        // Menu bar status item. Replaces SwiftUI `MenuBarExtra`, whose
+        // `isInserted: false` state infinite-loops the scene graph on macOS 26.
+        let menuBar = MenuBarController(modelContainer: modelContainer)
+        menuBar.install()
+        menuBarController = menuBar
+        defaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak menuBar] _ in
+            MainActor.assumeIsolated { menuBar?.syncFromPreferences() }
+        }
+    }
+```
+
+The existing `applicationShouldHandleReopen(_:hasVisibleWindows:)` stays unchanged — when the icon is hidden it is still the only way to bring Settings back, and it is now safe (no `MenuBarExtra` to loop).
+
+- [ ] **Step 6: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors. Pre-existing `nonisolated(unsafe)` warnings in `HoverPopover.swift` are unrelated and acceptable.
+
+If strict-concurrency rejects the `NSEvent` monitor closures, mirror the existing pattern in `HoverPopover.swift:58-67` (`[weak self]` capture + `MainActor.assumeIsolated`) — the design above already uses it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/MenuBarController.swift Sources/AnyDoor/Views/MenuBarView.swift Sources/AnyDoor/AnyDoor.swift Sources/AnyDoor/AppDelegate.swift
+git commit -m "fix(menubar): replace MenuBarExtra with a managed NSStatusItem
+
+Binding MenuBarExtra(isInserted:) to a false value drives an infinite
+scenesDidChange transaction storm on macOS 26, freezing the app at launch
+whenever the icon preference is off. SceneBuilder has no conditional, so
+the scene cannot be omitted; manage NSStatusItem directly instead."
+```
+
+---
+
+## Task 3: Verification
+
+**Files:** none (build, sample, manual run). Run from the repo root.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `swift test`
+Expected: all tests pass, including the 5 `MenuBarIconTests`.
+
+- [ ] **Step 2: Regression check — the freeze is gone (icon hidden)**
+
+This is the core check. Reproduce the original failure condition and confirm CPU stays idle:
+
+```bash
+swift build
+defaults write AnyDoor menuBar.iconVisible -bool false
+.build/debug/AnyDoor &
+PID=$!
+sleep 6
+ps -p $PID -o pid,%cpu,state
+kill $PID 2>/dev/null; sleep 1; kill -9 $PID 2>/dev/null
+```
+
+Expected: `%cpu` is near `0.0` and state is `S`/`SN` (sleeping). Before the fix this was 43–97% and `RN` (running). If `%cpu` is still high, STOP — the fix did not work; do not proceed.
+
+- [ ] **Step 3: Regression check — icon visible**
+
+```bash
+defaults write AnyDoor menuBar.iconVisible -bool true
+.build/debug/AnyDoor &
+PID=$!
+sleep 6
+ps -p $PID -o pid,%cpu,state
+kill $PID 2>/dev/null; sleep 1; kill -9 $PID 2>/dev/null
+```
+
+Expected: `%cpu` near `0.0`.
+
+- [ ] **Step 4: Manual UI verification**
+
+Run `swift run AnyDoor`. Verify:
+- The menu bar shows the `door.left.hand.open` icon.
+- Clicking the icon opens the panel anchored below it; the icon highlights while open.
+- Clicking inside the panel keeps it open; clicking elsewhere (another app, or empty desktop) closes it.
+- Hovering the "应用快捷键" / submenu rows still opens the side popover (the `HoverPopover` interaction is intact).
+- Footer "设置" opens the Settings window and closes the panel; "退出" quits.
+- In Settings → 通用 → 菜单栏: toggling "显示菜单栏图标" off removes the icon and leaves the rest of the app responsive; toggling it on restores the icon. Picking a different icon swatch updates the menu bar icon.
+- Quit, relaunch — the chosen icon and visibility persist.
+
+- [ ] **Step 5: Restore defaults and clean up**
+
+```bash
+defaults write AnyDoor menuBar.iconVisible -bool true
+pkill -9 -f AnyDoor 2>/dev/null; pgrep -fl AnyDoor
+```
+
+Expected: `pgrep` prints nothing (the `grep`/`pgrep` line itself excluded).


### PR DESCRIPTION
## Summary

Replaces SwiftUI's `MenuBarExtra` with a hand-managed `NSStatusItem` to fix
window layout recursion and popover sizing bugs, and polishes the port
manager popover along the way.

### Menu bar
- Replace `MenuBarExtra` with a managed `NSStatusItem` + `NSPanel`
  (`MenuBarController`), anchoring the panel to the status item's leading edge.
- Isolate `HoverPopover` and `ToastPanel` from their `NSHostingView` layout by
  wrapping content in a plain `NSView` container with empty `sizingOptions`,
  so SwiftUI content can no longer drive panel resizing.
- Track submenu trigger frames in screen space via a `ScreenFrameReader`
  `NSViewRepresentable`, removing the manual Y-flip math.
- Re-fire `HoverGate.onShow` when hovering an already-open popover so
  switching submenu rows refreshes content.
- Right-align the footer buttons; open Settings via the `openSettings` action.

### Settings
- Expand the menu bar icon catalog to 14 themed SF Symbols and switch to a
  dropdown `Picker`.

### Port manager
- Cache recent scans for 10s and add a `refresh(force:)` path.
- Treat task cancellation as a clean scan abort instead of an exit-15 error.
- Give the popover a fixed size, replace per-row glass cards with a plain
  hover background, and add a divider below the search header.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` passes (new tests: HoverGate, HoverPopover, MenuBarController, MenuBarIcon, PortInventory, PortManagerPopoverView, PortPopoverChrome, PortScanner, ToastPresenter)
- [x] Menu bar icon opens the panel; panel anchors correctly to the icon
- [x] Hovering submenu rows shows/refreshes the side popover
- [x] Port manager popover keeps a fixed size; refresh / ⌘R work
- [x] Toast appears centered without resizing glitches