### PR TITLE
feat(landing): marketing landing page for AnyDoor

### DIFF
--- a/landing/.gitignore
+++ b/landing/.gitignore
@@ -1,0 +1,23 @@
+# build output
+dist/
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# editor
+.vscode/
+.idea/

--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -1,0 +1,11 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import tailwindcss from '@tailwindcss/vite';
+
+// https://astro.build/config
+export default defineConfig({
+  site: 'https://anydoor.app',
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});

--- a/landing/bun.lock
+++ b/landing/bun.lock
@@ -1,0 +1,853 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "anydoor-landing",
+      "dependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "astro": "^5.0.0",
+        "tailwindcss": "^4.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.6", "", {}, "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q=="],
+
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.11", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.6", "@astrojs/prism": "3.3.0", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ=="],
+
+    "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
+
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
+    "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
+
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
+
+    "astro": ["astro@5.18.1", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.6", "@astrojs/markdown-remark": "6.3.11", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "base-64": ["base-64@1.0.0", "", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
+
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+
+    "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "deterministic-object-hash": ["deterministic-object-hash@2.0.2", "", { "dependencies": { "base-64": "^1.0.0" } }, "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
+
+    "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
+
+    "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
+
+    "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+
+    "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
+
+    "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
+
+    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
+
+    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-smartypants": ["remark-smartypants@3.0.2", "", { "dependencies": { "retext": "^9.0.0", "retext-smartypants": "^6.0.0", "unified": "^11.0.4", "unist-util-visit": "^5.0.0" } }, "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
+
+    "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
+
+    "retext-smartypants": ["retext-smartypants@6.2.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ=="],
+
+    "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
+
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
+
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unifont": ["unifont@0.7.4", "", { "dependencies": { "css-tree": "^3.1.0", "ofetch": "^1.5.1", "ohash": "^2.0.11" } }, "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg=="],
+
+    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-modify-children": ["unist-util-modify-children@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "array-iterate": "^2.0.0" } }, "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-children": ["unist-util-visit-children@3.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "yocto-spinner": ["yocto-spinner@0.2.3", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+  }
+}

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "anydoor-landing",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Marketing landing page for AnyDoor — a macOS menu bar control center driven by global hotkeys.",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^5.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "tailwindcss": "^4.0.0"
+  }
+}

--- a/landing/public/favicon.svg
+++ b/landing/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a84ff"></stop>
+      <stop offset="100%" stop-color="#bf5af2"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" fill="url(#g)"></rect>
+  <g fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9 26V11a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v15"></path>
+    <path d="M7 26h18"></path>
+    <circle cx="19" cy="17.5" r="1.1" fill="#fff" stroke="none"></circle>
+  </g>
+</svg>

--- a/landing/src/components/Actions.astro
+++ b/landing/src/components/Actions.astro
@@ -1,0 +1,136 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+---
+
+<section class="section container-x" data-screen-label="05 Actions">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-mac-orange); box-shadow: 0 0 12px var(--color-mac-orange)" />
+    <span data-i18n-zh>{copy.actions.eyebrow.zh}</span><span data-i18n-en>{copy.actions.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.actions.h2a.zh}</span><span data-i18n-en>{copy.actions.h2a.en}</span></span><br />
+    <span class="gradient-text"><span data-i18n-zh>{copy.actions.h2b.zh}</span><span data-i18n-en>{copy.actions.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.actions.lede.zh}</span><span data-i18n-en>{copy.actions.lede.en}</span>
+  </p>
+
+  <div class="actions-grid">
+    {/* OCR */}
+    <div class="acard">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+        <div class="head-ico" style="background:rgba(94,155,255,.15);color:#5e9bff" set:html={icons.ocr()} />
+        <h3><span data-i18n-zh>{copy.actions.ocrName.zh}</span><span data-i18n-en>{copy.actions.ocrName.en}</span></h3>
+      </div>
+      <p><span data-i18n-zh>{copy.actions.ocrDesc.zh}</span><span data-i18n-en>{copy.actions.ocrDesc.en}</span></p>
+      <div class="acard-stage ocr-stage">
+        <div class="ocr-doc">
+          <div class="ocr-h">README.md</div>
+          <div class="line" style="width:92%" />
+          <div class="line" style="width:88%" />
+          <div class="line" style="width:74%" />
+          <div class="line" style="width:95%" />
+          <div class="line" style="width:68%" />
+          <div class="line" style="width:82%" />
+          <div class="line" style="width:90%" />
+          <div class="line" style="width:62%" />
+          <div class="ocr-scan" />
+        </div>
+        <div class="ocr-toast">
+          <span set:html={icons.clipboard()} style="width:12px;height:12px" />
+          <span data-i18n-zh>{copy.actions.ocrToast.zh}</span><span data-i18n-en>{copy.actions.ocrToast.en}</span>
+        </div>
+      </div>
+    </div>
+
+    {/* Color picker */}
+    <div class="acard">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+        <div class="head-ico" style="background:rgba(191,90,242,.15);color:#bf5af2" set:html={icons.eyedropper()} />
+        <h3><span data-i18n-zh>{copy.actions.colorName.zh}</span><span data-i18n-en>{copy.actions.colorName.en}</span></h3>
+      </div>
+      <p><span data-i18n-zh>{copy.actions.colorDesc.zh}</span><span data-i18n-en>{copy.actions.colorDesc.en}</span></p>
+      <div class="acard-stage cp-stage" id="cp-stage">
+        <div class="cp-loupe" id="cp-loupe" />
+        <div class="cp-readout">
+          <span class="swatch" id="cp-swatch" style="background: #5E9BFF" />
+          <span id="cp-hex">#5E9BFF</span>
+        </div>
+      </div>
+    </div>
+
+    {/* Screenshot */}
+    <div class="acard">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+        <div class="head-ico" style="background:rgba(48,209,88,.15);color:#30d158" set:html={icons.camera()} />
+        <h3><span data-i18n-zh>{copy.actions.shotName.zh}</span><span data-i18n-en>{copy.actions.shotName.en}</span></h3>
+      </div>
+      <p><span data-i18n-zh>{copy.actions.shotDesc.zh}</span><span data-i18n-en>{copy.actions.shotDesc.en}</span></p>
+      <div class="acard-stage ss-stage">
+        <div style="position:absolute; inset:10%; border-radius:8px; background:linear-gradient(135deg, #2c2c30, #1a1a1d); border:.5px solid rgba(255,255,255,.06); padding:16px; display:flex; flex-direction:column; gap:6px">
+          <div style="height:8px; width:40%; background:rgba(255,255,255,.1); border-radius:3px" />
+          <div style="height:6px; width:85%; background:rgba(255,255,255,.07); border-radius:3px" />
+          <div style="height:6px; width:72%; background:rgba(255,255,255,.07); border-radius:3px" />
+          <div style="height:6px; width:90%; background:rgba(255,255,255,.07); border-radius:3px" />
+        </div>
+        <div class="ss-marquee" />
+        <div class="ss-shutter" />
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  // Color picker — sample real pixels under the cursor via canvas.
+  const stage = document.getElementById('cp-stage');
+  const loupe = document.getElementById('cp-loupe');
+  const swatch = document.getElementById('cp-swatch');
+  const hexEl = document.getElementById('cp-hex');
+  if (!stage || !loupe || !swatch || !hexEl) throw new Error('missing color picker els');
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const paint = () => {
+    const r = stage.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.floor(r.width));
+    canvas.height = Math.max(1, Math.floor(r.height));
+    const g = ctx.createLinearGradient(0, 0, r.width, r.height);
+    g.addColorStop(0,    '#ff453a');
+    g.addColorStop(0.18, '#ff9f0a');
+    g.addColorStop(0.40, '#30d158');
+    g.addColorStop(0.65, '#5e9bff');
+    g.addColorStop(0.88, '#bf5af2');
+    g.addColorStop(1.00, '#ff375f');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, r.width, r.height);
+  };
+
+  paint();
+  new ResizeObserver(paint).observe(stage);
+
+  stage.addEventListener('mousemove', (ev) => {
+    const e = ev as MouseEvent;
+    const r = stage.getBoundingClientRect();
+    const x = e.clientX - r.left;
+    const y = e.clientY - r.top;
+    if (x < 0 || y < 0 || x > r.width || y > r.height) return;
+    const px = ctx.getImageData(
+      Math.max(0, Math.min(canvas.width - 1, Math.floor(x))),
+      Math.max(0, Math.min(canvas.height - 1, Math.floor(y))),
+      1, 1,
+    ).data;
+    const hex = '#' + [px[0], px[1], px[2]].map((v) => v.toString(16).padStart(2, '0').toUpperCase()).join('');
+    hexEl.textContent = hex;
+    (swatch as HTMLElement).style.background = hex;
+    const l = loupe as HTMLElement;
+    l.style.display = 'block';
+    l.style.left = (x - 40) + 'px';
+    l.style.top = (y - 40) + 'px';
+    l.style.background = hex;
+  });
+  stage.addEventListener('mouseleave', () => {
+    (loupe as HTMLElement).style.display = 'none';
+  });
+</script>

--- a/landing/src/components/Download.astro
+++ b/landing/src/components/Download.astro
@@ -1,0 +1,63 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+---
+
+<section class="section container-x" id="download" data-screen-label="07 Download">
+  <div class="eyebrow">
+    <span class="dot" />
+    <span data-i18n-zh>{copy.download.eyebrow.zh}</span><span data-i18n-en>{copy.download.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.download.h2a.zh}</span><span data-i18n-en>{copy.download.h2a.en}</span></span>
+    <span class="accent-text"><span data-i18n-zh>{copy.download.h2b.zh}</span><span data-i18n-en>{copy.download.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.download.lede.zh}</span><span data-i18n-en>{copy.download.lede.en}</span>
+  </p>
+
+  <div class="dl-wrap">
+    <div class="dl-card primary">
+      <h3><span data-i18n-zh>{copy.download.dmgTitle.zh}</span><span data-i18n-en>{copy.download.dmgTitle.en}</span></h3>
+      <p><span data-i18n-zh>{copy.download.dmgDesc.zh}</span><span data-i18n-en>{copy.download.dmgDesc.en}</span></p>
+      <a class="btn-primary" href="https://github.com/ZingerLittleBee/AnyDoor/releases" target="_blank" rel="noreferrer">
+        <span set:html={icons.bolt()} style="width:16px;height:16px" />
+        <span data-i18n-zh>{copy.download.dmgBtn.zh}</span><span data-i18n-en>{copy.download.dmgBtn.en}</span>
+      </a>
+      <div class="dl-meta">
+        <span>~4.8 MB</span>
+        <span>macOS 14+</span>
+        <span>Universal Binary</span>
+      </div>
+    </div>
+
+    <div class="dl-card">
+      <h3><span data-i18n-zh>{copy.download.brewTitle.zh}</span><span data-i18n-en>{copy.download.brewTitle.en}</span></h3>
+      <p><span data-i18n-zh>{copy.download.brewDesc.zh}</span><span data-i18n-en>{copy.download.brewDesc.en}</span></p>
+      <div class="dl-cmd">
+        <span class="prompt">$</span>
+        <span>git clone https://github.com/ZingerLittleBee/AnyDoor.git</span>
+        <span class="copy" data-copy="git clone https://github.com/ZingerLittleBee/AnyDoor.git">
+          <span data-i18n-zh>{copy.download.copy.zh}</span><span data-i18n-en>{copy.download.copy.en}</span>
+        </span>
+      </div>
+      <div class="dl-cmd">
+        <span class="prompt">$</span>
+        <span>cd AnyDoor && make install</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-copy]').forEach((el) => {
+    el.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(el.dataset.copy!);
+        const original = el.innerHTML;
+        el.innerHTML = `<span data-i18n-zh>已复制</span><span data-i18n-en>Copied</span>`;
+        setTimeout(() => { el.innerHTML = original; }, 1500);
+      } catch {}
+    });
+  });
+</script>

--- a/landing/src/components/FAQ.astro
+++ b/landing/src/components/FAQ.astro
@@ -1,0 +1,36 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+---
+
+<section class="section container-x" id="faq" data-screen-label="08 FAQ">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-text-dim); box-shadow: none" />
+    <span data-i18n-zh>{copy.faq.eyebrow.zh}</span><span data-i18n-en>{copy.faq.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.faq.h2.zh}</span><span data-i18n-en>{copy.faq.h2.en}</span></span>
+  </h2>
+
+  <div class="faq">
+    {copy.faq.items.map((item, i) => (
+      <div class={`faq-item ${i === 0 ? 'is-open' : ''}`} data-faq>
+        <div class="faq-q">
+          <span><span data-i18n-zh>{item.q.zh}</span><span data-i18n-en>{item.q.en}</span></span>
+          <span class="ic" set:html={icons.plus()} style="width:20px;height:20px" />
+        </div>
+        <div class="faq-a">
+          <span data-i18n-zh>{item.a.zh}</span><span data-i18n-en>{item.a.en}</span>
+        </div>
+      </div>
+    ))}
+  </div>
+</section>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-faq]').forEach((item) => {
+    item.addEventListener('click', () => {
+      item.classList.toggle('is-open');
+    });
+  });
+</script>

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -1,0 +1,27 @@
+---
+import { copy } from '../lib/copy';
+---
+
+<footer class="container-x footer">
+  <div class="row">
+    <div class="left">
+      <div class="nav-brand">
+        <span class="logo" />
+        <span>AnyDoor</span>
+      </div>
+      <span style="color:var(--color-text-soft); font-weight:400; font-size:13px; margin-left:8px">
+        · <span data-i18n-zh>{copy.footer.tagline.zh}</span><span data-i18n-en>{copy.footer.tagline.en}</span>
+      </span>
+    </div>
+    <div class="links">
+      <a href="https://github.com/ZingerLittleBee/AnyDoor" target="_blank" rel="noreferrer">{copy.footer.links.zh[0]}</a>
+      <a href="https://github.com/ZingerLittleBee/AnyDoor/releases" target="_blank" rel="noreferrer">{copy.footer.links.zh[1]}</a>
+      <a href="https://github.com/ZingerLittleBee/AnyDoor/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer">{copy.footer.links.zh[2]}</a>
+      <a href="https://github.com/ZingerLittleBee/AnyDoor/blob/main/LICENSE" target="_blank" rel="noreferrer">{copy.footer.links.zh[3]}</a>
+    </div>
+  </div>
+  <div class="bot">
+    <div>© 2026 ZingerLittleBee · <span data-i18n-zh>{copy.footer.built.zh}</span><span data-i18n-en>{copy.footer.built.en}</span></div>
+    <div>v1.1.0 · 9VM4RM39R3</div>
+  </div>
+</footer>

--- a/landing/src/components/Hero.astro
+++ b/landing/src/components/Hero.astro
@@ -1,0 +1,58 @@
+---
+import MenuPanel from './MenuPanel.astro';
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+---
+
+<section class="hero container-x" data-screen-label="01 Hero">
+  <div>
+    <div class="eyebrow">
+      <span class="dot" />
+      <span data-i18n-zh>{copy.hero.eyebrow.zh}</span><span data-i18n-en>{copy.hero.eyebrow.en}</span>
+    </div>
+    <h1 class="hero-h">
+      <span class="gradient-text"><span data-i18n-zh>{copy.hero.h1a.zh}</span><span data-i18n-en>{copy.hero.h1a.en}</span></span><br />
+      <span class="accent-text"><span data-i18n-zh>{copy.hero.h1b.zh}</span><span data-i18n-en>{copy.hero.h1b.en}</span></span>
+    </h1>
+    <p class="lede">
+      <span data-i18n-zh>{copy.hero.lede.zh}</span><span data-i18n-en>{copy.hero.lede.en}</span>
+    </p>
+
+    <div class="hero-cta">
+      <a class="btn-primary" href="https://github.com/ZingerLittleBee/AnyDoor/releases" target="_blank" rel="noreferrer">
+        <span set:html={icons.bolt()} style="width:16px;height:16px" />
+        <span data-i18n-zh>{copy.hero.ctaPrimary.zh}</span><span data-i18n-en>{copy.hero.ctaPrimary.en}</span>
+      </a>
+      <a class="btn-secondary" href="https://github.com/ZingerLittleBee/AnyDoor" target="_blank" rel="noreferrer">
+        <span set:html={icons.github()} style="width:16px;height:16px" />
+        <span data-i18n-zh>{copy.hero.ctaSecondary.zh}</span><span data-i18n-en>{copy.hero.ctaSecondary.en}</span>
+      </a>
+    </div>
+
+    <div class="hero-meta">
+      <span><span class="check">✓</span><span data-i18n-zh>{copy.hero.meta1.zh}</span><span data-i18n-en>{copy.hero.meta1.en}</span></span>
+      <span><span class="check">✓</span><span data-i18n-zh>{copy.hero.meta2.zh}</span><span data-i18n-en>{copy.hero.meta2.en}</span></span>
+      <span><span class="check">✓</span><span data-i18n-zh>{copy.hero.meta3.zh}</span><span data-i18n-en>{copy.hero.meta3.en}</span></span>
+    </div>
+
+    <div class="feature-pills">
+      {copy.hero.pills.zh.map((p, i) => (
+        <span>
+          <span data-i18n-zh>{p}</span><span data-i18n-en>{copy.hero.pills.en[i]}</span>
+        </span>
+      ))}
+    </div>
+  </div>
+
+  <div class="hero-stage">
+    <div class="menubar-strip">
+      <span class="mb-apple" />
+      <span class="mb-right">
+        <span class="mb-door" set:html={icons.door()} style="width:15px;height:15px" />
+        <span>9:41</span>
+      </span>
+    </div>
+
+    <MenuPanel panelClass="" />
+  </div>
+</section>

--- a/landing/src/components/HotkeyDemo.astro
+++ b/landing/src/components/HotkeyDemo.astro
@@ -1,0 +1,195 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+import { hotkeyApps } from '../lib/data';
+
+const fnRow = ['Esc','F1','F2','F3','F4','F5','F6','F7','F8','F9','F10','F11','F12'];
+const row1  = ['`','1','2','3','4','5','6','7','8','9','0','-','=','⌫'];
+const row2  = ['⇥','Q','W','E','R','T','Y','U','I','O','P','[',']','\\'];
+const row3  = ['⇪','A','S','D','F','G','H','J','K','L',';',"'",'↩'];
+const row4  = ['⇧','Z','X','C','V','B','N','M',',','.','/','⇧'];
+
+const keyWidth = (k: string, ri = 0) => {
+  if (k === '⌫') return 60;
+  if (k === '⇥') return 50;
+  if (k === '⇪') return 56;
+  if (k === '↩') return 60;
+  if (k === '⇧') return ri === 4 ? 70 : 50;
+  return 38;
+};
+---
+
+<section class="section container-x" id="demo" data-screen-label="02 Hotkey demo">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-mac-purple); box-shadow: 0 0 12px var(--color-mac-purple)" />
+    <span data-i18n-zh>{copy.demo.eyebrow.zh}</span><span data-i18n-en>{copy.demo.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.demo.h2a.zh}</span><span data-i18n-en>{copy.demo.h2a.en}</span></span><br />
+    <span class="gradient-text"><span data-i18n-zh>{copy.demo.h2b.zh}</span><span data-i18n-en>{copy.demo.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.demo.lede.zh}</span><span data-i18n-en>{copy.demo.lede.en}</span>
+  </p>
+
+  <div class="hkstage">
+    <div class="hkscreen" id="hkscreen">
+      <div class="hkscreen-menu">
+        <span class="apple-mini" />
+        <span class="app-name" id="hkscreen-appname"><span data-i18n-zh>访达</span><span data-i18n-en>Finder</span></span>
+        <span class="menu-item"><span data-i18n-zh>{copy.demo.menuFile.zh}</span><span data-i18n-en>{copy.demo.menuFile.en}</span></span>
+        <span class="menu-item"><span data-i18n-zh>{copy.demo.menuEdit.zh}</span><span data-i18n-en>{copy.demo.menuEdit.en}</span></span>
+        <span class="menu-item"><span data-i18n-zh>{copy.demo.menuView.zh}</span><span data-i18n-en>{copy.demo.menuView.en}</span></span>
+        <span class="right">
+          <span class="door" set:html={icons.door()} />
+          <span>9:41</span>
+        </span>
+      </div>
+
+      <div class="hkscreen-hint">
+        <span data-i18n-zh>{copy.demo.hintScreen.zh}</span><span data-i18n-en>{copy.demo.hintScreen.en}</span>
+      </div>
+
+      <div class="winwrap" id="hkscreen-winwrap" />
+
+      <div class="hkscreen-dock">
+        {hotkeyApps.map((app) => (
+          <div class="dock-item" data-dock-app={app.name} style={`background:${app.grad}`} title={app.name} />
+        ))}
+        <div class="dock-divider" />
+        <div class="dock-item" style="background:linear-gradient(135deg, #2a2a2e, #0a0a0d)" title="Terminal" />
+      </div>
+    </div>
+
+    <div style="width:100%; display:flex; flex-direction:column; align-items:center">
+      <div class="keyboard">
+        <div class="kbrow">
+          {fnRow.map((k) => {
+            const isHot = hotkeyApps.some((a) => a.key === k);
+            return (
+              <div
+                class={`key ${k === 'Esc' ? '' : 'label'} ${isHot ? 'is-hint' : ''}`}
+                data-key={k}
+                style={`min-width: ${k === 'Esc' ? 50 : 36}px; height: 30px; font-size: 11px`}
+              >{k}</div>
+            );
+          })}
+        </div>
+        {[row1, row2, row3, row4].map((r, ri) => (
+          <div class="kbrow">
+            {r.map((k) => (
+              <div class="key" data-key={k} style={`min-width: ${keyWidth(k, ri + 1)}px`}>{k}</div>
+            ))}
+          </div>
+        ))}
+        <div class="kbrow">
+          <div class="key" style="min-width:48px">⌃</div>
+          <div class="key" style="min-width:48px">⌥</div>
+          <div class="key" style="min-width:54px">⌘</div>
+          <div class="key wide" style="min-width:320px">&nbsp;</div>
+          <div class="key" style="min-width:54px">⌘</div>
+          <div class="key" style="min-width:48px">⌥</div>
+          <div class="key" style="min-width:48px">←</div>
+        </div>
+      </div>
+      <div class="hint-line">
+        <b><span data-i18n-zh>{copy.demo.hint.zh}</span><span data-i18n-en>{copy.demo.hint.en}</span></b>
+        <span data-i18n-zh>{copy.demo.hintAfter.zh}</span><span data-i18n-en>{copy.demo.hintAfter.en}</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  import { hotkeyApps } from '../lib/data';
+
+  const screen = document.getElementById('hkscreen')!;
+  const winwrap = document.getElementById('hkscreen-winwrap')!;
+  const appNameEl = document.getElementById('hkscreen-appname')!;
+
+  let openApp: typeof hotkeyApps[number] | null = null;
+  let pressTimer: number | undefined;
+  let autoTimer: number | undefined;
+
+  const appsByKey = new Map(hotkeyApps.map((a) => [a.key, a]));
+
+  const renderApp = (app: typeof hotkeyApps[number] | null) => {
+    openApp = app;
+    if (!app) {
+      winwrap.innerHTML = '';
+      screen.removeAttribute('data-app-open');
+      appNameEl.innerHTML = `<span data-i18n-zh>访达</span><span data-i18n-en>Finder</span>`;
+    } else {
+      screen.setAttribute('data-app-open', '');
+      appNameEl.textContent = app.name;
+      winwrap.innerHTML = `
+        <div class="appwin show">
+          <div class="titlebar">
+            <div class="traffic"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+            <div class="title">${app.name}</div>
+            <div style="width:48px"></div>
+          </div>
+          <div class="body">
+            <div class="applogo" style="background:${app.grad}">${app.letter}</div>
+            <div class="appname">${app.name}</div>
+            <div class="apptag">${app.tag}</div>
+          </div>
+        </div>`;
+    }
+    // Dock state
+    document.querySelectorAll<HTMLElement>('[data-dock-app]').forEach((d) => {
+      d.classList.toggle('running', d.dataset.dockApp === app?.name);
+    });
+  };
+
+  const pressKey = (k: string, opts: { fromUser?: boolean } = {}) => {
+    if (opts.fromUser) {
+      clearInterval(autoTimer);
+      autoTimer = undefined;
+    }
+    document.querySelectorAll<HTMLElement>(`[data-key="${k}"]`).forEach((el) => el.classList.add('is-pressed'));
+    clearTimeout(pressTimer);
+    pressTimer = window.setTimeout(() => {
+      document.querySelectorAll<HTMLElement>(`[data-key="${k}"]`).forEach((el) => el.classList.remove('is-pressed'));
+    }, 180);
+
+    const app = appsByKey.get(k);
+    if (app) {
+      // Trigger dock bounce
+      const di = document.querySelector<HTMLElement>(`[data-dock-app="${app.name}"]`);
+      if (di) {
+        di.classList.remove('is-launching');
+        // Force reflow to restart animation
+        void di.offsetWidth;
+        di.classList.add('is-launching');
+      }
+      renderApp(openApp?.name === app.name ? null : app);
+    } else if (k === 'Esc') {
+      renderApp(null);
+    }
+  };
+
+  // Keyboard
+  window.addEventListener('keydown', (e) => {
+    if (appsByKey.has(e.key)) { pressKey(e.key, { fromUser: true }); e.preventDefault(); }
+    else if (e.key === 'Escape') { pressKey('Esc', { fromUser: true }); e.preventDefault(); }
+  });
+
+  // Click on rendered keys
+  document.querySelectorAll<HTMLElement>('[data-key]').forEach((el) => {
+    el.addEventListener('click', () => pressKey(el.dataset.key!, { fromUser: true }));
+  });
+
+  // Auto-cycle demo until user interacts
+  const cycle = ['F1', 'F2', 'F3', 'F4'];
+  let idx = 0;
+  const tick = async () => {
+    const k = cycle[idx % cycle.length];
+    pressKey(k);
+    await new Promise((r) => setTimeout(r, 2400));
+    pressKey(k); // hide
+    idx++;
+  };
+  autoTimer = window.setInterval(tick, 4600);
+  setTimeout(tick, 1500);
+</script>

--- a/landing/src/components/MenuPanel.astro
+++ b/landing/src/components/MenuPanel.astro
@@ -1,0 +1,77 @@
+---
+import { icons } from '../lib/icons';
+import { panelItems, defaultOnToggles, type PanelItem } from '../lib/data';
+import { copy } from '../lib/copy';
+
+interface Props {
+  items?: PanelItem[];
+  /** Wrapper class — e.g. for the hero panel fade mask. */
+  panelClass?: string;
+}
+
+const { items = panelItems, panelClass = '' } = Astro.props;
+---
+
+<div class={`mbpanel ${panelClass}`}>
+  <div class="mbpanel-head">
+    <div class="title">AnyDoor</div>
+    <div class="meta">
+      <span data-i18n-zh>{copy.ports.enabled.zh}</span><span data-i18n-en>{copy.ports.enabled.en}</span>
+    </div>
+  </div>
+
+  {items.map((item) => (
+    <div class="mbrow" data-key={item.key}>
+      <div class={`ico ${defaultOnToggles[item.key] && item.type === 'toggle' ? 'on' : ''}`} set:html={icons[item.icon as keyof typeof icons]?.()} />
+      <div style="flex:1; min-width:0">
+        <div class="label">
+          <span data-i18n-zh>{item.label.zh}</span><span data-i18n-en>{item.label.en}</span>
+        </div>
+        {item.sub && (
+          <div class="sub">
+            <span data-i18n-zh>{item.sub.zh}</span><span data-i18n-en>{item.sub.en}</span>
+          </div>
+        )}
+      </div>
+
+      {item.type === 'submenu' && <div class="chev" set:html={icons.chev()} />}
+      {item.type === 'toggle' && (
+        <button
+          class={`toggle ${defaultOnToggles[item.key] ? 'on' : ''}`}
+          data-toggle-key={item.key}
+          aria-label={item.label.en}
+        />
+      )}
+      {item.hotkey && (
+        <div class="keys">
+          {item.hotkey.map((k) => <span class="kbd">{k}</span>)}
+        </div>
+      )}
+    </div>
+  ))}
+
+  <div class="mbpanel-foot">
+    <div class="btn-foot">
+      <span set:html={icons.settings()} style="width:13px; height:13px" />
+      <span data-i18n-zh>设置</span><span data-i18n-en>Settings</span>
+    </div>
+    <div class="btn-foot">
+      <span set:html={icons.power()} style="width:13px; height:13px" />
+      <span data-i18n-zh>退出</span><span data-i18n-en>Quit</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Wire any .toggle inside .mbpanel to flip its `.on` class on click.
+  // Multiple panels stay independent — each click is scoped to its own button.
+  const flip = (e: Event) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.mbpanel .toggle');
+    if (!btn) return;
+    btn.classList.toggle('on');
+    // Mirror to the row's icon
+    const row = btn.closest('.mbrow');
+    row?.querySelector('.ico')?.classList.toggle('on', btn.classList.contains('on'));
+  };
+  document.addEventListener('click', flip);
+</script>

--- a/landing/src/components/Nav.astro
+++ b/landing/src/components/Nav.astro
@@ -1,0 +1,47 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+---
+
+<nav class="nav">
+  <div class="nav-brand">
+    <span class="logo" />
+    <span>AnyDoor</span>
+  </div>
+  <div class="nav-links">
+    <a href="#features"><span data-i18n-zh>{copy.nav.features.zh}</span><span data-i18n-en>{copy.nav.features.en}</span></a>
+    <a href="#demo"><span data-i18n-zh>{copy.nav.demo.zh}</span><span data-i18n-en>{copy.nav.demo.en}</span></a>
+    <a href="#faq"><span data-i18n-zh>{copy.nav.faq.zh}</span><span data-i18n-en>{copy.nav.faq.en}</span></a>
+    <a href="#download"><span data-i18n-zh>{copy.nav.download.zh}</span><span data-i18n-en>{copy.nav.download.en}</span></a>
+  </div>
+  <div class="nav-cta">
+    <div class="lang-toggle" role="tablist">
+      <button data-lang-btn="zh">中</button>
+      <button data-lang-btn="en">EN</button>
+    </div>
+    <a class="gh" href="https://github.com/ZingerLittleBee/AnyDoor" target="_blank" rel="noreferrer">
+      <span set:html={icons.github()} style="width:14px;height:14px" />
+      <span>1.4k</span>
+    </a>
+  </div>
+</nav>
+
+<script>
+  // Language toggle — persists to localStorage, swaps data-lang on <html>.
+  const KEY = 'anydoor.lang';
+  const setLang = (lang: 'zh' | 'en') => {
+    document.documentElement.setAttribute('data-lang', lang);
+    document.documentElement.setAttribute('lang', lang === 'zh' ? 'zh-CN' : 'en');
+    document.querySelectorAll<HTMLButtonElement>('[data-lang-btn]').forEach((b) => {
+      b.classList.toggle('is-active', b.dataset.langBtn === lang);
+    });
+    try { localStorage.setItem(KEY, lang); } catch {}
+  };
+
+  const initial = (localStorage.getItem(KEY) || document.documentElement.getAttribute('data-lang') || 'zh') as 'zh' | 'en';
+  setLang(initial);
+
+  document.querySelectorAll<HTMLButtonElement>('[data-lang-btn]').forEach((b) => {
+    b.addEventListener('click', () => setLang(b.dataset.langBtn as 'zh' | 'en'));
+  });
+</script>

--- a/landing/src/components/PortManager.astro
+++ b/landing/src/components/PortManager.astro
@@ -1,0 +1,139 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+import { samplePorts } from '../lib/data';
+---
+
+<section class="section container-x" data-screen-label="04 Ports">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-mac-green); box-shadow: 0 0 12px var(--color-mac-green)" />
+    <span data-i18n-zh>{copy.ports.eyebrow.zh}</span><span data-i18n-en>{copy.ports.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.ports.h2a.zh}</span><span data-i18n-en>{copy.ports.h2a.en}</span></span><br />
+    <span class="accent-text"><span data-i18n-zh>{copy.ports.h2b.zh}</span><span data-i18n-en>{copy.ports.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.ports.lede.zh}</span><span data-i18n-en>{copy.ports.lede.en}</span>
+  </p>
+
+  <div class="pm-wrap">
+    <div class="pm-side">
+      <div class="mbpanel-head">
+        <div class="title">AnyDoor</div>
+        <div class="meta">
+          <span data-i18n-zh>{copy.ports.enabled.zh}</span><span data-i18n-en>{copy.ports.enabled.en}</span>
+        </div>
+      </div>
+      <div class="mbrow" style="background: rgba(255,255,255,.08)">
+        <div class="ico" set:html={icons.globe()} />
+        <div class="label">
+          <span data-i18n-zh>{copy.ports.panelTitle.zh}</span><span data-i18n-en>{copy.ports.panelTitle.en}</span>
+        </div>
+        <div class="chev" set:html={icons.chev()} />
+      </div>
+      <div class="mbrow" style="opacity:.55">
+        <div class="ico" set:html={icons.keyboard()} />
+        <div class="label">
+          <span data-i18n-zh>{copy.ports.appShortcuts.zh}</span><span data-i18n-en>{copy.ports.appShortcuts.en}</span>
+        </div>
+        <div class="chev" set:html={icons.chev()} />
+      </div>
+      <div class="mbrow" style="opacity:.55">
+        <div class="ico" set:html={icons.coffee()} />
+        <div class="label">Keep Awake</div>
+        <button class="toggle" aria-label="Keep Awake"></button>
+      </div>
+    </div>
+
+    <div class="pm-main">
+      <div class="pm-search">
+        <span set:html={icons.search()} style="width:16px; height:16px; color: var(--color-text-soft)" />
+        <input id="pm-input" placeholder={copy.ports.placeholder.zh} data-ph-zh={copy.ports.placeholder.zh} data-ph-en={copy.ports.placeholder.en} />
+        <span class="count" id="pm-count">{samplePorts.length}</span>
+      </div>
+      <div class="pm-list" id="pm-list">
+        {samplePorts.map((p) => (
+          <div class="port-row" data-pm-row data-port={p.port} data-name={p.name} data-pid={p.pid}>
+            <span class="dot-running" />
+            <span class="port">:{p.port}</span>
+            <span class="pname">{p.name}</span>
+            <span class="pid">PID {p.pid}</span>
+          </div>
+        ))}
+        <div class="pm-empty" style="padding:30px; text-align:center; color:var(--color-text-soft); font-size:13px; display:none">
+          <span data-i18n-zh>{copy.ports.noMatch.zh}</span><span data-i18n-en>{copy.ports.noMatch.en}</span>
+        </div>
+      </div>
+      <div class="pm-foot">
+        <div class="pf-btn">
+          <span style="display:flex; align-items:center; gap:8px">
+            <span set:html={icons.refresh()} style="width:15px; height:15px" />
+            <span data-i18n-zh>{copy.ports.refresh.zh}</span><span data-i18n-en>{copy.ports.refresh.en}</span>
+          </span>
+          <span style="font-family: var(--font-mono)">⌘R</span>
+        </div>
+        <div class="pf-btn">
+          <span style="display:flex; align-items:center; gap:8px">
+            <span set:html={icons.tree()} style="width:15px; height:15px" />
+            <span data-i18n-zh>{copy.ports.tree.zh}</span><span data-i18n-en>{copy.ports.tree.en}</span>
+          </span>
+          <span style="font-family: var(--font-mono)">⌘T</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  const input = document.getElementById('pm-input') as HTMLInputElement;
+  const countEl = document.getElementById('pm-count')!;
+  const rows = Array.from(document.querySelectorAll<HTMLElement>('[data-pm-row]'));
+  const empty = document.querySelector<HTMLElement>('.pm-empty')!;
+
+  const highlight = (text: string, q: string) => {
+    if (!q) return text;
+    const i = text.toLowerCase().indexOf(q.toLowerCase());
+    if (i < 0) return text;
+    return `${text.slice(0, i)}<mark>${text.slice(i, i + q.length)}</mark>${text.slice(i + q.length)}`;
+  };
+
+  const filter = (q: string) => {
+    let visible = 0;
+    for (const row of rows) {
+      const name = row.dataset.name!;
+      const port = row.dataset.port!;
+      const match = !q || name.toLowerCase().includes(q.toLowerCase()) || port.includes(q);
+      row.style.display = match ? '' : 'none';
+      if (match) {
+        visible++;
+        row.querySelector('.pname')!.innerHTML = highlight(name, q);
+      }
+    }
+    countEl.textContent = String(visible);
+    empty.style.display = visible === 0 ? '' : 'none';
+  };
+
+  // Sync placeholder with current language
+  const syncPh = () => {
+    const lang = document.documentElement.getAttribute('data-lang') || 'zh';
+    input.placeholder = lang === 'en' ? (input.dataset.phEn || '') : (input.dataset.phZh || '');
+  };
+  syncPh();
+  new MutationObserver(syncPh).observe(document.documentElement, { attributes: true, attributeFilter: ['data-lang'] });
+
+  let userTyping = false;
+  input.addEventListener('input', () => { userTyping = true; filter(input.value); });
+  input.addEventListener('focus', () => { userTyping = true; });
+
+  // Auto-type "node" demo until user touches the input
+  const stages = ['', 'n', 'no', 'nod', 'node'];
+  let i = 0;
+  const auto = setInterval(() => {
+    if (userTyping) { clearInterval(auto); return; }
+    input.value = stages[i % stages.length];
+    filter(input.value);
+    i++;
+    if (i > stages.length + 3) i = 0;
+  }, 700);
+</script>

--- a/landing/src/components/Settings.astro
+++ b/landing/src/components/Settings.astro
@@ -1,0 +1,167 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+import { settingsRows } from '../lib/data';
+
+const meta = (type: string) =>
+  type === 'submenu' ? copy.settings.metaSubmenu
+  : type === 'action' ? copy.settings.metaAction
+  : copy.settings.metaSystem;
+const badge = (type: string) =>
+  type === 'submenu' ? copy.settings.badgeSubmenu
+  : type === 'action' ? copy.settings.badgeAction
+  : copy.settings.badgeToggle;
+---
+
+<section class="section container-x" data-screen-label="06 Settings">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-mac-pink); box-shadow: 0 0 12px var(--color-mac-pink)" />
+    <span data-i18n-zh>{copy.settings.eyebrow.zh}</span><span data-i18n-en>{copy.settings.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.settings.h2a.zh}</span><span data-i18n-en>{copy.settings.h2a.en}</span></span><br />
+    <span class="gradient-text"><span data-i18n-zh>{copy.settings.h2b.zh}</span><span data-i18n-en>{copy.settings.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.settings.lede.zh}</span><span data-i18n-en>{copy.settings.lede.en}</span>
+  </p>
+
+  <div class="settings-mock">
+    <div class="sm-titlebar">
+      <div class="traffic"><span class="r" /><span class="y" /><span class="g" /></div>
+      <div class="ttl">
+        <span data-i18n-zh>{copy.settings.tabPanel.zh}</span><span data-i18n-en>{copy.settings.tabPanel.en}</span>
+      </div>
+      <div style="width:60px" />
+    </div>
+
+    <div class="sm-tabs">
+      <div class="sm-tab active">
+        <span set:html={icons.clipboard()} />
+        <span><span data-i18n-zh>{copy.settings.tabPanel.zh}</span><span data-i18n-en>{copy.settings.tabPanel.en}</span></span>
+      </div>
+      <div class="sm-tab">
+        <span set:html={icons.settings()} />
+        <span><span data-i18n-zh>{copy.settings.tabGeneral.zh}</span><span data-i18n-en>{copy.settings.tabGeneral.en}</span></span>
+      </div>
+    </div>
+
+    <div class="sm-body" id="sm-body">
+      {settingsRows.map((r) => {
+        const m = meta(r.type);
+        const b = badge(r.type);
+        return (
+          <div class="sm-row" draggable="true" data-sm-row={r.key}>
+            <div class="grip" set:html={icons.grip()} />
+            <div class="checkbox" set:html={icons.check()} />
+            <div class="ico-cell" set:html={icons[r.icon as keyof typeof icons]?.()} />
+            <div class="text-cell">
+              <span class="name"><span data-i18n-zh>{r.label.zh}</span><span data-i18n-en>{r.label.en}</span></span>
+              <span class="meta"><span data-i18n-zh>{m.zh}</span><span data-i18n-en>{m.en}</span></span>
+            </div>
+            <div class="badge"><span data-i18n-zh>{b.zh}</span><span data-i18n-en>{b.en}</span></div>
+            {r.type === 'submenu' ? (
+              <div class="rec" style="min-width:100px; color:var(--color-text-soft); cursor:default">
+                {r.key === 'shortcuts' ? (
+                  <><span data-i18n-zh>{copy.settings.twoBindings.zh}</span><span data-i18n-en>{copy.settings.twoBindings.en}</span></>
+                ) : (
+                  <><span data-i18n-zh>{copy.settings.portsCount.zh}</span><span data-i18n-en>{copy.settings.portsCount.en}</span></>
+                )}
+              </div>
+            ) : (
+              <button class="rec" data-sm-record={r.key}>
+                <span class="rec-default"><span data-i18n-zh>{copy.settings.record.zh}</span><span data-i18n-en>{copy.settings.record.en}</span></span>
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+
+    <div style="padding:12px 24px 18px; color:var(--color-text-soft); font-size:12px; text-align:center">
+      <span data-i18n-zh>{copy.settings.hint.zh}</span><span data-i18n-en>{copy.settings.hint.en}</span>
+    </div>
+  </div>
+</section>
+
+<script>
+  // Drag-to-reorder
+  const body = document.getElementById('sm-body')!;
+  let dragKey: string | null = null;
+
+  body.addEventListener('dragstart', (e) => {
+    const row = (e.target as HTMLElement).closest<HTMLElement>('[data-sm-row]');
+    if (!row) return;
+    dragKey = row.dataset.smRow!;
+    e.dataTransfer!.effectAllowed = 'move';
+    try { e.dataTransfer!.setData('text/plain', dragKey); } catch {}
+    row.classList.add('is-dragging');
+  });
+  body.addEventListener('dragend', (e) => {
+    const row = (e.target as HTMLElement).closest<HTMLElement>('[data-sm-row]');
+    row?.classList.remove('is-dragging');
+    document.querySelectorAll('.sm-row.drag-hover').forEach((el) => el.classList.remove('drag-hover'));
+    dragKey = null;
+  });
+  body.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-sm-row]');
+    if (!target || target.dataset.smRow === dragKey) return;
+    document.querySelectorAll('.sm-row.drag-hover').forEach((el) => el.classList.remove('drag-hover'));
+    target.classList.add('drag-hover');
+  });
+  body.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-sm-row]');
+    if (!target || !dragKey) return;
+    const dragged = body.querySelector<HTMLElement>(`[data-sm-row="${dragKey}"]`);
+    if (!dragged || dragged === target) return;
+    body.insertBefore(dragged, target);
+    target.classList.remove('drag-hover');
+  });
+
+  // Hotkey recorder
+  let recording: HTMLButtonElement | null = null;
+  const stopRec = () => {
+    if (recording) {
+      recording.classList.remove('is-recording');
+      const def = recording.querySelector<HTMLElement>('.rec-default');
+      if (def) def.style.display = '';
+      const lbl = recording.querySelector<HTMLElement>('.rec-recording');
+      lbl?.remove();
+    }
+    recording = null;
+  };
+
+  document.querySelectorAll<HTMLButtonElement>('[data-sm-record]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      stopRec();
+      recording = btn;
+      btn.classList.add('is-recording');
+      const def = btn.querySelector<HTMLElement>('.rec-default');
+      if (def) def.style.display = 'none';
+      const lbl = document.createElement('span');
+      lbl.className = 'rec-recording';
+      lbl.innerHTML = `<span data-i18n-zh>请按下…</span><span data-i18n-en>Press keys…</span>`;
+      btn.appendChild(lbl);
+    });
+  });
+
+  window.addEventListener('keydown', (e) => {
+    if (!recording) return;
+    e.preventDefault();
+    if (e.key === 'Escape') { stopRec(); return; }
+    if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) return; // wait for non-modifier
+    const parts: string[] = [];
+    if (e.shiftKey) parts.push('⇧');
+    if (e.ctrlKey) parts.push('⌃');
+    if (e.altKey) parts.push('⌥');
+    if (e.metaKey) parts.push('⌘');
+    parts.push(e.key.length === 1 ? e.key.toUpperCase() : e.key);
+    const btn = recording;
+    stopRec();
+    btn.classList.add('has-key');
+    btn.innerHTML = `<span>${parts.join(' ')}</span>`;
+  });
+</script>

--- a/landing/src/components/Toggles.astro
+++ b/landing/src/components/Toggles.astro
@@ -1,0 +1,63 @@
+---
+import { icons } from '../lib/icons';
+import { copy } from '../lib/copy';
+import { toggleCards, defaultOnToggles } from '../lib/data';
+---
+
+<section class="section container-x" id="features" data-screen-label="03 Toggles">
+  <div class="eyebrow">
+    <span class="dot" style="background: var(--color-accent-2); box-shadow: 0 0 12px var(--color-accent-2)" />
+    <span data-i18n-zh>{copy.toggles.eyebrow.zh}</span><span data-i18n-en>{copy.toggles.eyebrow.en}</span>
+  </div>
+  <h2 class="sec-h">
+    <span class="gradient-text"><span data-i18n-zh>{copy.toggles.h2a.zh}</span><span data-i18n-en>{copy.toggles.h2a.en}</span></span><br />
+    <span class="gradient-text"><span data-i18n-zh>{copy.toggles.h2b.zh}</span><span data-i18n-en>{copy.toggles.h2b.en}</span></span>
+  </h2>
+  <p class="lede">
+    <span data-i18n-zh>{copy.toggles.lede.zh}</span><span data-i18n-en>{copy.toggles.lede.en}</span>
+  </p>
+
+  <div class="toggles-grid">
+    {toggleCards.map((card) => {
+      const isOn = !!defaultOnToggles[card.key];
+      return (
+        <div
+          class={`tcard ${card.cardClass || ''} ${isOn ? 'is-on' : ''}`}
+          data-tcard={card.key}
+          style={`--ico-on-bg: ${card.iconOnBg}; --ico-on-color: ${card.iconOnColor}`}
+        >
+          <div class="head">
+            <div class="ico" set:html={icons[card.icon as keyof typeof icons]?.()} />
+            <button class={`toggle ${isOn ? 'on' : ''}`} data-tcard-toggle={card.key} aria-label={card.name.en} />
+          </div>
+          <h4>
+            <span data-i18n-zh>{card.name.zh}</span><span data-i18n-en>{card.name.en}</span>
+          </h4>
+          <p>
+            <span data-i18n-zh>{card.desc.zh}</span><span data-i18n-en>{card.desc.en}</span>
+          </p>
+          <div class="state">
+            <span data-i18n-zh class="state-on" style={isOn ? '' : 'display:none'}>{card.stateOn.zh}</span>
+            <span data-i18n-en class="state-on" style={isOn ? '' : 'display:none'}>{card.stateOn.en}</span>
+            <span data-i18n-zh class="state-off" style={isOn ? 'display:none' : ''}>{card.stateOff.zh}</span>
+            <span data-i18n-en class="state-off" style={isOn ? 'display:none' : ''}>{card.stateOff.en}</span>
+          </div>
+        </div>
+      );
+    })}
+  </div>
+</section>
+
+<script>
+  // Click anywhere on a card to flip; mirror state to icon + state text.
+  const onClick = (e: Event) => {
+    const card = (e.target as HTMLElement).closest<HTMLElement>('[data-tcard]');
+    if (!card) return;
+    const isOn = card.classList.toggle('is-on');
+    const toggle = card.querySelector<HTMLButtonElement>('[data-tcard-toggle]');
+    toggle?.classList.toggle('on', isOn);
+    card.querySelectorAll<HTMLElement>('.state-on').forEach((el) => { el.style.display = isOn ? '' : 'none'; });
+    card.querySelectorAll<HTMLElement>('.state-off').forEach((el) => { el.style.display = isOn ? 'none' : ''; });
+  };
+  document.querySelectorAll<HTMLElement>('[data-tcard]').forEach((el) => el.addEventListener('click', onClick));
+</script>

--- a/landing/src/lib/copy.ts
+++ b/landing/src/lib/copy.ts
@@ -1,0 +1,159 @@
+// Bilingual strings. Both versions are rendered into the HTML and the active
+// language is shown via [data-lang] on <html> + CSS rules in global.css.
+
+export type Lang = 'zh' | 'en';
+export type Bi<T = string> = { zh: T; en: T };
+
+export const copy = {
+  nav: { features: { zh: '功能', en: 'Features' }, demo: { zh: '演示', en: 'Demo' }, faq: { zh: 'FAQ', en: 'FAQ' }, download: { zh: '下载', en: 'Download' } },
+
+  hero: {
+    eyebrow: { zh: '一颗按键，一扇任意门', en: 'One key. Any door.' },
+    h1a: { zh: '菜单栏，', en: 'Your menu bar,' },
+    h1b: { zh: '全副武装。', en: 'supercharged.' },
+    lede: {
+      zh: 'AnyDoor 是一个由全局热键驱动的 macOS 菜单栏控制中心。绑定任意按键来唤起 App、翻转系统开关、运行一次性动作——双手永远不必离开键盘。',
+      en: 'AnyDoor is a macOS menu bar control center driven by global hotkeys. Bind any key combination to launch and toggle apps, flip system settings, or run one-off actions — all without leaving the keyboard.',
+    },
+    ctaPrimary: { zh: '下载 v1.1.0', en: 'Download v1.1.0' },
+    ctaSecondary: { zh: '在 GitHub 上查看', en: 'View on GitHub' },
+    meta1: { zh: '免费 & 开源', en: 'Free & open source' },
+    meta2: { zh: 'macOS 14+', en: 'macOS 14+' },
+    meta3: { zh: 'MIT 协议', en: 'MIT License' },
+    pills: {
+      zh: ['全局热键', '端口管理', '深色模式', '屏幕 OCR', '取色器', '识别二维码', 'Liquid Glass'],
+      en: ['Global hotkeys', 'Port manager', 'Dark mode', 'Screen OCR', 'Color picker', 'QR scan', 'Liquid Glass'],
+    },
+  },
+
+  demo: {
+    eyebrow: { zh: '全局热键', en: 'Global hotkeys' },
+    h2a: { zh: '按一下打开，', en: 'Press to open.' },
+    h2b: { zh: '再按一下隐藏。', en: 'Press again to hide.' },
+    lede: {
+      zh: '为每个常用 App 绑定一个组合键。AnyDoor 在 HID 层级别截获键盘事件，再快的肌肉记忆都赶得上。试试键盘上的 F1 – F6 →',
+      en: "Bind a key combination to any app. AnyDoor intercepts keyboard events at the HID level, so it's faster than your muscle memory. Try F1 – F6 on the keyboard below →",
+    },
+    hintScreen: { zh: '↓ 按 F1 – F6 启动应用', en: '↓ Press F1 – F6 to launch' },
+    hint: { zh: '试试按 F1 – F6', en: 'Try F1 – F6' },
+    hintAfter: { zh: ' — 也可以试按 Esc 关闭。', en: ' — or hit Esc to dismiss.' },
+    menuFile: { zh: '文件', en: 'File' },
+    menuEdit: { zh: '编辑', en: 'Edit' },
+    menuView: { zh: '显示', en: 'View' },
+  },
+
+  toggles: {
+    eyebrow: { zh: '系统开关', en: 'System toggles' },
+    h2a: { zh: '一键翻转每一个', en: 'Flip every setting' },
+    h2b: { zh: '你常翻的设置。', en: 'you keep flipping.' },
+    lede: {
+      zh: '深色模式、静音、Keep Awake、隐藏 Dock、自动隐藏菜单栏…… 全部映射成简单的 Toggle。',
+      en: 'Dark mode, mute, Keep Awake, hide Dock, auto-hide menu bar — all mapped to a single toggle, or a single key.',
+    },
+  },
+
+  ports: {
+    eyebrow: { zh: '端口管理器', en: 'Port Manager' },
+    h2a: { zh: '哪个进程占了', en: "What's running" },
+    h2b: { zh: ':3000？', en: 'on :3000?' },
+    lede: {
+      zh: '一个子菜单列出系统上每个正在监听的端口。按端口号或进程名搜索，平铺或按进程分组查看，扫描失败自动重试。',
+      en: 'A submenu listing every listening port on the system. Search by port or process name. Flat list and process-grouped tree views. Live refresh with retry on scan failure.',
+    },
+    placeholder: { zh: '搜索端口或进程...', en: 'Search ports or processes...' },
+    refresh: { zh: '刷新', en: 'Refresh' },
+    tree: { zh: '树状视图', en: 'Tree View' },
+    noMatch: { zh: '无匹配端口', en: 'No matching ports' },
+    panelTitle: { zh: '端口管理', en: 'Port Manager' },
+    appShortcuts: { zh: '应用快捷键', en: 'App Shortcuts' },
+    enabled: { zh: '22 个已启用', en: '22 enabled' },
+  },
+
+  actions: {
+    eyebrow: { zh: '内置动作', en: 'Built-in actions' },
+    h2a: { zh: 'OCR、取色、截图,', en: 'OCR, color picker, capture —' },
+    h2b: { zh: '都在一个键之内。', en: 'one key away.' },
+    lede: {
+      zh: '不只是 App 切换。绑定任意热键来运行 macOS 自带的内置动作——结果直接进入剪贴板。',
+      en: 'AnyDoor is more than an app switcher. Bind any hotkey to run a built-in macOS action — results land directly on the clipboard.',
+    },
+    ocrName: { zh: '屏幕取词', en: 'Screen OCR' },
+    ocrDesc: { zh: 'Vision 框架识别屏幕区域文字，自动复制到剪贴板。', en: 'Vision framework recognizes text in a screen region and copies it to the clipboard.' },
+    ocrToast: { zh: '已复制到剪贴板', en: 'Copied to clipboard' },
+    colorName: { zh: '屏幕取色', en: 'Pick Color' },
+    colorDesc: { zh: '系统取色器把任意像素的 HEX 写入剪贴板。', en: 'System color sampler captures HEX into the clipboard.' },
+    shotName: { zh: '区域截图', en: 'Region Screenshot' },
+    shotDesc: { zh: '交互式区域截图，直接到剪贴板。', en: 'Interactive region capture, straight to the clipboard.' },
+  },
+
+  settings: {
+    eyebrow: { zh: '设置面板', en: 'Settings' },
+    h2a: { zh: '可拖拽排序的', en: 'Drag-to-reorder rows.' },
+    h2b: { zh: '面板项与录入式快捷键。', en: 'Inline hotkey recorder.' },
+    lede: {
+      zh: '在「面板」标签页里：拖拽重排、按项隐藏、内联录入热键、类型徽标（开关 / 动作 / 子菜单）。「通用」标签页：开机启动、菜单栏图标样式、权限状态。',
+      en: 'In the Panel tab: drag-to-reorder, per-item visibility, inline hotkey recorder, type badges (toggle / action / submenu). In the General tab: launch at login, menu bar icon style, accessibility & automation permissions.',
+    },
+    tabPanel: { zh: '面板', en: 'Panel' },
+    tabGeneral: { zh: '通用', en: 'General' },
+    record: { zh: '点击录入', en: 'Click to record' },
+    recordPress: { zh: '请按下…', en: 'Press keys…' },
+    hint: { zh: '系统条目无法删除，只能隐藏；应用快捷键可自由增删。', en: 'System items can be hidden but not removed; app shortcuts can be added or removed freely.' },
+    badgeSubmenu: { zh: '子菜单', en: 'submenu' },
+    badgeToggle: { zh: '开关', en: 'toggle' },
+    badgeAction: { zh: '动作', en: 'action' },
+    metaSystem: { zh: '系统', en: 'system' },
+    metaSubmenu: { zh: '系统 · 子菜单', en: 'system · submenu' },
+    metaAction: { zh: '系统 · 动作', en: 'system · action' },
+    twoBindings: { zh: '2 个绑定', en: '2 bindings' },
+    portsCount: { zh: '26 个端口', en: '26 ports' },
+  },
+
+  download: {
+    eyebrow: { zh: '下载', en: 'Download' },
+    h2a: { zh: '准备好了', en: 'Ready when' },
+    h2b: { zh: '吗？', en: 'you are.' },
+    lede: { zh: '免费、开源、本地运行，没有任何遥测。', en: 'Free, open source, runs entirely locally. No telemetry, no account.' },
+    dmgTitle: { zh: '下载 .dmg', en: 'Download the .dmg' },
+    dmgDesc: { zh: '签名 + 公证的安装包，集成 Sparkle 自动更新。', en: 'Signed + notarized installer with Sparkle auto-update built in.' },
+    dmgBtn: { zh: '下载 AnyDoor 1.1.0', en: 'Download AnyDoor 1.1.0' },
+    brewTitle: { zh: '或者用源码构建', en: 'Or build from source' },
+    brewDesc: { zh: '从源码构建并安装到 /Applications。', en: 'Build the release binary and install to /Applications.' },
+    copy: { zh: '复制', en: 'Copy' },
+    copied: { zh: '已复制', en: 'Copied' },
+  },
+
+  faq: {
+    eyebrow: { zh: 'FAQ', en: 'FAQ' },
+    h2: { zh: '一些常见的问题。', en: 'Some common questions.' },
+    items: [
+      {
+        q: { zh: 'AnyDoor 收集任何数据吗？', en: 'Does AnyDoor collect any data?' },
+        a: { zh: '不。AnyDoor 完全在本地运行，没有任何遥测、统计或网络回传。源码 100% 开源、可审计。', en: 'No. AnyDoor runs entirely on-device. There is no telemetry, no analytics, no network callbacks. The source is 100% open and auditable.' },
+      },
+      {
+        q: { zh: '为什么需要辅助功能权限？', en: 'Why does it need accessibility permission?' },
+        a: { zh: 'AnyDoor 通过 CGEvent tap 在 HID 层级别截获键盘事件，这是 macOS 实现全局热键的标准方式。所有事件处理都在本地完成。', en: 'AnyDoor uses a CGEvent tap at the HID level to intercept keyboard events — the standard macOS path for global hotkeys. All event handling stays local.' },
+      },
+      {
+        q: { zh: 'Liquid Glass 在我的 macOS 上能看到吗？', en: 'Will I see Liquid Glass on my macOS?' },
+        a: { zh: 'Liquid Glass 效果在 macOS 26 (Tahoe) 上完整启用；macOS 14–25 会自动降级为标准的菜单材质，功能完全相同。', en: 'Liquid Glass effects light up on macOS 26 (Tahoe); macOS 14–25 fall back to the standard menu material — same features, same behaviour.' },
+      },
+      {
+        q: { zh: '怎么打包做开发自定义？', en: 'How do I build it myself?' },
+        a: { zh: '仓库里包含完整的 Make 流水线：make swift-release 构建二进制，make release 1.1.0 做签名 + 公证 + 上传 GitHub Release + 更新 Sparkle appcast。', en: 'The repo ships a complete Make pipeline: `make swift-release` builds the binary, `make release 1.1.0` signs, notarizes, ships to GitHub Releases, and refreshes the Sparkle appcast.' },
+      },
+    ] as { q: Bi; a: Bi }[],
+  },
+
+  footer: {
+    tagline: { zh: '一颗按键，一扇任意门。', en: 'One key. Any door.' },
+    links: { zh: ['GitHub', 'Releases', 'CHANGELOG', 'MIT License'], en: ['GitHub', 'Releases', 'CHANGELOG', 'MIT License'] },
+    built: { zh: 'Made with Swift 6.2 in 2026.', en: 'Made with Swift 6.2 in 2026.' },
+  },
+};
+
+// Render helper — emits both language nodes; CSS hides the inactive one.
+export function bi(s: Bi): string {
+  return `<span data-i18n-zh>${s.zh}</span><span data-i18n-en>${s.en}</span>`;
+}

--- a/landing/src/lib/data.ts
+++ b/landing/src/lib/data.ts
@@ -1,0 +1,132 @@
+// Data tables — panel items, sample ports, hotkey apps, settings rows, toggle cards.
+
+import type { Bi } from './copy';
+
+// Menu-panel rows (mirror the AnyDoor screenshots, all 22 items).
+export type PanelItem = {
+  key: string;
+  type: 'submenu' | 'toggle' | 'action';
+  icon: string;            // key into icons.ts
+  label: Bi;
+  sub?: Bi;
+  hotkey?: string[];        // displayed key glyphs
+};
+
+export const panelItems: PanelItem[] = [
+  { key: 'shortcuts',    type: 'submenu', icon: 'keyboard',   label: { zh: '应用快捷键', en: 'App Shortcuts' }, sub: { zh: '2 个绑定', en: '2 bindings' } },
+  { key: 'ports',        type: 'submenu', icon: 'globe',      label: { zh: '端口管理', en: 'Port Manager' } },
+  { key: 'keepAwake',    type: 'toggle',  icon: 'coffee',     label: { zh: 'Keep Awake', en: 'Keep Awake' } },
+  { key: 'mute',         type: 'toggle',  icon: 'mute',       label: { zh: '静音', en: 'Mute' } },
+  { key: 'hideDesk',     type: 'toggle',  icon: 'hideDesk',   label: { zh: '隐藏桌面图标', en: 'Hide Desktop' } },
+  { key: 'showHidden',   type: 'toggle',  icon: 'eye',        label: { zh: '显示隐藏文件', en: 'Show Hidden Files' } },
+  { key: 'dark',         type: 'toggle',  icon: 'moon',       label: { zh: '深色模式', en: 'Dark Mode' } },
+  { key: 'lock',         type: 'action',  icon: 'lock',       label: { zh: '锁定屏幕', en: 'Lock Screen' } },
+  { key: 'trash',        type: 'action',  icon: 'trash',      label: { zh: '清空废纸篓', en: 'Empty Trash' } },
+  { key: 'screenshot',   type: 'action',  icon: 'camera',     label: { zh: '截图到剪贴板', en: 'Screenshot to Clipboard' } },
+  { key: 'displaySleep', type: 'action',  icon: 'sleepZ',     label: { zh: '显示器睡眠', en: 'Display Sleep' } },
+  { key: 'systemSleep',  type: 'action',  icon: 'moon',       label: { zh: '系统休眠', en: 'System Sleep' } },
+  { key: 'hideDock',     type: 'toggle',  icon: 'dock',       label: { zh: '隐藏 Dock', en: 'Hide Dock' } },
+  { key: 'hideMenubar',  type: 'toggle',  icon: 'menubar',    label: { zh: '自动隐藏菜单栏', en: 'Auto-hide Menu Bar' } },
+  { key: 'restartFinder',type: 'action',  icon: 'finder',     label: { zh: '重启访达', en: 'Restart Finder' } },
+  { key: 'restartDock',  type: 'action',  icon: 'restart',    label: { zh: '重启 Dock', en: 'Restart Dock' } },
+  { key: 'restartMB',    type: 'action',  icon: 'upload',     label: { zh: '重启菜单栏', en: 'Restart Menu Bar' } },
+  { key: 'flushDNS',     type: 'action',  icon: 'refreshDNS', label: { zh: '刷新 DNS', en: 'Flush DNS' } },
+  { key: 'kbLock',       type: 'toggle',  icon: 'keyOff',     label: { zh: '禁用键盘', en: 'Keyboard Lock' } },
+  { key: 'ocr',          type: 'action',  icon: 'ocr',        label: { zh: '屏幕取词', en: 'Screen OCR' }, hotkey: ['⇧', '⌘', '2'] },
+  { key: 'pickColor',    type: 'action',  icon: 'eyedropper', label: { zh: '屏幕取色', en: 'Pick Color' } },
+  { key: 'qr',           type: 'action',  icon: 'qr',         label: { zh: '识别二维码', en: 'Scan QR Code' } },
+];
+
+// Toggles defaulted on
+export const defaultOnToggles: Record<string, boolean> = {
+  dark: true,
+  hideDock: true,
+};
+
+// Sample ports — generic services, no exposed app names.
+export type Port = { port: number; name: string; pid: number };
+export const samplePorts: Port[] = [
+  { port: 3000,  name: 'node',        pid: 1024 },
+  { port: 5173,  name: 'vite',        pid: 2156 },
+  { port: 5432,  name: 'postgres',    pid: 487  },
+  { port: 6379,  name: 'redis-server',pid: 612  },
+  { port: 8080,  name: 'docker',      pid: 1893 },
+  { port: 8088,  name: 'nginx',       pid: 902  },
+  { port: 9229,  name: 'node',        pid: 4421 },
+  { port: 27017, name: 'mongod',      pid: 765  },
+  { port: 4000,  name: 'python3',     pid: 3104 },
+  { port: 7000,  name: 'ControlCenter',pid: 665 },
+  { port: 4500,  name: 'rapportd',    pid: 412  },
+  { port: 50000, name: 'python3',     pid: 5821 },
+];
+
+// Hotkey apps shown in the desktop / dock animation.
+export type HotkeyApp = { key: string; name: string; grad: string; letter: string; tag: string };
+export const hotkeyApps: HotkeyApp[] = [
+  { key: 'F1', name: 'Dockerman',  grad: 'linear-gradient(135deg, #0db7ed, #066da5)', letter: 'D', tag: 'Docker Desktop Manager' },
+  { key: 'F2', name: 'ServerBee',  grad: 'linear-gradient(135deg, #ffb900, #ff7a00)', letter: 'S', tag: 'Server Monitor' },
+  { key: 'F3', name: 'Finder',     grad: 'linear-gradient(135deg, #6dd4ff, #1f8fff)', letter: 'F', tag: 'macOS File Browser' },
+  { key: 'F4', name: 'Safari',     grad: 'linear-gradient(135deg, #36d4ff, #1873e8)', letter: 'S', tag: 'macOS Web Browser' },
+  { key: 'F5', name: 'Notes',      grad: 'linear-gradient(135deg, #ffe28a, #f5b800)', letter: 'N', tag: 'macOS Notes' },
+  { key: 'F6', name: 'Calculator', grad: 'linear-gradient(135deg, #2a2a2e, #0a0a0d)', letter: 'C', tag: 'macOS Calculator' },
+];
+
+// Toggle hero cards.
+export type ToggleCard = {
+  key: string;
+  icon: string;
+  iconOnBg: string;
+  iconOnColor: string;
+  cardClass?: string;
+  name: Bi;
+  desc: Bi;
+  stateOn: Bi;
+  stateOff: Bi;
+};
+export const toggleCards: ToggleCard[] = [
+  { key: 'dark',        icon: 'moon',    iconOnBg: 'rgba(94,155,255,.18)',  iconOnColor: '#5e9bff',
+    cardClass: 'dark-card',
+    name: { zh: '深色模式', en: 'Dark Mode' },
+    desc: { zh: '通过 AppleScript 翻转系统外观。', en: 'Flip system appearance via AppleScript.' },
+    stateOn: { zh: '已启用', en: 'Engaged' }, stateOff: { zh: '已关闭', en: 'Disabled' } },
+  { key: 'keepAwake',   icon: 'coffee',  iconOnBg: 'rgba(255,159,10,.18)',  iconOnColor: '#ff9f0a',
+    cardClass: 'awake-card',
+    name: { zh: 'Keep Awake', en: 'Keep Awake' },
+    desc: { zh: '持有 IOPMAssertion，阻止显示器和系统休眠。', en: 'Holds an IOPMAssertion to prevent sleep.' },
+    stateOn: { zh: '屏幕不会睡眠', en: 'Display stays on' }, stateOff: { zh: '按系统设置睡眠', en: 'Default sleep' } },
+  { key: 'mute',        icon: 'mute',    iconOnBg: 'rgba(255,159,10,.18)',  iconOnColor: '#ff9f0a',
+    name: { zh: '静音', en: 'Mute' },
+    desc: { zh: '静音/取消静音 Core Audio 默认输出设备。', en: 'Mute the default Core Audio output device.' },
+    stateOn: { zh: '输出已静音', en: 'Output muted' }, stateOff: { zh: '输出已开启', en: 'Output live' } },
+  { key: 'hideDock',    icon: 'dock',    iconOnBg: 'rgba(94,155,255,.18)',  iconOnColor: '#5e9bff',
+    name: { zh: '隐藏 Dock', en: 'Hide Dock' },
+    desc: { zh: '切换 Dock 自动隐藏。', en: 'Toggle Dock auto-hide.' },
+    stateOn: { zh: 'Dock 已隐藏', en: 'Dock hidden' }, stateOff: { zh: 'Dock 已显示', en: 'Dock visible' } },
+  { key: 'hideMenubar', icon: 'menubar', iconOnBg: 'rgba(94,155,255,.18)',  iconOnColor: '#5e9bff',
+    name: { zh: '自动隐藏菜单栏', en: 'Auto-hide MB' },
+    desc: { zh: '切换 _HIHideMenuBar。', en: 'Toggle _HIHideMenuBar.' },
+    stateOn: { zh: '菜单栏已隐藏', en: 'Menu bar hidden' }, stateOff: { zh: '菜单栏常驻', en: 'Menu bar visible' } },
+  { key: 'showHidden',  icon: 'eye',     iconOnBg: 'rgba(48,209,88,.18)',   iconOnColor: '#30d158',
+    name: { zh: '显示隐藏文件', en: 'Show Hidden' },
+    desc: { zh: '切换 Finder 的 AppleShowAllFiles。', en: "Toggle Finder's AppleShowAllFiles." },
+    stateOn: { zh: '隐藏文件可见', en: 'Hidden files shown' }, stateOff: { zh: '隐藏文件不可见', en: 'Hidden files hidden' } },
+];
+
+// Settings panel rows.
+export type SettingsRow = {
+  key: string;
+  icon: string;
+  type: 'submenu' | 'toggle' | 'action';
+  label: Bi;
+};
+export const settingsRows: SettingsRow[] = [
+  { key: 'shortcuts', icon: 'keyboard', type: 'submenu', label: { zh: '应用快捷键', en: 'App Shortcuts' } },
+  { key: 'ports',     icon: 'globe',    type: 'submenu', label: { zh: '端口管理', en: 'Port Manager' } },
+  { key: 'keepAwake', icon: 'coffee',   type: 'toggle',  label: { zh: 'Keep Awake', en: 'Keep Awake' } },
+  { key: 'mute',      icon: 'mute',     type: 'toggle',  label: { zh: '静音', en: 'Mute' } },
+  { key: 'hideDesk',  icon: 'hideDesk', type: 'toggle',  label: { zh: '隐藏桌面图标', en: 'Hide Desktop' } },
+  { key: 'showHidden',icon: 'eye',      type: 'toggle',  label: { zh: '显示隐藏文件', en: 'Show Hidden Files' } },
+  { key: 'dark',      icon: 'moon',     type: 'toggle',  label: { zh: '深色模式', en: 'Dark Mode' } },
+  { key: 'lock',      icon: 'lock',     type: 'action',  label: { zh: '锁定屏幕', en: 'Lock Screen' } },
+  { key: 'trash',     icon: 'trash',    type: 'action',  label: { zh: '清空废纸篓', en: 'Empty Trash' } },
+];

--- a/landing/src/lib/icons.ts
+++ b/landing/src/lib/icons.ts
@@ -1,0 +1,42 @@
+// SVG icons used in the menu panel and elsewhere.
+// Returned as raw strings so .astro components can `set:html` them.
+
+const wrap = (paths: string, stroke = 1.6) =>
+  `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="${stroke}" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`;
+
+export const icons = {
+  keyboard:   () => wrap(`<rect x="2" y="6" width="20" height="13" rx="2.5"/><path d="M6 10h.01M10 10h.01M14 10h.01M18 10h.01M6 14h.01M18 14h.01M9 14h6"/>`),
+  globe:      () => wrap(`<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18"/>`),
+  coffee:     () => wrap(`<path d="M17 8h1a3 3 0 0 1 0 6h-1"/><path d="M3 8h14v7a5 5 0 0 1-5 5H8a5 5 0 0 1-5-5z"/><path d="M6 2v3M10 2v3M14 2v3"/>`),
+  mute:       () => wrap(`<path d="M11 5L6 9H2v6h4l5 4z"/><path d="M22 9l-6 6M16 9l6 6"/>`),
+  hideDesk:   () => wrap(`<path d="M3 3l18 18"/><rect x="3" y="3" width="18" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>`),
+  eye:        () => wrap(`<path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/>`),
+  moon:       () => wrap(`<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>`),
+  lock:       () => wrap(`<rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/>`),
+  trash:      () => wrap(`<path d="M4 7h16M10 11v6M14 11v6"/><path d="M6 7l1 13a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-13"/><path d="M9 7V4h6v3"/>`),
+  camera:     () => wrap(`<path d="M3 8h4l2-3h6l2 3h4v11H3z"/><circle cx="12" cy="13" r="3.5"/>`),
+  sleepZ:     () => wrap(`<circle cx="12" cy="12" r="9"/><path d="M9 9h6l-6 6h6"/>`),
+  dock:       () => wrap(`<rect x="3" y="6" width="18" height="12" rx="2"/><path d="M3 14h18"/>`),
+  menubar:    () => wrap(`<rect x="3" y="6" width="18" height="12" rx="2"/><path d="M3 10h18"/>`),
+  finder:     () => wrap(`<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 8v3M16 8v3M8 16c1 1 2.5 2 4 2s3-1 4-2"/>`),
+  restart:    () => wrap(`<path d="M21 12a9 9 0 1 1-3.2-6.9"/><path d="M21 4v5h-5"/>`),
+  upload:     () => wrap(`<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M12 16V8m-3 3l3-3 3 3"/>`),
+  refreshDNS: () => wrap(`<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3v18"/>`),
+  keyOff:     () => wrap(`<rect x="2" y="6" width="20" height="13" rx="2.5"/><path d="M3 4l18 18"/>`),
+  ocr:        () => wrap(`<path d="M4 8V6a2 2 0 0 1 2-2h2M16 4h2a2 2 0 0 1 2 2v2M20 16v2a2 2 0 0 1-2 2h-2M8 20H6a2 2 0 0 1-2-2v-2"/><path d="M8 11h.01M12 11h.01M16 11h.01M8 14h8"/>`),
+  eyedropper: () => wrap(`<path d="M11 4l2-2 5 5-2 2"/><path d="M14 7l-9 9v4h4l9-9"/>`),
+  qr:         () => wrap(`<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><path d="M14 14h3v3h-3zM20 14h1M14 20h3M20 17v4"/>`),
+  settings:   () => wrap(`<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1A1.7 1.7 0 0 0 9 19.4a1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1A1.7 1.7 0 0 0 4.6 9a1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9c.4.6 1 1 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>`),
+  power:      () => wrap(`<path d="M18.4 6.6a9 9 0 1 1-12.8 0M12 2v10"/>`),
+  chev:       () => wrap(`<path d="M9 6l6 6-6 6"/>`, 1.8),
+  search:     () => wrap(`<circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/>`),
+  refresh:    () => wrap(`<path d="M21 12a9 9 0 1 1-3.2-6.9"/><path d="M21 4v5h-5"/>`),
+  tree:       () => wrap(`<path d="M5 4h6M5 4v16h6M5 12h6M17 4h2v3h-2zM17 11h2v3h-2zM17 18h2v3h-2z"/>`),
+  check:      () => wrap(`<path d="M5 12l5 5L20 7"/>`, 2.4),
+  plus:       () => wrap(`<path d="M12 5v14M5 12h14"/>`),
+  grip:       () => wrap(`<circle cx="8" cy="8" r=".8" fill="currentColor"/><circle cx="16" cy="8" r=".8" fill="currentColor"/><circle cx="8" cy="12" r=".8" fill="currentColor"/><circle cx="16" cy="12" r=".8" fill="currentColor"/><circle cx="8" cy="16" r=".8" fill="currentColor"/><circle cx="16" cy="16" r=".8" fill="currentColor"/>`),
+  github:     () => wrap(`<path d="M9 19c-4.5 1.5-4.5-2.5-6-3M16 22v-3.8c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 0 0-1.3-3.2 4.2 4.2 0 0 0-.1-3.2s-1-.3-3.6 1.3a12.4 12.4 0 0 0-6 0C7.5 3.7 6.5 4 6.5 4a4.2 4.2 0 0 0-.1 3.2A4.6 4.6 0 0 0 5 10.4c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V22"/>`),
+  bolt:       () => wrap(`<path d="M13 2L3 14h7l-1 8 10-12h-7z"/>`),
+  clipboard:  () => wrap(`<rect x="6" y="4" width="12" height="18" rx="2"/><path d="M9 4V3a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1"/>`),
+  door:       () => wrap(`<path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16"/><path d="M4 21h16"/><circle cx="14.5" cy="13" r="0.9" fill="currentColor"/>`, 1.8),
+};

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -7,6 +7,7 @@ import Toggles from '../components/Toggles.astro';
 import PortManager from '../components/PortManager.astro';
 import Actions from '../components/Actions.astro';
 import Settings from '../components/Settings.astro';
+import Download from '../components/Download.astro';
 ---
 
 <!doctype html>
@@ -34,6 +35,7 @@ import Settings from '../components/Settings.astro';
       <PortManager />
       <Actions />
       <Settings />
+      <Download />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Hero from '../components/Hero.astro';
+import HotkeyDemo from '../components/HotkeyDemo.astro';
 ---
 
 <!doctype html>
@@ -24,6 +25,7 @@ import Hero from '../components/Hero.astro';
 
     <main>
       <Hero />
+      <HotkeyDemo />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -6,6 +6,7 @@ import HotkeyDemo from '../components/HotkeyDemo.astro';
 import Toggles from '../components/Toggles.astro';
 import PortManager from '../components/PortManager.astro';
 import Actions from '../components/Actions.astro';
+import Settings from '../components/Settings.astro';
 ---
 
 <!doctype html>
@@ -32,6 +33,7 @@ import Actions from '../components/Actions.astro';
       <Toggles />
       <PortManager />
       <Actions />
+      <Settings />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
+import Hero from '../components/Hero.astro';
 ---
 
 <!doctype html>
@@ -21,7 +22,9 @@ import Nav from '../components/Nav.astro';
 
     <Nav />
 
-    <main></main>
+    <main>
+      <Hero />
+    </main>
 
     <script>
       // Cursor glow follows pointer.

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from '../components/Hero.astro';
 import HotkeyDemo from '../components/HotkeyDemo.astro';
 import Toggles from '../components/Toggles.astro';
 import PortManager from '../components/PortManager.astro';
+import Actions from '../components/Actions.astro';
 ---
 
 <!doctype html>
@@ -30,6 +31,7 @@ import PortManager from '../components/PortManager.astro';
       <HotkeyDemo />
       <Toggles />
       <PortManager />
+      <Actions />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import Nav from '../components/Nav.astro';
 ---
 
 <!doctype html>
@@ -17,6 +18,8 @@ import '../styles/global.css';
   </head>
   <body>
     <div class="cursor-glow" id="cursor-glow"></div>
+
+    <Nav />
 
     <main></main>
 

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -1,0 +1,34 @@
+---
+import '../styles/global.css';
+---
+
+<!doctype html>
+<html lang="zh-CN" data-lang="zh">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>AnyDoor — 一颗按键，一扇任意门</title>
+    <meta name="description" content="A macOS menu bar control center driven by global hotkeys." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta property="og:title" content="AnyDoor — macOS menu bar control center" />
+    <meta property="og:description" content="Bind any key combination to launch and toggle apps, flip system settings, or run one-off actions." />
+    <meta property="og:type" content="website" />
+    <meta name="theme-color" content="#050507" />
+  </head>
+  <body>
+    <div class="cursor-glow" id="cursor-glow"></div>
+
+    <main></main>
+
+    <script>
+      // Cursor glow follows pointer.
+      const glow = document.getElementById('cursor-glow');
+      if (glow) {
+        window.addEventListener('mousemove', (e) => {
+          glow.style.left = e.clientX + 'px';
+          glow.style.top = e.clientY + 'px';
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -4,6 +4,7 @@ import Nav from '../components/Nav.astro';
 import Hero from '../components/Hero.astro';
 import HotkeyDemo from '../components/HotkeyDemo.astro';
 import Toggles from '../components/Toggles.astro';
+import PortManager from '../components/PortManager.astro';
 ---
 
 <!doctype html>
@@ -28,6 +29,7 @@ import Toggles from '../components/Toggles.astro';
       <Hero />
       <HotkeyDemo />
       <Toggles />
+      <PortManager />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Hero from '../components/Hero.astro';
 import HotkeyDemo from '../components/HotkeyDemo.astro';
+import Toggles from '../components/Toggles.astro';
 ---
 
 <!doctype html>
@@ -26,6 +27,7 @@ import HotkeyDemo from '../components/HotkeyDemo.astro';
     <main>
       <Hero />
       <HotkeyDemo />
+      <Toggles />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -8,6 +8,7 @@ import PortManager from '../components/PortManager.astro';
 import Actions from '../components/Actions.astro';
 import Settings from '../components/Settings.astro';
 import Download from '../components/Download.astro';
+import FAQ from '../components/FAQ.astro';
 ---
 
 <!doctype html>
@@ -36,6 +37,7 @@ import Download from '../components/Download.astro';
       <Actions />
       <Settings />
       <Download />
+      <FAQ />
     </main>
 
     <script>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -9,6 +9,7 @@ import Actions from '../components/Actions.astro';
 import Settings from '../components/Settings.astro';
 import Download from '../components/Download.astro';
 import FAQ from '../components/FAQ.astro';
+import Footer from '../components/Footer.astro';
 ---
 
 <!doctype html>
@@ -39,6 +40,8 @@ import FAQ from '../components/FAQ.astro';
       <Download />
       <FAQ />
     </main>
+
+    <Footer />
 
     <script>
       // Cursor glow follows pointer.

--- a/landing/src/styles/global.css
+++ b/landing/src/styles/global.css
@@ -1,0 +1,709 @@
+@import "tailwindcss";
+
+/* ─────────────────────────── Tokens ─────────────────────────── */
+@theme {
+  --color-bg: #050507;
+  --color-surface: rgba(28, 28, 32, 0.85);
+  --color-line: rgba(255, 255, 255, 0.08);
+  --color-line-strong: rgba(255, 255, 255, 0.14);
+  --color-text: #f5f5f7;
+  --color-text-dim: #a1a1aa;
+  --color-text-soft: #6e6e76;
+  --color-accent: #0a84ff;
+  --color-accent-2: #5e9bff;
+  --color-mac-green: #30d158;
+  --color-mac-orange: #ff9f0a;
+  --color-mac-red: #ff453a;
+  --color-mac-purple: #bf5af2;
+  --color-mac-pink: #ff375f;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+    "PingFang SC", "Helvetica Neue", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+/* ─────────────────────────── Base ─────────────────────────── */
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--color-bg);color:var(--color-text)}
+body{
+  font: 16px/1.55 var(--font-sans);
+  font-feature-settings: "ss01", "cv11";
+  letter-spacing: -.01em;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+body::before{
+  content:"";
+  position:fixed; inset:0; z-index:-2;
+  background:
+    radial-gradient(900px 600px at 80% -10%, rgba(10,132,255,.18), transparent 60%),
+    radial-gradient(900px 600px at -10% 30%, rgba(191,90,242,.10), transparent 60%),
+    radial-gradient(700px 500px at 50% 110%, rgba(48,209,88,.06), transparent 70%),
+    var(--color-bg);
+  pointer-events:none;
+}
+body::after{
+  content:""; position:fixed; inset:0; z-index:-1; pointer-events:none;
+  background-image: radial-gradient(rgba(255,255,255,.045) 1px, transparent 1px);
+  background-size: 3px 3px;
+  mix-blend-mode: screen;
+  opacity:.5;
+}
+
+/* Cursor glow */
+.cursor-glow{
+  position:fixed; pointer-events:none; z-index:0;
+  width:520px; height:520px;
+  border-radius:50%;
+  transform: translate(-50%,-50%);
+  background: radial-gradient(closest-side, rgba(94,155,255,.16), transparent 70%);
+  filter: blur(20px);
+  opacity: .9;
+}
+
+/* ─────────────────────────── i18n ─────────────────────────── */
+/* Show only the active language's nodes */
+html[data-lang="zh"] [data-i18n-en]{display:none !important}
+html[data-lang="en"] [data-i18n-zh]{display:none !important}
+
+/* ─────────────────────────── Type ─────────────────────────── */
+.gradient-text{
+  background: linear-gradient(180deg, #fff 30%, #8b8b94 130%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+}
+.accent-text{
+  background: linear-gradient(135deg, #5e9bff 0%, #bf5af2 60%, #ff375f 110%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+}
+.eyebrow{
+  display:inline-flex; align-items:center; gap:8px;
+  font-size:12px; letter-spacing:.18em; text-transform:uppercase;
+  color: var(--color-text-dim); font-weight:600;
+}
+.eyebrow .dot{width:6px; height:6px; border-radius:50%; background: var(--color-accent); box-shadow: 0 0 12px var(--color-accent);}
+
+/* ─────────────────────────── Layout helpers ─────────────────────────── */
+.container-x{max-width: 1240px; margin: 0 auto; padding: 0 28px}
+.section{padding: 120px 0; position:relative}
+
+/* ─────────────────────────── Buttons ─────────────────────────── */
+.btn-primary{
+  display:inline-flex; align-items:center; gap:8px;
+  background: #fff; color: #000;
+  padding: 13px 22px; border-radius: 999px;
+  font-weight: 600; font-size: 14.5px; text-decoration:none;
+  border: none; cursor:pointer;
+  transition: transform .15s ease, box-shadow .2s ease;
+  box-shadow: 0 8px 24px rgba(255,255,255,.12);
+}
+.btn-primary:hover{transform: translateY(-1px); box-shadow: 0 12px 30px rgba(255,255,255,.18)}
+.btn-secondary{
+  display:inline-flex; align-items:center; gap:8px;
+  color: var(--color-text); padding: 13px 22px;
+  background: rgba(255,255,255,.06);
+  border: .5px solid var(--color-line-strong);
+  border-radius: 999px;
+  font-weight: 500; font-size: 14.5px; text-decoration:none;
+  cursor:pointer;
+  transition: background .15s ease;
+}
+.btn-secondary:hover{background: rgba(255,255,255,.12)}
+
+/* ─────────────────────────── Menu bar panel ─────────────────────────── */
+.mbpanel{
+  width: 320px;
+  background: linear-gradient(180deg, rgba(38,38,42,.92), rgba(22,22,26,.92));
+  border: .5px solid rgba(255,255,255,.10);
+  box-shadow:
+    0 0 0 .5px rgba(255,255,255,.06) inset,
+    0 30px 80px rgba(0,0,0,.6),
+    0 8px 28px rgba(0,0,0,.4);
+  border-radius: 16px;
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  padding: 8px;
+  user-select: none;
+  font-size: 13px;
+  color: var(--color-text);
+  position: relative;
+}
+.mbpanel-head{display:flex; align-items:center; justify-content:space-between; padding: 6px 10px 10px}
+.mbpanel-head .title{font-size:14px; font-weight:600; letter-spacing:-.01em}
+.mbpanel-head .meta{font-size:11.5px; color:var(--color-text-soft)}
+
+.mbrow{
+  display:flex; align-items:center; gap:12px;
+  padding: 9px 10px; border-radius:9px;
+  transition: background .15s ease;
+  position: relative;
+}
+.mbrow:hover{background: rgba(255,255,255,.06)}
+.mbrow .ico{width:22px; height:22px; display:grid; place-items:center; color:#d8d8dc; flex:0 0 22px}
+.mbrow .ico.on{color: var(--color-accent-2)}
+.mbrow .label{flex:1; font-size:13.5px; font-weight:500; letter-spacing:-.005em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+.mbrow .sub{font-size:11px; color:var(--color-text-soft); margin-top:1px}
+.mbrow .chev{color: var(--color-text-soft)}
+.mbrow .keys{display:flex; gap:4px}
+.kbd{
+  display:inline-flex; align-items:center; justify-content:center;
+  min-width: 22px; height: 22px; padding: 0 6px;
+  background: rgba(255,255,255,.07);
+  border: .5px solid rgba(255,255,255,.12);
+  border-radius: 5px;
+  font: 600 11px/1 var(--font-mono);
+  color: var(--color-text);
+}
+
+/* iOS-style toggle */
+.toggle{
+  --w: 38px; --h: 22px;
+  position:relative; width:var(--w); height:var(--h);
+  border-radius: 999px; background: rgba(120,120,128,.32);
+  border: none; padding: 0; cursor: pointer; transition: background .25s ease;
+  flex: 0 0 auto;
+}
+.toggle::after{
+  content:""; position:absolute; top:2px; left:2px;
+  width: calc(var(--h) - 4px); height: calc(var(--h) - 4px);
+  border-radius: 50%; background: #fff;
+  box-shadow: 0 1px 2px rgba(0,0,0,.25), 0 1px 4px rgba(0,0,0,.15);
+  transition: transform .25s cubic-bezier(.4,.6,.3,1.2);
+}
+.toggle.on{background: var(--color-accent)}
+.toggle.on::after{transform: translateX(calc(var(--w) - var(--h)))}
+
+.mbpanel-foot{
+  display:flex; gap:6px; padding: 8px 4px 4px;
+  border-top: .5px solid var(--color-line);
+  margin-top: 6px;
+}
+.mbpanel-foot .btn-foot{
+  flex:1; display:flex; align-items:center; justify-content:center; gap:6px;
+  padding: 8px; border-radius: 8px; color: var(--color-text-dim);
+  font-size: 12.5px; cursor: pointer; transition: background .15s, color .15s;
+}
+.mbpanel-foot .btn-foot:hover{background: rgba(255,255,255,.06); color:var(--color-text)}
+
+/* Popover off the side of a row */
+.popover{
+  position:absolute; left: calc(100% + 12px); top: 0;
+  width: 360px;
+  background: linear-gradient(180deg, rgba(38,38,42,.95), rgba(22,22,26,.95));
+  border: .5px solid rgba(255,255,255,.10);
+  box-shadow: 0 30px 80px rgba(0,0,0,.6);
+  border-radius: 16px;
+  padding: 8px;
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  z-index: 5;
+  opacity: 0; pointer-events: none;
+  transform: translateX(-6px) scale(.98);
+  transition: opacity .25s ease, transform .25s ease;
+}
+.popover.is-open{opacity: 1; transform: translateX(0) scale(1)}
+.popover .pop-head{
+  display:flex; align-items:center; gap:8px; padding: 6px 10px 8px;
+  font-size:12px; color: var(--color-text-dim);
+  border-bottom: .5px solid var(--color-line); margin-bottom: 6px;
+}
+
+.port-row{
+  display:flex; align-items:center; gap:12px; padding: 8px 10px;
+  border-radius: 8px; font-size:13px;
+}
+.port-row:hover{background: rgba(255,255,255,.06)}
+.port-row .dot-running{width:8px; height:8px; border-radius:50%; background:var(--color-mac-green); box-shadow:0 0 6px rgba(48,209,88,.6)}
+.port-row .port{font: 600 13px/1 var(--font-mono); color:var(--color-text); min-width: 60px}
+.port-row .pname{flex:1; font-size:13px; color: var(--color-text)}
+.port-row .pid{font: 500 11.5px/1 var(--font-mono); color: var(--color-text-soft)}
+.port-row mark{background: rgba(10,132,255,.3); color:var(--color-text); padding:1px 3px; border-radius:3px}
+
+/* ─────────────────────────── Hero ─────────────────────────── */
+.hero{
+  min-height: 720px;
+  padding-top: 140px; padding-bottom: 80px;
+  display:grid; grid-template-columns: 1.2fr 340px; gap: 48px;
+  align-items: start; position:relative;
+}
+.hero-stage{
+  position: relative; perspective: 1400px;
+  display:flex; justify-content:center; align-items:flex-start;
+  max-height: 540px;
+  margin-top: 18px;
+}
+.hero-stage .mbpanel{
+  max-height: 510px;
+  mask-image: linear-gradient(180deg, #000 78%, transparent 100%);
+  -webkit-mask-image: linear-gradient(180deg, #000 78%, transparent 100%);
+  overflow: hidden;
+}
+.menubar-strip{
+  position:absolute; top:-44px; left: -20px; right: -20px;
+  height: 28px; border-radius: 8px;
+  background: linear-gradient(180deg, rgba(38,38,42,.86), rgba(20,20,24,.86));
+  border: .5px solid var(--color-line);
+  display:flex; align-items:center; gap: 14px;
+  padding: 0 12px;
+  backdrop-filter: blur(20px);
+  white-space: nowrap; overflow: hidden;
+}
+.mb-apple{
+  width: 14px; height: 14px; flex-shrink:0;
+  background: rgba(255,255,255,.85);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M12.146 7.583c-.01-1.74 1.42-2.575 1.485-2.616-.81-1.185-2.068-1.347-2.513-1.366-1.071-.109-2.092.629-2.636.629-.544 0-1.385-.612-2.276-.595-1.171.017-2.252.681-2.855 1.731-1.218 2.111-.311 5.231.876 6.945.582.84 1.275 1.785 2.185 1.751.876-.034 1.207-.567 2.266-.567 1.058 0 1.358.567 2.286.55.943-.017 1.541-.857 2.117-1.698.668-.974.942-1.917.958-1.967-.021-.009-1.838-.704-1.849-2.797zM10.42 2.4c.484-.587.81-1.401.721-2.21-.697.029-1.541.464-2.041 1.051-.449.521-.842 1.353-.736 2.146.778.06 1.572-.396 2.056-.987z'/></svg>") center/contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M12.146 7.583c-.01-1.74 1.42-2.575 1.485-2.616-.81-1.185-2.068-1.347-2.513-1.366-1.071-.109-2.092.629-2.636.629-.544 0-1.385-.612-2.276-.595-1.171.017-2.252.681-2.855 1.731-1.218 2.111-.311 5.231.876 6.945.582.84 1.275 1.785 2.185 1.751.876-.034 1.207-.567 2.266-.567 1.058 0 1.358.567 2.286.55.943-.017 1.541-.857 2.117-1.698.668-.974.942-1.917.958-1.967-.021-.009-1.838-.704-1.849-2.797zM10.42 2.4c.484-.587.81-1.401.721-2.21-.697.029-1.541.464-2.041 1.051-.449.521-.842 1.353-.736 2.146.778.06 1.572-.396 2.056-.987z'/></svg>") center/contain no-repeat;
+}
+.mb-right{margin-left:auto; display:flex; align-items:center; gap:10px; color: var(--color-text-dim); font-size:11.5px; flex-shrink:0}
+.mb-door{color: rgba(255,255,255,.95); animation: anydoorBlink 4s ease-in-out infinite; flex-shrink: 0}
+@keyframes anydoorBlink{ 0%,90%,100%{opacity:1} 95%{opacity:.5} }
+
+h1.hero-h{
+  font-size: clamp(48px, 7.2vw, 96px);
+  line-height: 1.0; font-weight: 700; letter-spacing: -.045em;
+  margin: 18px 0 24px; text-wrap: balance;
+}
+h2.sec-h{
+  font-size: clamp(36px, 4.6vw, 64px);
+  line-height: 1.05; font-weight: 700; letter-spacing: -.035em;
+  margin: 14px 0 18px; text-wrap: balance;
+}
+.lede{
+  font-size: clamp(17px, 1.4vw, 21px);
+  color: var(--color-text-dim);
+  max-width: 640px; line-height: 1.5; text-wrap: pretty;
+}
+.hero-cta{display:flex; gap:14px; margin-top: 34px; align-items:center; flex-wrap:wrap}
+.hero-meta{display:flex; gap:24px; color:var(--color-text-soft); font-size:12.5px; margin-top: 22px}
+.hero-meta .check{color: var(--color-mac-green); margin-right:5px}
+.feature-pills{display:flex; flex-wrap:wrap; gap:8px; margin-top: 22px}
+.feature-pills span{
+  font-size: 12px; padding: 6px 12px;
+  background: rgba(255,255,255,.05);
+  border: .5px solid var(--color-line);
+  border-radius: 999px; color: var(--color-text-dim);
+}
+
+/* ─────────────────────────── Hotkey demo ─────────────────────────── */
+.hkstage{display:flex; flex-direction:column; align-items:center; gap:40px; margin-top:60px}
+.hkscreen{
+  width: 100%; max-width: 880px;
+  position: relative;
+  aspect-ratio: 16/10;
+  border-radius: 14px;
+  background:
+    radial-gradient(120% 80% at 30% 30%, rgba(94,155,255,.45), transparent 60%),
+    radial-gradient(110% 70% at 75% 75%, rgba(191,90,242,.40), transparent 60%),
+    radial-gradient(90% 60% at 50% 110%, rgba(255,55,95,.20), transparent 60%),
+    linear-gradient(160deg, #1a1a2e 0%, #16213e 40%, #0f0f1e 100%);
+  border: .5px solid var(--color-line-strong);
+  overflow: hidden;
+  box-shadow: 0 0 0 2px rgba(255,255,255,.04) inset, 0 30px 80px rgba(0,0,0,.55);
+  padding: 6px;
+}
+.hkscreen::before{
+  content:""; position:absolute; top:0; left:0; right:0; height:22px;
+  background: rgba(20,20,28,.55);
+  backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: .5px solid rgba(255,255,255,.06);
+  z-index: 2;
+}
+.hkscreen-menu{
+  position:absolute; top:0; left:0; right:0; height:22px;
+  display:flex; align-items:center; gap:14px; padding: 0 12px;
+  font: 500 9.5px/1 var(--font-sans); color: rgba(255,255,255,.85);
+  z-index: 3; pointer-events:none;
+}
+.hkscreen-menu .apple-mini{
+  width: 9px; height: 9px;
+  background: rgba(255,255,255,.85);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M12.146 7.583c-.01-1.74 1.42-2.575 1.485-2.616-.81-1.185-2.068-1.347-2.513-1.366-1.071-.109-2.092.629-2.636.629-.544 0-1.385-.612-2.276-.595-1.171.017-2.252.681-2.855 1.731-1.218 2.111-.311 5.231.876 6.945.582.84 1.275 1.785 2.185 1.751.876-.034 1.207-.567 2.266-.567 1.058 0 1.358.567 2.286.55.943-.017 1.541-.857 2.117-1.698.668-.974.942-1.917.958-1.967-.021-.009-1.838-.704-1.849-2.797z'/></svg>") center/contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M12.146 7.583c-.01-1.74 1.42-2.575 1.485-2.616-.81-1.185-2.068-1.347-2.513-1.366-1.071-.109-2.092.629-2.636.629-.544 0-1.385-.612-2.276-.595-1.171.017-2.252.681-2.855 1.731-1.218 2.111-.311 5.231.876 6.945.582.84 1.275 1.785 2.185 1.751.876-.034 1.207-.567 2.266-.567 1.058 0 1.358.567 2.286.55.943-.017 1.541-.857 2.117-1.698.668-.974.942-1.917.958-1.967-.021-.009-1.838-.704-1.849-2.797z'/></svg>") center/contain no-repeat;
+}
+.hkscreen-menu .app-name{font-weight:700}
+.hkscreen-menu .menu-item{color: rgba(255,255,255,.7); font-weight:400}
+.hkscreen-menu .right{margin-left:auto; display:flex; align-items:center; gap:8px}
+.hkscreen-menu .door{width:9px; height:9px; color: rgba(255,255,255,.95); animation: anydoorBlink 4s ease-in-out infinite}
+.hkscreen .winwrap{position:absolute; inset: 22px 0 50px 0; display:grid; place-items:center; z-index:4}
+.hkscreen-hint{
+  position:absolute; left:50%; top: 42%; transform: translateX(-50%);
+  font-size: 12px; color: rgba(255,255,255,.5);
+  letter-spacing: .04em; z-index: 1;
+  pointer-events: none; transition: opacity .25s ease;
+}
+.hkscreen[data-app-open] .hkscreen-hint{opacity:0; visibility:hidden}
+
+.hkscreen-dock{
+  position:absolute; left:50%; bottom: 10px; transform: translateX(-50%);
+  display:flex; align-items:flex-end; gap: 6px; padding: 5px 7px;
+  background: rgba(255,255,255,.08);
+  border: .5px solid rgba(255,255,255,.14);
+  border-radius: 12px;
+  backdrop-filter: blur(20px) saturate(180%);
+  z-index: 3;
+}
+.dock-item{
+  width: 28px; height: 28px; border-radius: 7px;
+  flex-shrink: 0; position: relative;
+}
+.dock-item.running::after{
+  content:""; position:absolute; bottom:-7px; left:50%; transform: translateX(-50%);
+  width: 3px; height: 3px; border-radius: 50%; background: rgba(255,255,255,.7);
+}
+.dock-item.is-launching{animation: dockBounce .5s cubic-bezier(.4,1.4,.6,1) both}
+@keyframes dockBounce{0%,100%{transform:translateY(0)} 40%{transform:translateY(-14px)}}
+.dock-divider{width: 1px; height: 22px; background: rgba(255,255,255,.15); margin: 0 2px; align-self: center}
+
+.appwin{
+  width: 70%; height: 75%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #2a2a2e, #1c1c1f);
+  border: .5px solid var(--color-line-strong);
+  box-shadow: 0 20px 50px rgba(0,0,0,.6);
+  display: flex; flex-direction: column; overflow:hidden;
+  opacity: 0; transform: translateY(40px) scale(.96);
+  transition: opacity .35s ease, transform .35s cubic-bezier(.3,.7,.3,1.2);
+}
+.appwin.show{opacity:1; transform: translateY(0) scale(1)}
+.appwin .titlebar{display:flex; align-items:center; gap:8px; padding: 10px 14px; border-bottom: .5px solid var(--color-line)}
+.appwin .traffic{display:flex; gap:6px}
+.appwin .traffic span{width:11px;height:11px;border-radius:50%}
+.appwin .traffic .r{background:#ff5f57}
+.appwin .traffic .y{background:#febc2e}
+.appwin .traffic .g{background:#28c840}
+.appwin .titlebar .title{flex:1; text-align:center; font-size:12px; color:var(--color-text-dim)}
+.appwin .body{flex:1; padding: 18px; display:flex; align-items:center; justify-content:center; flex-direction:column; gap:12px}
+.appwin .body .applogo{width:60px; height:60px; border-radius:14px; display:grid; place-items:center; font-size:28px; font-weight:700; color:white}
+.appwin .body .appname{font-size:18px; font-weight:600}
+.appwin .body .apptag{font-size:12px; color:var(--color-text-soft)}
+
+/* Keyboard */
+.keyboard{
+  display:flex; flex-direction:column; gap: 8px;
+  padding: 18px; border-radius: 16px;
+  background: linear-gradient(180deg, rgba(28,28,32,.7), rgba(18,18,22,.7));
+  border: .5px solid var(--color-line);
+  max-width: 880px; width: 100%;
+}
+.kbrow{display:flex; gap:8px; justify-content:center}
+.key{
+  min-width: 38px; height: 38px; padding: 0 10px;
+  display:grid; place-items:center;
+  background: linear-gradient(180deg, #2c2c30, #1c1c20);
+  border: .5px solid var(--color-line-strong);
+  border-bottom-width: 2px;
+  border-radius: 8px;
+  color: var(--color-text);
+  font: 500 12px/1 var(--font-mono);
+  cursor: pointer; user-select: none;
+  transition: transform .08s ease, background .15s, box-shadow .15s;
+}
+.key:hover{background: linear-gradient(180deg, #34343a, #1f1f24)}
+.key.label{color:var(--color-text-soft); font-size:10px}
+.key.is-pressed{
+  transform: translateY(2px);
+  background: var(--color-accent);
+  border-color: var(--color-accent-2);
+  color:#fff;
+  box-shadow: 0 0 24px rgba(10,132,255,.6);
+}
+.key.is-hint{
+  box-shadow: 0 0 0 .5px rgba(10,132,255,.5), 0 0 22px rgba(10,132,255,.45);
+  border-color: rgba(10,132,255,.5);
+}
+.hint-line{font-size: 13px; color:var(--color-text-soft); margin-top: 18px; text-align:center}
+.hint-line b{color:var(--color-text)}
+
+/* ─────────────────────────── Toggle cards ─────────────────────────── */
+.toggles-grid{display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 56px}
+.tcard{
+  background: rgba(28,28,32,.55);
+  border: .5px solid var(--color-line);
+  border-radius: 18px;
+  padding: 22px;
+  position:relative; overflow:hidden;
+  cursor: pointer;
+  transition: border-color .2s, transform .2s, background .2s;
+}
+.tcard:hover{border-color: var(--color-line-strong); transform: translateY(-2px)}
+.tcard .head{display:flex; align-items:center; justify-content:space-between; gap:10px}
+.tcard .ico{width:38px; height:38px; border-radius:10px; background: rgba(255,255,255,.06); display:grid; place-items:center}
+.tcard.is-on .ico{background: var(--ico-on-bg, rgba(94,155,255,.18)); color: var(--ico-on-color, #5e9bff)}
+.tcard h4{font-size:17px; font-weight:600; margin: 14px 0 4px; letter-spacing:-.01em}
+.tcard p{font-size:13.5px; color:var(--color-text-dim); margin:0; line-height:1.4}
+.tcard .state{font-size:11.5px; color:var(--color-text-soft); margin-top:10px; font-family: var(--font-mono); letter-spacing:.04em}
+.tcard.dark-card.is-on{background: #000}
+.tcard.awake-card.is-on::before{
+  content:""; position:absolute; top:-30%; right:-30%; width: 200px; height: 200px;
+  border-radius: 50%;
+  background: radial-gradient(closest-side, rgba(255,159,10,.35), transparent 70%);
+  animation: pulse 3s ease-in-out infinite;
+}
+@keyframes pulse{0%,100%{opacity:.4} 50%{opacity:.9}}
+
+/* ─────────────────────────── Port manager ─────────────────────────── */
+.pm-wrap{
+  display:grid; grid-template-columns: 1fr 1.6fr; gap: 24px;
+  margin-top: 56px;
+  background: rgba(15,15,18,.65);
+  border: .5px solid var(--color-line);
+  border-radius: 18px;
+  padding: 14px;
+  box-shadow: 0 40px 80px rgba(0,0,0,.4);
+}
+.pm-side{
+  background: linear-gradient(180deg, rgba(38,38,42,.6), rgba(22,22,26,.6));
+  border-radius: 12px;
+  border: .5px solid var(--color-line);
+  padding: 8px;
+  height: 520px; overflow: hidden;
+}
+.pm-main{
+  background: linear-gradient(180deg, rgba(38,38,42,.6), rgba(22,22,26,.6));
+  border-radius: 12px;
+  border: .5px solid var(--color-line);
+  display:flex; flex-direction:column;
+  height: 520px; overflow: hidden;
+}
+.pm-search{display:flex; align-items:center; gap:10px; padding: 14px 18px; border-bottom: .5px solid var(--color-line)}
+.pm-search input{background:transparent; border:none; color:var(--color-text); outline:none; font-family:inherit; font-size:14.5px; flex:1}
+.pm-search .count{color:var(--color-text-soft); font-size:13px; font-family: var(--font-mono)}
+.pm-list{flex:1; overflow:hidden; padding: 4px 6px}
+.pm-list .port-row{padding: 10px 14px; font-size:14px}
+.pm-list .port-row .port{font-size:14px}
+.pm-foot{display:flex; padding: 6px; border-top: .5px solid var(--color-line); gap:4px}
+.pm-foot .pf-btn{flex:1; display:flex; align-items:center; gap:8px; padding: 10px 12px; border-radius: 8px; color:var(--color-text-dim); font-size:13px; cursor:pointer; justify-content: space-between}
+.pm-foot .pf-btn:hover{background: rgba(255,255,255,.05); color:var(--color-text)}
+
+/* ─────────────────────────── Actions ─────────────────────────── */
+.actions-grid{display:grid; grid-template-columns: 1.2fr 1fr 1fr; gap: 20px; margin-top: 56px}
+.acard{
+  position:relative; overflow:hidden;
+  background: linear-gradient(180deg, rgba(28,28,32,.7), rgba(15,15,18,.7));
+  border: .5px solid var(--color-line);
+  border-radius: 18px;
+  padding: 28px;
+  display: flex; flex-direction: column;
+  min-height: 360px;
+}
+.acard h3{font-size: 22px; font-weight:600; margin: 0 0 6px; letter-spacing:-.015em}
+.acard p{font-size: 13.5px; color: var(--color-text-dim); margin:0; max-width: 320px}
+.acard-stage{flex:1; position:relative; margin-top: 18px; border-radius: 12px; overflow:hidden}
+.acard .head-ico{width:34px; height:34px; border-radius:9px; display:grid; place-items:center}
+
+/* OCR */
+.ocr-stage{background: linear-gradient(180deg, #1b1b1f, #0d0d10); border: .5px solid var(--color-line); display:flex; flex-direction:column; padding: 16px}
+.ocr-doc{font: 12px/1.55 var(--font-sans); color: #c8c8d0; position:relative; flex:1; overflow:hidden}
+.ocr-doc .ocr-h{font-size: 13px; font-weight: 600; color:#fff; margin-bottom:4px}
+.ocr-doc .line{background: rgba(255,255,255,.08); height:8px; border-radius:3px; margin: 6px 0}
+.ocr-scan{
+  position:absolute; left: 0; right:0; height: 2px;
+  background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+  box-shadow: 0 0 18px rgba(10,132,255,.8), 0 0 4px var(--color-accent);
+  top: 0;
+  animation: ocrScan 3.2s ease-in-out infinite;
+}
+@keyframes ocrScan{0%{top:0; opacity:0} 10%{opacity:1} 50%{top: calc(100% - 4px); opacity:1} 60%{opacity:0} 100%{top:0; opacity:0}}
+.ocr-toast{
+  position:absolute; bottom: 14px; left: 50%; transform: translateX(-50%) translateY(20px);
+  padding: 10px 16px;
+  background: rgba(0,0,0,.85); border:.5px solid var(--color-line-strong);
+  border-radius: 999px;
+  font: 600 12px/1 var(--font-mono); color: #fff;
+  display:flex; align-items:center; gap:8px;
+  opacity: 0;
+  animation: toastShow 3.2s ease-in-out infinite;
+}
+@keyframes toastShow{0%,55%,100%{opacity:0; transform:translateX(-50%) translateY(20px)} 60%,90%{opacity:1; transform: translateX(-50%) translateY(0)}}
+
+/* Color picker */
+.cp-stage{
+  cursor: crosshair;
+  background: linear-gradient(135deg, #ff453a, #ff9f0a 18%, #30d158 40%, #5e9bff 65%, #bf5af2 88%, #ff375f);
+  position:relative;
+}
+.cp-loupe{
+  position:absolute; width: 80px; height: 80px; border-radius:50%;
+  border: 3px solid #fff;
+  box-shadow: 0 0 0 1px rgba(0,0,0,.4), 0 20px 30px rgba(0,0,0,.5);
+  pointer-events:none; display:none;
+}
+.cp-loupe::after{
+  content:""; position:absolute; left:50%; top:50%;
+  width: 10px; height: 10px;
+  border: 1.5px solid #fff; border-radius:50%;
+  transform: translate(-50%,-50%);
+  box-shadow: 0 0 0 1px rgba(0,0,0,.4);
+}
+.cp-readout{
+  position:absolute; left: 14px; bottom: 14px;
+  display:flex; align-items:center; gap: 8px;
+  background: rgba(0,0,0,.85);
+  border: .5px solid var(--color-line-strong);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font: 600 12px/1 var(--font-mono); color: #fff;
+}
+.cp-readout .swatch{width: 16px; height: 16px; border-radius: 4px; border: 1px solid rgba(255,255,255,.4)}
+
+/* Screenshot marquee */
+.ss-stage{background: linear-gradient(135deg, #1a1a1e, #0a0a0d); position:relative; display:grid; place-items:center; overflow:hidden}
+.ss-stage::before{content:""; position:absolute; inset:0; background: radial-gradient(circle at 30% 30%, rgba(94,155,255,.25), transparent 50%), radial-gradient(circle at 70% 70%, rgba(191,90,242,.25), transparent 50%)}
+.ss-marquee{position:absolute; border: 1.5px dashed rgba(255,255,255,.9); background: rgba(10,132,255,.15); border-radius: 3px; animation: marquee 4s ease-in-out infinite}
+@keyframes marquee{0%,100%{left:16%; top:22%; width:30%; height:40%; opacity:0} 10%{opacity:1} 40%{left:16%; top:22%; width:30%; height:40%; opacity:1} 55%{left:25%; top:30%; width:50%; height:45%; opacity:1} 80%{left:25%; top:30%; width:50%; height:45%; opacity:1} 85%{opacity:0}}
+.ss-shutter{position:absolute; inset:0; background: rgba(255,255,255,.85); opacity: 0; animation: shutter 4s ease-in-out infinite; pointer-events: none}
+@keyframes shutter{0%,78%,84%,100%{opacity:0} 80%{opacity:1}}
+
+/* ─────────────────────────── Settings ─────────────────────────── */
+.settings-mock{
+  margin-top: 56px;
+  background: linear-gradient(180deg, rgba(28,28,32,.7), rgba(15,15,18,.7));
+  border: .5px solid var(--color-line);
+  border-radius: 18px; overflow:hidden;
+  box-shadow: 0 30px 80px rgba(0,0,0,.4);
+}
+.sm-titlebar{display:flex; align-items:center; padding: 12px 16px; border-bottom: .5px solid var(--color-line)}
+.sm-titlebar .traffic{display:flex; gap:7px}
+.sm-titlebar .traffic span{width:12px;height:12px;border-radius:50%}
+.sm-titlebar .traffic .r{background:#ff5f57}
+.sm-titlebar .traffic .y{background:#febc2e}
+.sm-titlebar .traffic .g{background:#28c840}
+.sm-titlebar .ttl{flex:1; text-align:center; font-size:13px; color:var(--color-text-dim)}
+.sm-tabs{display:flex; justify-content:center; gap: 18px; padding: 16px 0; border-bottom: .5px solid var(--color-line)}
+.sm-tab{display:flex; flex-direction:column; align-items:center; gap:5px; padding: 8px 14px; border-radius: 8px; color:var(--color-text-dim); cursor:pointer; font-size:12px}
+.sm-tab.active{background: rgba(255,255,255,.06); color:var(--color-text)}
+.sm-tab.active svg{color: var(--color-accent)}
+.sm-body{padding: 8px 20px 20px}
+.sm-row{
+  display:flex; align-items:center; gap: 14px;
+  padding: 12px 14px;
+  border-bottom: .5px solid var(--color-line);
+  cursor: grab;
+}
+.sm-row:last-child{border-bottom:none}
+.sm-row:active{cursor:grabbing}
+.sm-row.drag-hover{background: rgba(10,132,255,.08); border-radius: 8px}
+.sm-row.is-dragging{opacity:.4}
+.sm-row .grip{color: var(--color-text-soft); cursor: grab; display:grid; place-items:center; flex: 0 0 18px}
+.sm-row .checkbox{width:18px; height:18px; border-radius:5px; background: var(--color-accent); display:grid; place-items:center; color:#fff; flex: 0 0 18px}
+.sm-row .ico-cell{color:#d8d8dc; flex: 0 0 28px; display:grid; place-items:center}
+.sm-row .text-cell{display:flex; align-items:baseline; gap:8px; font-size:14px; flex:1; min-width:0}
+.sm-row .text-cell .name{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-weight:500}
+.sm-row .text-cell .meta{font-size:11px; color: var(--color-text-soft); white-space:nowrap}
+.sm-row .badge{font-size: 10.5px; padding: 3px 8px; border-radius: 999px; background: rgba(255,255,255,.05); border: .5px solid var(--color-line); color: var(--color-text-soft); letter-spacing: .03em; white-space:nowrap; flex:0 0 auto}
+.sm-row .rec{
+  display:flex; align-items:center; gap:4px; min-width: 100px; height: 30px;
+  padding: 0 12px; border-radius: 6px;
+  background: rgba(255,255,255,.05); border: .5px solid var(--color-line);
+  font: 500 12px/1 var(--font-mono); color: var(--color-text-soft);
+  justify-content: center; white-space:nowrap; flex:0 0 auto;
+  cursor: pointer;
+}
+.sm-row .rec.has-key{background: rgba(10,132,255,.12); border-color: rgba(10,132,255,.3); color: var(--color-text)}
+.sm-row .rec.is-recording{background: rgba(255,69,58,.18); border-color: rgba(255,69,58,.4); color:#fff; animation: rec 1s linear infinite}
+@keyframes rec{50%{background: rgba(255,69,58,.06)}}
+
+/* ─────────────────────────── Download ─────────────────────────── */
+.dl-wrap{display:grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 56px}
+.dl-card{
+  background: linear-gradient(180deg, rgba(28,28,32,.7), rgba(15,15,18,.7));
+  border: .5px solid var(--color-line);
+  border-radius: 18px;
+  padding: 32px 32px 28px;
+  position: relative; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.dl-card.primary{background: linear-gradient(135deg, rgba(10,132,255,.20), rgba(191,90,242,.15)); border-color: rgba(94,155,255,.25)}
+.dl-card h3{font-size:22px; margin: 0 0 6px; font-weight: 600; letter-spacing:-.015em}
+.dl-card p{font-size:14px; color:var(--color-text-dim); margin: 0 0 22px; max-width: 400px}
+.dl-card .btn-primary{align-self: flex-start}
+.dl-meta{display:flex; gap: 24px; color: var(--color-text-soft); font-size: 12px; margin-top: auto; padding-top: 22px}
+.dl-cmd{
+  display:flex; align-items:center; gap: 8px;
+  padding: 16px 18px; background: rgba(0,0,0,.5);
+  border: .5px solid var(--color-line);
+  border-radius: 12px;
+  font: 500 13px/1.4 var(--font-mono); color: var(--color-text);
+  margin-bottom: 12px; overflow-x: auto; word-break: break-all;
+}
+.dl-cmd > span:nth-child(2){flex:1; word-break: break-all}
+.dl-cmd .prompt{color: var(--color-mac-green)}
+.dl-cmd .copy{margin-left:auto; color: var(--color-text-soft); cursor: pointer; padding: 6px 10px; border-radius: 6px; font-size: 12px}
+.dl-cmd .copy:hover{background: rgba(255,255,255,.06); color: var(--color-text)}
+
+/* ─────────────────────────── FAQ ─────────────────────────── */
+.faq{margin-top: 48px; max-width: 820px}
+.faq-item{border-bottom: .5px solid var(--color-line); padding: 22px 4px; cursor: pointer}
+.faq-q{display:flex; align-items:center; justify-content:space-between; gap: 20px; font-size: 19px; font-weight: 500; letter-spacing: -.01em}
+.faq-q .ic{transition: transform .25s ease; color: var(--color-text-dim)}
+.faq-item.is-open .faq-q .ic{transform: rotate(45deg); color: var(--color-text)}
+.faq-a{
+  max-height: 0; overflow:hidden;
+  transition: max-height .35s ease, margin-top .35s ease, opacity .25s ease;
+  opacity: 0; color: var(--color-text-dim); font-size: 15px; line-height: 1.6;
+}
+.faq-item.is-open .faq-a{max-height: 280px; margin-top: 14px; opacity: 1}
+
+/* ─────────────────────────── Nav + Footer ─────────────────────────── */
+.nav{
+  position:fixed; top:0; left:0; right:0; z-index:100;
+  display:flex; align-items:center; justify-content:space-between;
+  padding: 14px 28px;
+  backdrop-filter: blur(24px) saturate(180%);
+  background: rgba(5,5,7,.55);
+  border-bottom: .5px solid var(--color-line);
+}
+.nav-brand{display:flex; align-items:center; gap:10px; font-weight:600; font-size:15px; letter-spacing:-.01em}
+.nav-brand .logo{
+  width:26px; height:26px; border-radius:7px;
+  background: linear-gradient(135deg, #0a84ff 0%, #bf5af2 100%);
+  position:relative;
+  box-shadow: 0 0 0 .5px rgba(255,255,255,.12), 0 6px 20px rgba(10,132,255,.35);
+}
+.nav-brand .logo::after{
+  content:""; position:absolute; inset:6px;
+  background: rgba(255,255,255,.92);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='M4 21V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13'/><path d='M2 21h20'/><circle cx='15' cy='14' r='1'/></svg>") center/contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='M4 21V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13'/><path d='M2 21h20'/><circle cx='15' cy='14' r='1'/></svg>") center/contain no-repeat;
+}
+.nav-links{display:flex; align-items:center; gap:28px}
+.nav-links a{color:var(--color-text-dim); text-decoration:none; font-size:13.5px; transition: color .2s ease}
+.nav-links a:hover{color:var(--color-text)}
+.nav-cta{display:flex; align-items:center; gap:10px}
+.lang-toggle{display:flex; padding:3px; gap:0; background: rgba(255,255,255,.06); border-radius:999px; border: .5px solid var(--color-line)}
+.lang-toggle button{border:none; background:transparent; color:var(--color-text-dim); font-size:12px; padding:5px 12px; border-radius:999px; cursor:pointer; transition: all .2s ease; font-weight: 500; font-family:inherit}
+.lang-toggle button.is-active{background:rgba(255,255,255,.13); color:var(--color-text)}
+.nav-cta .gh{display:flex; align-items:center; gap:6px; padding:7px 14px; border-radius:999px; background: rgba(255,255,255,.07); border: .5px solid var(--color-line); color: var(--color-text); font-size:13px; text-decoration:none; transition: background .2s}
+.nav-cta .gh:hover{background:rgba(255,255,255,.13)}
+
+.footer{padding: 60px 0 80px; border-top: .5px solid var(--color-line); margin-top: 80px}
+.footer .row{display:flex; justify-content:space-between; align-items:center; gap: 28px; flex-wrap: wrap}
+.footer .left{display:flex; align-items:center; gap: 12px; font-weight:600}
+.footer .links{display:flex; gap: 24px}
+.footer .links a{color:var(--color-text-dim); text-decoration:none; font-size: 13.5px}
+.footer .links a:hover{color: var(--color-text)}
+.footer .bot{margin-top: 28px; color: var(--color-text-soft); font-size: 12px; display:flex; justify-content:space-between; flex-wrap: wrap; gap: 12px}
+
+/* ─────────────────────────── Responsive ─────────────────────────── */
+@media (max-width: 860px){
+  .hero{grid-template-columns: 1fr; padding-top:120px}
+  .hero-stage{justify-content:flex-start; margin-top: 30px}
+  .toggles-grid{grid-template-columns: 1fr 1fr}
+  .pm-wrap{grid-template-columns: 1fr}
+  .pm-side{height: 240px}
+  .actions-grid{grid-template-columns: 1fr}
+  .dl-wrap{grid-template-columns: 1fr}
+}
+@media (max-width: 640px){
+  .toggles-grid{grid-template-columns: 1fr}
+  .nav{padding: 12px 18px}
+  .container-x{padding: 0 18px}
+  .section{padding: 80px 0}
+  .nav-links{display:none}
+}

--- a/landing/tsconfig.json
+++ b/landing/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary

- New `landing/` Astro 5 + Tailwind 4 project for the AnyDoor marketing site, with bilingual (中文 / English) copy driven from a single shared lib
- Section components: Nav, Hero (+ reusable MenuPanel preview), interactive HotkeyDemo, system Toggles showcase, Port Manager submenu, built-in Actions, Settings panel, Download cards, FAQ, Footer
- 11 atomic commits split by feature so the diff can be reviewed one section at a time; `index.astro` builds cleanly at every commit

## Test plan

- [x] `cd landing && bun install && bun run dev` — visit http://localhost:4321 and confirm every section renders
- [x] Verify language switch in Nav flips all copy (zh ↔ en)
- [x] Hotkey demo: press F1 – F6 / Esc and confirm the dock animation reacts
- [x] Port Manager: search by port / process, toggle tree view, click refresh
- [x] Settings: switch Panel / General tab, click a hotkey row and confirm the recorder placeholder flips to "Press keys…"
- [x] Download: click "复制" on the build-from-source card and confirm the clipboard contains the snippet
- [x] `bun run build` succeeds with no Astro errors