### PR TITLE
feat(history): polish clipboard history popover interactions

### DIFF
--- a/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
+++ b/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
@@ -14,6 +14,7 @@ struct ClipboardHistoryPopoverView: View {
 
     let store: ClipboardHistoryStore
     let kind: ClipboardHistoryKind
+    let onHoverChange: (Bool) -> Void
     let onDismissPopover: () -> Void
     let onCopyAndClosePanel: () -> Void
 
@@ -39,6 +40,7 @@ struct ClipboardHistoryPopoverView: View {
         .frame(width: Self.popoverWidth, height: Self.popoverHeight)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .onHover(perform: onHoverChange)
         .onAppear {
             selection.replaceItems(items.map(\.id))
         }

--- a/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
+++ b/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
@@ -283,6 +283,18 @@ private struct KeyboardMonitor: NSViewRepresentable {
                 selection.moveDown()
                 return true
             case kVK_Space:
+                // Screenshot items open a dedicated 60%-screen preview panel
+                // and dismiss the popover; other kinds use the inline overlay.
+                if let id = selection.selectedID,
+                   let item = items.first(where: { $0.id == id }),
+                   item.historyKind == .screenshot {
+                    if let url = store.screenshotURL(for: item),
+                       let image = NSImage(contentsOf: url) {
+                        ScreenshotPreviewWindow.shared.show(image: image)
+                    }
+                    onDismissPopover()
+                    return true
+                }
                 selection.togglePreview()
                 return true
             case kVK_Return:

--- a/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
+++ b/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
@@ -67,9 +67,37 @@ struct ClipboardHistoryPopoverView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
             Spacer()
+            if !items.isEmpty {
+                keyboardHint
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
+    }
+
+    private var keyboardHint: some View {
+        HStack(spacing: 6) {
+            hintChip("↑↓", label: "选择")
+            hintChip("Space", label: "预览")
+            hintChip("⏎", label: "复制")
+        }
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+    }
+
+    private func hintChip(_ key: String, label: String) -> some View {
+        HStack(spacing: 3) {
+            Text(key)
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3, style: .continuous)
+                        .fill(Color.primary.opacity(0.08))
+                )
+            Text(label)
+        }
     }
 
     // MARK: Content

--- a/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
+++ b/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
@@ -221,9 +221,15 @@ struct ClipboardHistoryPopoverView: View {
 
 // MARK: - Keyboard monitor
 
-/// Mirrors the pattern in `PortManagerPopoverView.KeyboardMonitor`: extracts
-/// primitive key info from `NSEvent` (which is not `Sendable`) before
-/// `MainActor.assumeIsolated` calls into the selection/store closures.
+/// Routes Up/Down/Space/Return/Esc into selection + copy logic.
+///
+/// Implementation note: previous version used `NSEvent.addLocalMonitorForEvents`,
+/// but in the menu-bar + non-activating popover combo, arrow / Return keys
+/// were intercepted by upstream handlers before reaching the local monitor
+/// (Space happened to slip through, which made the bug confusing). Now we
+/// install a first-responder NSView inside the popover panel that overrides
+/// `keyDown(with:)` directly, which gets the events first via the panel's
+/// own responder chain.
 private struct KeyboardMonitor: NSViewRepresentable {
     let selection: ClipboardHistorySelectionModel
     let items: [ClipboardHistoryItem]
@@ -241,21 +247,29 @@ private struct KeyboardMonitor: NSViewRepresentable {
         )
     }
 
-    func makeNSView(context: Context) -> NSView {
-        context.coordinator.install()
-        return NSView(frame: .zero)
+    func makeNSView(context: Context) -> KeyHandlerView {
+        let view = KeyHandlerView()
+        view.onKeyDown = { [weak coordinator = context.coordinator] keyCode in
+            guard let coordinator else { return false }
+            return coordinator.handle(keyCode: keyCode)
+        }
+        // Defer first-responder grab until the view is in a window.
+        DispatchQueue.main.async { [weak view] in
+            guard let view, let window = view.window else { return }
+            window.makeFirstResponder(view)
+        }
+        return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {
-        // Keep the coordinator's references current so the key handler always
-        // sees the latest items / closures without reinstalling the monitor.
+    func updateNSView(_ nsView: KeyHandlerView, context: Context) {
         context.coordinator.items = items
         context.coordinator.onCopyAndClosePanel = onCopyAndClosePanel
         context.coordinator.onDismissPopover = onDismissPopover
-    }
-
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.uninstall()
+        // Re-assert first-responder in case the panel re-mounted us without
+        // hooking up focus (e.g., updateContent swap inside HoverPopover).
+        if let window = nsView.window, window.firstResponder !== nsView {
+            window.makeFirstResponder(nsView)
+        }
     }
 
     @MainActor
@@ -265,7 +279,6 @@ private struct KeyboardMonitor: NSViewRepresentable {
         let store: ClipboardHistoryStore
         var onCopyAndClosePanel: () -> Void
         var onDismissPopover: () -> Void
-        nonisolated(unsafe) private var monitor: Any?
 
         init(
             selection: ClipboardHistorySelectionModel,
@@ -281,28 +294,7 @@ private struct KeyboardMonitor: NSViewRepresentable {
             self.onDismissPopover = onDismissPopover
         }
 
-        deinit {
-            if let monitor { NSEvent.removeMonitor(monitor) }
-        }
-
-        func install() {
-            uninstall()
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                let keyCode = Int(event.keyCode)
-                let consumed: Bool = MainActor.assumeIsolated {
-                    guard let self else { return false }
-                    return self.handle(keyCode: keyCode)
-                }
-                return consumed ? nil : event
-            }
-        }
-
-        func uninstall() {
-            if let m = monitor { NSEvent.removeMonitor(m) }
-            monitor = nil
-        }
-
-        private func handle(keyCode: Int) -> Bool {
+        func handle(keyCode: Int) -> Bool {
             switch keyCode {
             case kVK_UpArrow:
                 selection.moveUp()
@@ -348,5 +340,22 @@ private struct KeyboardMonitor: NSViewRepresentable {
                 return false
             }
         }
+    }
+}
+
+/// First-responder NSView whose only job is to forward `keyDown` to a
+/// SwiftUI-owned handler. Returning `false` calls `super.keyDown` so we
+/// don't accidentally swallow keys we don't recognize (e.g., ⌘+letter).
+final class KeyHandlerView: NSView {
+    var onKeyDown: ((Int) -> Bool)?
+
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        if let handler = onKeyDown, handler(Int(event.keyCode)) {
+            return
+        }
+        super.keyDown(with: event)
     }
 }

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -272,6 +272,7 @@ struct MenuBarView: View {
                     ClipboardHistoryPopoverView(
                         store: store,
                         kind: kind,
+                        onHoverChange: { gate.popoverHover($0) },
                         onDismissPopover: {
                             gate.reset()
                             popover.hide()

--- a/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
+++ b/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+/// Standalone borderless floating panel used for previewing a screenshot
+/// history item at 60% of the active screen's visible frame, centered.
+///
+/// Becomes the key window so `cancelOperation` (Esc) reaches it. Closes when
+/// the user clicks anywhere outside the panel, via `didResignKeyNotification`
+/// — any other window taking key (the menu bar panel, another app, the
+/// desktop) collapses the preview.
+@MainActor
+final class ScreenshotPreviewWindow {
+    static let shared = ScreenshotPreviewWindow()
+
+    private final class Panel: NSPanel {
+        var onCancel: (() -> Void)?
+        override var canBecomeKey: Bool { true }
+        override var canBecomeMain: Bool { false }
+        override func cancelOperation(_ sender: Any?) { onCancel?() }
+    }
+
+    private var panel: Panel?
+    @ObservationIgnored nonisolated(unsafe) private var resignObserver: NSObjectProtocol?
+
+    private init() {}
+
+    func show(image: NSImage, anchorScreen: NSScreen? = nil) {
+        close()
+
+        let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+        let visible = screen.visibleFrame
+        let width = visible.width * 0.6
+        let height = visible.height * 0.6
+        let rect = NSRect(
+            x: visible.midX - width / 2,
+            y: visible.midY - height / 2,
+            width: width,
+            height: height
+        )
+
+        let p = Panel(
+            contentRect: rect,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        p.isOpaque = false
+        p.backgroundColor = .clear
+        p.level = .floating
+        p.hasShadow = true
+        p.isMovableByWindowBackground = true
+        p.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+        p.onCancel = { [weak self] in self?.close() }
+
+        let hosting = NSHostingView(rootView: ScreenshotPreviewContent(image: image))
+        hosting.frame = NSRect(origin: .zero, size: rect.size)
+        hosting.autoresizingMask = [.width, .height]
+        p.contentView = hosting
+        panel = p
+
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: p,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.close() }
+        }
+
+        p.makeKeyAndOrderFront(nil)
+    }
+
+    func close() {
+        if let observer = resignObserver {
+            NotificationCenter.default.removeObserver(observer)
+            resignObserver = nil
+        }
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+private struct ScreenshotPreviewContent: View {
+    let image: NSImage
+
+    var body: some View {
+        Image(nsImage: image)
+            .resizable()
+            .interpolation(.high)
+            .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(16)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}

--- a/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
+++ b/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
@@ -48,7 +48,9 @@ final class ScreenshotPreviewWindow {
         p.hidesOnDeactivate = false
         p.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
 
-        let hosting = NSHostingView(rootView: ScreenshotPreviewContent(image: image))
+        let hosting = NSHostingView(rootView: ScreenshotPreviewContent(image: image) { [weak self] in
+            MainActor.assumeIsolated { self?.close() }
+        })
         hosting.frame = NSRect(origin: .zero, size: rect.size)
         hosting.autoresizingMask = [.width, .height]
         p.contentView = hosting
@@ -94,15 +96,29 @@ final class ScreenshotPreviewWindow {
 
 private struct ScreenshotPreviewContent: View {
     let image: NSImage
+    let onClose: () -> Void
 
     var body: some View {
-        Image(nsImage: image)
-            .resizable()
-            .interpolation(.high)
-            .aspectRatio(contentMode: .fit)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(16)
-            .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+        ZStack(alignment: .topTrailing) {
+            Image(nsImage: image)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(16)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.55))
+                    .font(.system(size: 22, weight: .regular))
+            }
+            .buttonStyle(.plain)
+            .help("关闭预览")
+            .keyboardShortcut(.cancelAction)
+            .padding(12)
+        }
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }

--- a/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
+++ b/Sources/AnyDoor/Views/ScreenshotPreviewWindow.swift
@@ -4,23 +4,18 @@ import SwiftUI
 /// Standalone borderless floating panel used for previewing a screenshot
 /// history item at 60% of the active screen's visible frame, centered.
 ///
-/// Becomes the key window so `cancelOperation` (Esc) reaches it. Closes when
-/// the user clicks anywhere outside the panel, via `didResignKeyNotification`
-/// — any other window taking key (the menu bar panel, another app, the
-/// desktop) collapses the preview.
+/// Uses `.nonactivatingPanel` so AnyDoor's `.accessory` activation policy and
+/// the surrounding hover popover key state are left untouched. Closes on Esc
+/// and on any mouse-down outside the panel frame, via local + global event
+/// monitors.
 @MainActor
 final class ScreenshotPreviewWindow {
     static let shared = ScreenshotPreviewWindow()
 
-    private final class Panel: NSPanel {
-        var onCancel: (() -> Void)?
-        override var canBecomeKey: Bool { true }
-        override var canBecomeMain: Bool { false }
-        override func cancelOperation(_ sender: Any?) { onCancel?() }
-    }
-
-    private var panel: Panel?
-    @ObservationIgnored nonisolated(unsafe) private var resignObserver: NSObjectProtocol?
+    private var panel: NSPanel?
+    @ObservationIgnored nonisolated(unsafe) private var localMouseMonitor: Any?
+    @ObservationIgnored nonisolated(unsafe) private var globalMouseMonitor: Any?
+    @ObservationIgnored nonisolated(unsafe) private var keyMonitor: Any?
 
     private init() {}
 
@@ -39,9 +34,9 @@ final class ScreenshotPreviewWindow {
             height: height
         )
 
-        let p = Panel(
+        let p = NSPanel(
             contentRect: rect,
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -50,8 +45,8 @@ final class ScreenshotPreviewWindow {
         p.level = .floating
         p.hasShadow = true
         p.isMovableByWindowBackground = true
+        p.hidesOnDeactivate = false
         p.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
-        p.onCancel = { [weak self] in self?.close() }
 
         let hosting = NSHostingView(rootView: ScreenshotPreviewContent(image: image))
         hosting.frame = NSRect(origin: .zero, size: rect.size)
@@ -59,22 +54,39 @@ final class ScreenshotPreviewWindow {
         p.contentView = hosting
         panel = p
 
-        resignObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResignKeyNotification,
-            object: p,
-            queue: .main
+        p.orderFrontRegardless()
+
+        // Esc anywhere in this app closes the preview.
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == 53 /* Esc */ else { return event }
+            MainActor.assumeIsolated { self?.close() }
+            return nil
+        }
+
+        // Click anywhere inside this app outside the panel closes the preview
+        // (events for our own app never reach the global monitor).
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            guard let self else { return event }
+            let inside = MainActor.assumeIsolated { event.window === self.panel }
+            if inside { return event }
+            MainActor.assumeIsolated { self.close() }
+            return event
+        }
+
+        // Click in another app or on the desktop also closes.
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.close() }
         }
-
-        p.makeKeyAndOrderFront(nil)
     }
 
     func close() {
-        if let observer = resignObserver {
-            NotificationCenter.default.removeObserver(observer)
-            resignObserver = nil
-        }
+        if let m = keyMonitor { NSEvent.removeMonitor(m); keyMonitor = nil }
+        if let m = localMouseMonitor { NSEvent.removeMonitor(m); localMouseMonitor = nil }
+        if let m = globalMouseMonitor { NSEvent.removeMonitor(m); globalMouseMonitor = nil }
         panel?.orderOut(nil)
         panel = nil
     }


### PR DESCRIPTION
## Summary
- Adds a discoverable keyboard-hint row (↑↓ select · Space preview · ⏎ copy) to the popover header.
- Routes Up/Down/Return through a first-responder `KeyHandlerView` so they reach the selection + copy logic reliably (the previous local `NSEvent` monitor was being bypassed for arrow/return keys in the menu-bar + non-activating panel combo, which left Space as the only working key).
- Screenshot rows now open a dedicated 60%-screen floating preview panel (with a top-right close button, Esc / click-outside dismissal) instead of an inline overlay, and the popover stays open while the user hovers it.

## Test plan
- [x] Open the menu bar, hover a history kind with ≥ 2 items, confirm ↑/↓ moves the row selection.
- [x] Press ⏎ on a selected text/color/OCR/QR row — clipboard updated, menu bar closes.
- [x] Press Space on a screenshot row — dedicated 60% preview panel opens, popover dismisses; Esc and the top-right ✕ close the preview.
- [x] Press Space on a non-screenshot row — inline preview overlay toggles.
- [x] Hover off the trigger row but onto the popover — popover stays open.
- [x] Empty list — no keyboard-hint row is shown.