### PR TITLE
feat: external display brightness control via DDC/CI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35a45a793952d0f2c6bad29789901f69475952ea3036cfa0c87e3b211688fb8f",
+  "originHash" : "90331f38bf394e04a4b608c9793301a6b16a6efab2a421468a6554c4444de4f3",
   "pins" : [
     {
       "identity" : "askforpermission",
@@ -7,6 +7,15 @@
       "location" : "https://github.com/riko2chen/AskForPermission.git",
       "state" : {
         "revision" : "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e"
+      }
+    },
+    {
+      "identity" : "ddc.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/reitermarkus/DDC.swift",
+      "state" : {
+        "branch" : "master",
+        "revision" : "15b3ef8235a831e0d7812dbdf12d6a4bb16d3bd6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
             url: "https://github.com/sparkle-project/Sparkle",
             exact: "2.9.2"
         ),
+        .package(
+            url: "https://github.com/reitermarkus/DDC.swift",
+            branch: "master"
+        ),
     ],
     targets: [
         .executableTarget(
@@ -20,6 +24,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AskForPermission", package: "AskForPermission"),
                 .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "DDC", package: "DDC.swift"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ publishes it.
 - CGEvent tap
 - Swift Package Manager
 
+## Acknowledgements
+
+- [DDC.swift](https://github.com/reitermarkus/DDC.swift) (MIT) — DDC/CI brightness control for external displays on Intel Macs.
+- [AskForPermission](https://github.com/riko2chen/AskForPermission) — macOS accessibility permission helper.
+- [Sparkle](https://sparkle-project.org/) — application auto-update.
+
 ## License
 
 MIT

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -268,6 +268,12 @@ codesign，提交 Apple 公证，打包 DMG 和 zip，重新生成 Sparkle appca
 - CGEvent tap
 - Swift Package Manager
 
+## 致谢
+
+- [DDC.swift](https://github.com/reitermarkus/DDC.swift) (MIT) — Intel Mac 上外置显示器的 DDC/CI 亮度控制。
+- [AskForPermission](https://github.com/riko2chen/AskForPermission) — macOS 辅助功能权限助手。
+- [Sparkle](https://sparkle-project.org/) — 应用自动更新。
+
 ## 许可证
 
 MIT

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -74,6 +74,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ]
         PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)
 
+        // Brightness control (external DDC/CI displays). Arch-selected backend.
+        #if arch(arm64)
+        let ddcBackend: any DDCBackend = Arm64DDCBackend()
+        #else
+        let ddcBackend: any DDCBackend = IntelDDCBackend()
+        #endif
+        let brightnessController = BrightnessController(backend: ddcBackend)
+        DisplayBrightnessService.shared.bootstrap(controller: brightnessController)
+
+        // Pre-warm the brightness service so the first hover finds data cached.
+        Task.detached(priority: .utility) {
+            await DisplayBrightnessService.shared.refresh()
+        }
+
         // Wire HotkeyService dispatcher
         HotkeyService.shared.setDispatcher { action in
             PanelStore.shared.dispatch(action)

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -25,11 +25,16 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case keyboardLock
     case portManager
     case qrcode
+    case brightness
+    case brightnessUp
+    case brightnessDown
 
     enum Kind: Sendable {
         case toggle
         case action
         case submenu
+        case brightnessControl
+        case hiddenHotkey
     }
 
     var kind: Kind {
@@ -39,6 +44,8 @@ enum BuiltinItem: String, CaseIterable, Sendable {
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
         case .lockScreen, .emptyTrash, .screenshot, .ocr, .qrcode, .pickColor, .displaySleep, .systemSleep,
              .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+        case .brightness: return .brightnessControl
+        case .brightnessUp, .brightnessDown: return .hiddenHotkey
         }
     }
 
@@ -66,6 +73,9 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .keyboardLock: return "禁用键盘"
         case .portManager: return "端口管理"
         case .qrcode: return "识别二维码"
+        case .brightness: return "屏幕亮度"
+        case .brightnessUp: return "亮度 +"
+        case .brightnessDown: return "亮度 −"
         }
     }
 
@@ -93,6 +103,9 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .keyboardLock: return "keyboard.fill"
         case .portManager: return "network"
         case .qrcode: return "qrcode.viewfinder"
+        case .brightness: return "sun.max"
+        case .brightnessUp: return "sun.max"
+        case .brightnessDown: return "sun.min"
         }
     }
 
@@ -121,6 +134,9 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .keyboardLock: return 1800
         case .portManager: return 1900
         case .qrcode: return 960
+        case .brightness: return 650
+        case .brightnessUp: return 999_998
+        case .brightnessDown: return 999_999
         }
     }
 
@@ -151,6 +167,15 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         switch self {
         case .emptyTrash: return .emptyTrash
         default: return nil
+        }
+    }
+
+    /// Whether this item should default to being shown in the menu bar panel when first seeded.
+    /// False only for hidden-hotkey items (brightness ± live on the brightness row only).
+    var defaultVisibility: Bool {
+        switch self.kind {
+        case .toggle, .action, .submenu, .brightnessControl: return true
+        case .hiddenHotkey:                                   return false
         }
     }
 }

--- a/Sources/AnyDoor/Models/HotkeyAction.swift
+++ b/Sources/AnyDoor/Models/HotkeyAction.swift
@@ -8,6 +8,8 @@ enum HotkeyAction: Sendable, Hashable {
     case launchApp(bundleID: String, path: String)
     case toggleBuiltin(itemKey: String)
     case runBuiltin(itemKey: String)
+    case brightnessUp
+    case brightnessDown
 }
 
 /// Sendable snapshot passed across the CGEvent tap boundary.

--- a/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
@@ -55,10 +55,13 @@ struct Arm64DDCBackend: DDCBackend {
     func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
         guard let service = Self.cache.service(for: displayID) else { return nil }
         return await Task.detached(priority: .userInitiated) { () -> UInt16? in
-            // DDC read request packet: [src=0x51, len=0x82, op=0x01, vcp, chksum]
-            // followed by a separate read of the 11-byte reply.
-            var request: [UInt8] = [0x51, 0x82, 0x01, vcp]
-            request.append(checksum(destination: 0x6E, bytes: request))
+            // DDC VCP read request, 2 data bytes [op=0x01, vcp]:
+            //   [length=0x80|2, op=0x01, vcp, chksum]
+            // The source byte (0x51) is supplied via IOAVServiceWriteI2C's
+            // dataAddress parameter and is NOT placed in the packet buffer,
+            // but it still counts toward the checksum domain.
+            var request: [UInt8] = [0x82, 0x01, vcp, 0x00]
+            request[request.count - 1] = ddcChecksum(packet: request)
 
             let writeResult = request.withUnsafeBufferPointer { buf -> IOReturn in
                 IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
@@ -68,6 +71,9 @@ struct Arm64DDCBackend: DDCBackend {
             // Per DDC/CI: the source must wait at least 40 ms before reading the reply.
             try? await Task.sleep(nanoseconds: 50_000_000)
 
+            // 11-byte VCP response:
+            //   [src=0x6E, len=0x88, op=0x02, result=0x00, vcp, type,
+            //    maxHi, maxLo, curHi, curLo, chksum]
             var reply = [UInt8](repeating: 0, count: 11)
             let readResult = reply.withUnsafeMutableBufferPointer { buf -> IOReturn in
                 IOAVServiceReadI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
@@ -87,11 +93,17 @@ struct Arm64DDCBackend: DDCBackend {
                           userInfo: [NSLocalizedDescriptionKey: "transport not ready"])
         }
         try await Task.detached(priority: .userInitiated) {
-            // DDC write packet: [src=0x51, len=0x84, op=0x03, vcp, valHi, valLo, chksum]
-            var packet: [UInt8] = [0x51, 0x84, 0x03, vcp,
-                                   UInt8((value >> 8) & 0xFF),
-                                   UInt8(value & 0xFF)]
-            packet.append(checksum(destination: 0x6E, bytes: packet))
+            // DDC VCP write, 4 data bytes [op=0x03, vcp, valHi, valLo]:
+            //   [length=0x80|4, op=0x03, vcp, valHi, valLo, chksum]
+            // The source byte (0x51) is supplied via IOAVServiceWriteI2C's
+            // dataAddress parameter and is NOT in the packet buffer.
+            var packet: [UInt8] = [
+                0x84, 0x03, vcp,
+                UInt8((value >> 8) & 0xFF),
+                UInt8(value & 0xFF),
+                0x00
+            ]
+            packet[packet.count - 1] = ddcChecksum(packet: packet)
 
             let result = packet.withUnsafeBufferPointer { buf -> IOReturn in
                 IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
@@ -104,10 +116,14 @@ struct Arm64DDCBackend: DDCBackend {
     }
 }
 
-private func checksum(destination: UInt8, bytes: [UInt8]) -> UInt8 {
-    var sum = destination
-    for byte in bytes { sum ^= byte }
-    return sum
+/// XOR-checksum over the packet, excluding the trailing checksum slot.
+/// Seed is `dest(0x6E) ^ src(0x51) = 0x3F`: those two bytes belong to the
+/// DDC framing but are sent out-of-band by IOAVService (as I2C chip and
+/// data addresses) rather than appearing in the buffer.
+private func ddcChecksum(packet: [UInt8]) -> UInt8 {
+    var chk: UInt8 = 0x6E ^ 0x51
+    for i in 0..<(packet.count - 1) { chk ^= packet[i] }
+    return chk
 }
 
 /// Per-displayID IOAVService lookup, cached for the process lifetime.

--- a/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
@@ -1,0 +1,174 @@
+#if arch(arm64)
+import Foundation
+import IOKit
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "ddc.arm64")
+
+// MARK: - Private IOAVService symbol declarations
+//
+// These three symbols live in CoreDisplay/IOKit's private surface. Function
+// signatures are not copyrightable; the calling convention is documented in
+// public Apple sample code (AVCustomEdit, AVScreenShack) and in Apple's
+// open-source IOAVService headers shipped historically with xnu.
+
+@_silgen_name("IOAVServiceCreate")
+private func IOAVServiceCreate(_ allocator: CFAllocator?) -> Unmanaged<AnyObject>?
+
+@_silgen_name("IOAVServiceCreateWithService")
+private func IOAVServiceCreateWithService(
+    _ allocator: CFAllocator?,
+    _ service: io_service_t
+) -> Unmanaged<AnyObject>?
+
+@_silgen_name("IOAVServiceReadI2C")
+private func IOAVServiceReadI2C(
+    _ service: AnyObject,
+    _ chipAddress: UInt32,
+    _ offset: UInt32,
+    _ buffer: UnsafeMutableRawPointer,
+    _ length: UInt32
+) -> IOReturn
+
+@_silgen_name("IOAVServiceWriteI2C")
+private func IOAVServiceWriteI2C(
+    _ service: AnyObject,
+    _ chipAddress: UInt32,
+    _ offset: UInt32,
+    _ buffer: UnsafeRawPointer,
+    _ length: UInt32
+) -> IOReturn
+
+// MARK: - Backend
+
+struct Arm64DDCBackend: DDCBackend {
+    /// Per-process cache: displayID -> IOAVService object. Invalidated by
+    /// the caller (DisplayBrightnessService) on screen-change notifications.
+    private static let cache = AVServiceCache()
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        return Self.cache.service(for: displayID) != nil
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        guard let service = Self.cache.service(for: displayID) else { return nil }
+        return await Task.detached(priority: .userInitiated) { () -> UInt16? in
+            // DDC read request packet: [src=0x51, len=0x82, op=0x01, vcp, chksum]
+            // followed by a separate read of the 11-byte reply.
+            var request: [UInt8] = [0x51, 0x82, 0x01, vcp]
+            request.append(checksum(destination: 0x6E, bytes: request))
+
+            let writeResult = request.withUnsafeBufferPointer { buf -> IOReturn in
+                IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard writeResult == KERN_SUCCESS else { return nil }
+
+            // Per DDC/CI: the source must wait at least 40 ms before reading the reply.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+
+            var reply = [UInt8](repeating: 0, count: 11)
+            let readResult = reply.withUnsafeMutableBufferPointer { buf -> IOReturn in
+                IOAVServiceReadI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard readResult == KERN_SUCCESS, reply[0] == 0x6E, reply[1] == 0x88,
+                  reply[2] == 0x02, reply[3] == 0x00, reply[4] == vcp else {
+                return nil
+            }
+            let current = (UInt16(reply[8]) << 8) | UInt16(reply[9])
+            return current
+        }.value
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        guard let service = Self.cache.service(for: displayID) else {
+            throw NSError(domain: "Arm64DDC", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "transport not ready"])
+        }
+        try await Task.detached(priority: .userInitiated) {
+            // DDC write packet: [src=0x51, len=0x84, op=0x03, vcp, valHi, valLo, chksum]
+            var packet: [UInt8] = [0x51, 0x84, 0x03, vcp,
+                                   UInt8((value >> 8) & 0xFF),
+                                   UInt8(value & 0xFF)]
+            packet.append(checksum(destination: 0x6E, bytes: packet))
+
+            let result = packet.withUnsafeBufferPointer { buf -> IOReturn in
+                IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard result == KERN_SUCCESS else {
+                throw NSError(domain: "Arm64DDC", code: Int(result),
+                              userInfo: [NSLocalizedDescriptionKey: "I2C write failed"])
+            }
+        }.value
+    }
+}
+
+private func checksum(destination: UInt8, bytes: [UInt8]) -> UInt8 {
+    var sum = destination
+    for byte in bytes { sum ^= byte }
+    return sum
+}
+
+/// Per-displayID IOAVService lookup, cached for the process lifetime.
+/// Higher layers must drop entries on screen-change notifications.
+private final class AVServiceCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var map: [CGDirectDisplayID: AnyObject] = [:]
+
+    func service(for displayID: CGDirectDisplayID) -> AnyObject? {
+        lock.withLock {
+            if let s = map[displayID] { return s }
+            guard let s = locateService(for: displayID) else { return nil }
+            map[displayID] = s
+            return s
+        }
+    }
+
+    func invalidate() {
+        lock.withLock {
+            map.removeAll()
+        }
+    }
+
+    /// Walks IORegistry for IOAVService entries; matches by the IOAVService's
+    /// "VendorID" / "ProductID" / "AlphanumericSerialNumber" against
+    /// `CGDisplayVendorNumber` / `CGDisplayModelNumber` / `CGDisplaySerialNumber`.
+    private func locateService(for displayID: CGDirectDisplayID) -> AnyObject? {
+        let vendor = CGDisplayVendorNumber(displayID)
+        let model = CGDisplayModelNumber(displayID)
+        let serial = CGDisplaySerialNumber(displayID)
+        guard vendor != 0 || model != 0 else { return nil }
+
+        var iter: io_iterator_t = 0
+        let matching = IOServiceMatching("IOAVService")
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter) == KERN_SUCCESS else {
+            return nil
+        }
+        defer { IOObjectRelease(iter) }
+
+        var match: AnyObject?
+        while case let service = IOIteratorNext(iter), service != 0 {
+            defer { IOObjectRelease(service) }
+            guard let props = serviceProperties(service) else { continue }
+            let v = (props["VendorID"] as? UInt32) ?? 0
+            let m = (props["ProductID"] as? UInt32) ?? 0
+            let s = (props["AlphanumericSerialNumber"] as? String).flatMap(UInt32.init) ?? 0
+            if v == vendor && m == model && (serial == 0 || s == serial) {
+                if let av = IOAVServiceCreateWithService(kCFAllocatorDefault, service)?.takeRetainedValue() {
+                    match = av
+                    break
+                }
+            }
+        }
+        return match
+    }
+
+    private func serviceProperties(_ service: io_service_t) -> [String: Any]? {
+        var unmanaged: Unmanaged<CFMutableDictionary>?
+        let result = IORegistryEntryCreateCFProperties(service, &unmanaged, kCFAllocatorDefault, 0)
+        guard result == KERN_SUCCESS, let dict = unmanaged?.takeRetainedValue() else { return nil }
+        return dict as? [String: Any]
+    }
+}
+
+#endif

--- a/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
@@ -13,9 +13,6 @@ private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "ddc.arm64
 // public Apple sample code (AVCustomEdit, AVScreenShack) and in Apple's
 // open-source IOAVService headers shipped historically with xnu.
 
-@_silgen_name("IOAVServiceCreate")
-private func IOAVServiceCreate(_ allocator: CFAllocator?) -> Unmanaged<AnyObject>?
-
 @_silgen_name("IOAVServiceCreateWithService")
 private func IOAVServiceCreateWithService(
     _ allocator: CFAllocator?,
@@ -49,6 +46,10 @@ struct Arm64DDCBackend: DDCBackend {
 
     func transportReady(displayID: CGDirectDisplayID) -> Bool {
         return Self.cache.service(for: displayID) != nil
+    }
+
+    func invalidateCaches() {
+        Self.cache.invalidate()
     }
 
     func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {

--- a/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
@@ -131,37 +131,70 @@ private final class AVServiceCache: @unchecked Sendable {
         }
     }
 
-    /// Walks IORegistry for IOAVService entries; matches by the IOAVService's
-    /// "VendorID" / "ProductID" / "AlphanumericSerialNumber" against
-    /// `CGDisplayVendorNumber` / `CGDisplayModelNumber` / `CGDisplaySerialNumber`.
+    /// Pairs each external `CGDirectDisplayID` with a `DCPAVServiceProxy`
+    /// IORegistry entry by position.
+    ///
+    /// Background: on macOS 26 Apple Silicon the `IOAVService` class is no
+    /// longer populated (`ioreg`'s class counter shows zero instances).
+    /// Active entries are `DCPAVServiceProxy` (provider `AFKEndpointInterface`,
+    /// `Location = External` for external monitors). These entries have no
+    /// `VendorID` / `ProductID` / `AlphanumericSerialNumber` properties to
+    /// match against `CGDisplay*Number`, so we fall back to position-based
+    /// matching: enumerate proxies in IORegistry order, then the Nth external
+    /// online display gets the Nth proxy. For typical setups (1-3 external
+    /// monitors) the pairing is stable across reboots.
+    ///
+    /// Worst case (mismatched pairing): brightness slider for monitor A
+    /// drives monitor B. Spec § "Out-of-scope failure modes" explicitly
+    /// accepts position-based fallback as the v1 strategy.
     private func locateService(for displayID: CGDirectDisplayID) -> AnyObject? {
-        let vendor = CGDisplayVendorNumber(displayID)
-        let model = CGDisplayModelNumber(displayID)
-        let serial = CGDisplaySerialNumber(displayID)
-        guard vendor != 0 || model != 0 else { return nil }
+        let proxies = enumerateExternalProxies()
+        guard !proxies.isEmpty else { return nil }
+        let externalDisplays = onlineExternalDisplays()
+        guard let index = externalDisplays.firstIndex(of: displayID),
+              index < proxies.count else { return nil }
+        defer {
+            for (i, service) in proxies.enumerated() where i != index {
+                IOObjectRelease(service)
+            }
+        }
+        let service = proxies[index]
+        let av = IOAVServiceCreateWithService(kCFAllocatorDefault, service)?
+            .takeRetainedValue()
+        IOObjectRelease(service)
+        return av
+    }
 
+    /// Online external displays in `CGGetOnlineDisplayList` order.
+    private func onlineExternalDisplays() -> [CGDirectDisplayID] {
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        return ids.filter { CGDisplayIsBuiltin($0) == 0 }
+    }
+
+    /// `DCPAVServiceProxy` IORegistry entries with `Location == "External"`.
+    /// Caller owns the returned `io_service_t` references (must `IOObjectRelease`).
+    private func enumerateExternalProxies() -> [io_service_t] {
         var iter: io_iterator_t = 0
-        let matching = IOServiceMatching("IOAVService")
+        guard let matching = IOServiceMatching("DCPAVServiceProxy") else { return [] }
         guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter) == KERN_SUCCESS else {
-            return nil
+            return []
         }
         defer { IOObjectRelease(iter) }
 
-        var match: AnyObject?
+        var out: [io_service_t] = []
         while case let service = IOIteratorNext(iter), service != 0 {
-            defer { IOObjectRelease(service) }
-            guard let props = serviceProperties(service) else { continue }
-            let v = (props["VendorID"] as? UInt32) ?? 0
-            let m = (props["ProductID"] as? UInt32) ?? 0
-            let s = (props["AlphanumericSerialNumber"] as? String).flatMap(UInt32.init) ?? 0
-            if v == vendor && m == model && (serial == 0 || s == serial) {
-                if let av = IOAVServiceCreateWithService(kCFAllocatorDefault, service)?.takeRetainedValue() {
-                    match = av
-                    break
-                }
+            if let props = serviceProperties(service),
+               let location = props["Location"] as? String,
+               location == "External" {
+                out.append(service)   // ownership transferred to caller
+            } else {
+                IOObjectRelease(service)
             }
         }
-        return match
+        return out
     }
 
     private func serviceProperties(_ service: io_service_t) -> [String: Any]? {

--- a/Sources/AnyDoor/Services/Brightness/BrightnessController.swift
+++ b/Sources/AnyDoor/Services/Brightness/BrightnessController.swift
@@ -28,6 +28,14 @@ actor BrightnessController {
         return backend.transportReady(displayID: displayID)
     }
 
+    /// Forward cache invalidation to the backend. Called by
+    /// `DisplayBrightnessService.refresh()` on every screen-change so stale
+    /// IOAVService handles from unplugged displays are dropped before we
+    /// probe / read the new topology.
+    func invalidateCaches() async {
+        backend.invalidateCaches()
+    }
+
     /// Reads current brightness, normalised 0.0...1.0; nil on backend nil.
     func read(displayID: CGDirectDisplayID) async -> Float? {
         guard let raw = await backend.read(displayID: displayID, vcp: Self.vcpBrightness) else {

--- a/Sources/AnyDoor/Services/Brightness/BrightnessController.swift
+++ b/Sources/AnyDoor/Services/Brightness/BrightnessController.swift
@@ -1,0 +1,55 @@
+import Foundation
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "brightness.controller")
+
+/// Serialises VCP 0x10 I/O for one or more displays. One write retry on failure.
+/// Read/write timeouts handled by the underlying backend.
+///
+/// Always operates on VCP 0x10 (brightness). Values are normalised to 0.0...1.0
+/// on the public API; internally converted to the DDC byte range 0...100.
+actor BrightnessController {
+    enum Failure: Error { case transportUnavailable, writeFailed }
+
+    private let backend: DDCBackend
+    private static let vcpBrightness: UInt8 = 0x10
+    /// DDC standard: brightness max value byte for VCP 0x10 on essentially every
+    /// monitor. A VCP-max handshake is deferred (see spec § "Out-of-scope failure modes").
+    private static let maxValue: UInt16 = 100
+
+    init(backend: DDCBackend) {
+        self.backend = backend
+    }
+
+    /// Transport probe — fast, no VCP query. Returns true iff the backend reports
+    /// the display reachable. A subsequent read or write may still time out.
+    func probe(displayID: CGDirectDisplayID) async -> Bool {
+        return backend.transportReady(displayID: displayID)
+    }
+
+    /// Reads current brightness, normalised 0.0...1.0; nil on backend nil.
+    func read(displayID: CGDirectDisplayID) async -> Float? {
+        guard let raw = await backend.read(displayID: displayID, vcp: Self.vcpBrightness) else {
+            return nil
+        }
+        return Float(min(raw, Self.maxValue)) / Float(Self.maxValue)
+    }
+
+    /// Writes brightness (0.0...1.0). Throws `Failure.writeFailed` after exactly
+    /// one retry on transient failure.
+    func write(displayID: CGDirectDisplayID, value: Float) async throws {
+        let clamped = max(0, min(1, value))
+        let raw = UInt16((clamped * Float(Self.maxValue)).rounded())
+        do {
+            try await backend.write(displayID: displayID, vcp: Self.vcpBrightness, value: raw)
+        } catch {
+            logger.debug("DDC write retry for display \(displayID, privacy: .public)")
+            do {
+                try await backend.write(displayID: displayID, vcp: Self.vcpBrightness, value: raw)
+            } catch {
+                throw Failure.writeFailed
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Brightness/DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/DDCBackend.swift
@@ -1,0 +1,68 @@
+import Foundation
+import CoreGraphics
+
+/// Abstract DDC/CI transport. Two production implementations exist
+/// (`IntelDDCBackend` and `Arm64DDCBackend`), selected per slice via
+/// `#if arch(arm64)` in the wiring code. `MockDDCBackend` is used by tests.
+protocol DDCBackend: Sendable {
+    /// Fast, side-effect-free check: is the I2C / IOAVService transport
+    /// reachable for this display? Does NOT issue a VCP read.
+    func transportReady(displayID: CGDirectDisplayID) -> Bool
+
+    /// Issue a VCP read. Returns nil on timeout / NACK / unsupported VCP.
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16?
+
+    /// Issue a VCP write. Throws on I/O failure.
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws
+}
+
+/// In-memory mock for unit tests. Scripted return values + recording of calls.
+final class MockDDCBackend: DDCBackend, @unchecked Sendable {
+    struct ReadCall: Equatable { let displayID: CGDirectDisplayID; let vcp: UInt8 }
+    struct WriteCall: Equatable { let displayID: CGDirectDisplayID; let vcp: UInt8; let value: UInt16 }
+
+    private let lock = NSLock()
+    private var _transportSupported: Set<CGDirectDisplayID>
+    private var _readResults: [CGDirectDisplayID: UInt16?]
+    private var _writeError: Error?
+    private(set) var readCalls: [ReadCall] = []
+    private(set) var writeCalls: [WriteCall] = []
+
+    init(transportSupported: Set<CGDirectDisplayID> = [],
+         readResults: [CGDirectDisplayID: UInt16?] = [:],
+         writeError: Error? = nil) {
+        self._transportSupported = transportSupported
+        self._readResults = readResults
+        self._writeError = writeError
+    }
+
+    func setReadResult(_ value: UInt16?, for displayID: CGDirectDisplayID) {
+        lock.lock(); defer { lock.unlock() }
+        _readResults[displayID] = value
+    }
+
+    func setWriteError(_ error: Error?) {
+        lock.lock(); defer { lock.unlock() }
+        _writeError = error
+    }
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _transportSupported.contains(displayID)
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        lock.withLock {
+            readCalls.append(ReadCall(displayID: displayID, vcp: vcp))
+            return _readResults[displayID] ?? nil
+        }
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        let err: Error? = lock.withLock {
+            writeCalls.append(WriteCall(displayID: displayID, vcp: vcp, value: value))
+            return _writeError
+        }
+        if let err { throw err }
+    }
+}

--- a/Sources/AnyDoor/Services/Brightness/DDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/DDCBackend.swift
@@ -14,6 +14,18 @@ protocol DDCBackend: Sendable {
 
     /// Issue a VCP write. Throws on I/O failure.
     func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws
+
+    /// Drop any per-displayID transport caches. Called by
+    /// `DisplayBrightnessService.refresh()` on every screen-change notification
+    /// so that hot-unplug + replug with a recycled `CGDirectDisplayID` does not
+    /// route subsequent I/O to a defunct transport object.
+    func invalidateCaches()
+}
+
+extension DDCBackend {
+    /// Default no-op for backends that don't cache (Intel via DDC.swift
+    /// re-resolves per call; mocks have no transport).
+    func invalidateCaches() {}
 }
 
 /// In-memory mock for unit tests. Scripted return values + recording of calls.

--- a/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
+++ b/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
@@ -1,0 +1,228 @@
+import Foundation
+import AppKit
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "brightness.service")
+
+struct DisplayInfo: Identifiable, Hashable, Sendable {
+    let id: CGDirectDisplayID
+    let name: String
+    let supportsDDC: Bool
+}
+
+@MainActor
+@Observable
+final class DisplayBrightnessService {
+    static let shared = DisplayBrightnessService()
+
+    private(set) var displays: [DisplayInfo] = []
+    private(set) var levels: [CGDirectDisplayID: Float] = [:]
+    private(set) var isLoading: Set<CGDirectDisplayID> = []
+
+    /// Monotonic counter per display, incremented on every level mutation.
+    /// Used by deferred backfill reads to drop themselves when a newer user
+    /// action has superseded them.
+    private var levelGeneration: [CGDirectDisplayID: UInt64] = [:]
+
+    private var controller: BrightnessController?
+    private var screenChangeObserver: NSObjectProtocol?
+    private var pendingWrites: [CGDirectDisplayID: Task<Void, Never>] = [:]
+    private static let writeDebounceNanos: UInt64 = 30_000_000   // 30 ms
+
+    enum BumpTarget: Sendable { case displayUnderMouse }
+
+    init() {}
+
+    func bootstrap(controller: BrightnessController) {
+        self.controller = controller
+        installScreenObserver()
+    }
+
+    private func installScreenObserver() {
+        if let observer = screenChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor [weak self] in await self?.refresh() }
+        }
+    }
+
+    /// Re-enumerate NSScreen.screens; probe + read every external display.
+    func refresh() async {
+        guard let controller else { return }
+
+        let externalIDs = Self.externalDisplayIDs()
+        var newDisplays: [DisplayInfo] = []
+        var rawNames: [(CGDirectDisplayID, String)] = []
+
+        for id in externalIDs {
+            let baseName = Self.localizedName(for: id) ?? "Display \(id)"
+            rawNames.append((id, baseName))
+        }
+
+        let dedupedNames = Self.dedupedNames(rawNames)
+
+        for (id, name) in zip(externalIDs, dedupedNames) {
+            isLoading.insert(id)
+            let supports = await controller.probe(displayID: id)
+            newDisplays.append(DisplayInfo(id: id, name: name, supportsDDC: supports))
+            if supports {
+                if let value = await controller.read(displayID: id) {
+                    levels[id] = value
+                }
+            }
+            isLoading.remove(id)
+        }
+
+        // Drop entries for unplugged displays.
+        let present = Set(newDisplays.map(\.id))
+        for stale in levels.keys where !present.contains(stale) { levels.removeValue(forKey: stale) }
+
+        displays = newDisplays
+    }
+
+    /// Slider drag entry. Updates UI immediately; debounces DDC write.
+    func setBrightness(_ value: Float, for displayID: CGDirectDisplayID) {
+        guard let controller else { return }
+        let clamped = max(0, min(1, value))
+        levels[displayID] = clamped
+        bumpGeneration(displayID)
+        pendingWrites[displayID]?.cancel()
+        pendingWrites[displayID] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.writeDebounceNanos)
+            if Task.isCancelled { return }
+            try? await controller.write(displayID: displayID, value: clamped)
+            await MainActor.run { [weak self] in
+                self?.pendingWrites[displayID] = nil
+            }
+        }
+    }
+
+    /// Hotkey bump entry.
+    func bump(_ delta: Float, target: BumpTarget) {
+        guard let displayID = resolveTarget(target) else { return }
+        bumpInternal(delta, displayID: displayID, showOSD: true)
+    }
+
+    // MARK: - Internal (also reused by test seams)
+
+    fileprivate func bumpInternal(_ delta: Float, displayID: CGDirectDisplayID, showOSD: Bool) {
+        guard let controller else { return }
+        let usedFallback = (levels[displayID] == nil)
+        let baseline = levels[displayID] ?? 0.5
+        let newValue = max(0, min(1, baseline + delta))
+        bumpGeneration(displayID)
+        let gen = levelGeneration[displayID] ?? 0
+        levels[displayID] = newValue
+
+        if showOSD {
+            OSDBridge.showBrightness(newValue, on: displayID)
+        }
+
+        // Task started from a @MainActor method in Swift 6 inherits MainActor
+        // isolation. The actor `await controller.write/read` hops away and back
+        // automatically, so direct `self.levelGeneration[...]` checks are
+        // MainActor-safe without explicit MainActor.run wrappers.
+        Task { [weak self] in
+            do {
+                try await controller.write(displayID: displayID, value: newValue)
+            } catch {
+                return
+            }
+            guard let self else { return }
+            guard usedFallback else { return }
+            guard self.levelGeneration[displayID] == gen else { return }
+            guard let real = await controller.read(displayID: displayID) else { return }
+            guard self.levelGeneration[displayID] == gen else { return }
+            self.levels[displayID] = real
+        }
+    }
+
+    private func bumpGeneration(_ id: CGDirectDisplayID) {
+        levelGeneration[id, default: 0] &+= 1
+    }
+
+    private func resolveTarget(_ target: BumpTarget) -> CGDirectDisplayID? {
+        switch target {
+        case .displayUnderMouse:
+            return Self.displayUnderMouse(displays: displays) ?? Self.mainDisplayIfSupported(displays: displays)
+        }
+    }
+
+    // MARK: - Static helpers (pure functions, no MainActor state)
+
+    private static func externalDisplayIDs() -> [CGDirectDisplayID] {
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        return ids.filter { CGDisplayIsBuiltin($0) == 0 }
+    }
+
+    private static func localizedName(for displayID: CGDirectDisplayID) -> String? {
+        for screen in NSScreen.screens {
+            let key = NSDeviceDescriptionKey("NSScreenNumber")
+            if let number = screen.deviceDescription[key] as? NSNumber,
+               number.uint32Value == displayID {
+                return screen.localizedName
+            }
+        }
+        return nil
+    }
+
+    fileprivate static func dedupedNames(_ pairs: [(CGDirectDisplayID, String)]) -> [String] {
+        var counts: [String: Int] = [:]
+        // Stable: first occurrence keeps the bare name, subsequent get " (n)".
+        let sorted = pairs.sorted { $0.0 < $1.0 }
+        var result = Array(repeating: "", count: pairs.count)
+        var assigned: [CGDirectDisplayID: String] = [:]
+        for (id, name) in sorted {
+            let n = counts[name] ?? 0
+            assigned[id] = (n == 0) ? name : "\(name) (\(n))"
+            counts[name] = n + 1
+        }
+        for (i, pair) in pairs.enumerated() { result[i] = assigned[pair.0] ?? pair.1 }
+        return result
+    }
+
+    private static func displayUnderMouse(displays: [DisplayInfo]) -> CGDirectDisplayID? {
+        let mouse = NSEvent.mouseLocation
+        for screen in NSScreen.screens where screen.frame.contains(mouse) {
+            let key = NSDeviceDescriptionKey("NSScreenNumber")
+            if let number = screen.deviceDescription[key] as? NSNumber {
+                let id = number.uint32Value
+                if displays.contains(where: { $0.id == id && $0.supportsDDC }) { return id }
+            }
+        }
+        return nil
+    }
+
+    private static func mainDisplayIfSupported(displays: [DisplayInfo]) -> CGDirectDisplayID? {
+        let id = CGMainDisplayID()
+        return displays.contains(where: { $0.id == id && $0.supportsDDC }) ? id : nil
+    }
+}
+
+// MARK: - Test seams (XCTest @testable import)
+
+extension DisplayBrightnessService {
+    func injectDisplaysForTesting(_ d: [DisplayInfo]) { self.displays = d }
+    func setLevelForTesting(_ v: Float, for id: CGDirectDisplayID) { levels[id] = v }
+    func bumpForTesting(_ delta: Float, displayID: CGDirectDisplayID) {
+        bumpInternal(delta, displayID: displayID, showOSD: false)
+    }
+}
+
+// MARK: - Temporary stub until OSDBridge lands (Task 12)
+// DELETE THIS BLOCK in Task 12 when the real OSDBridge is added.
+enum OSDBridge {
+    static func showBrightness(_ value: Float, on displayID: CGDirectDisplayID) {
+        _ = (value, displayID)
+    }
+}

--- a/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
+++ b/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
@@ -57,6 +57,12 @@ final class DisplayBrightnessService {
     func refresh() async {
         guard let controller else { return }
 
+        // Drop any transport caches keyed by the *previous* display topology
+        // before we enumerate the new one. Hot-unplug + replug can recycle
+        // CGDirectDisplayIDs; without this, a stale IOAVService handle would
+        // silently route writes to a defunct transport.
+        await controller.invalidateCaches()
+
         let externalIDs = Self.externalDisplayIDs()
         var newDisplays: [DisplayInfo] = []
         var rawNames: [(CGDirectDisplayID, String)] = []

--- a/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
+++ b/Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift
@@ -218,11 +218,3 @@ extension DisplayBrightnessService {
         bumpInternal(delta, displayID: displayID, showOSD: false)
     }
 }
-
-// MARK: - Temporary stub until OSDBridge lands (Task 12)
-// DELETE THIS BLOCK in Task 12 when the real OSDBridge is added.
-enum OSDBridge {
-    static func showBrightness(_ value: Float, on displayID: CGDirectDisplayID) {
-        _ = (value, displayID)
-    }
-}

--- a/Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift
@@ -1,0 +1,36 @@
+#if !arch(arm64)
+import Foundation
+import CoreGraphics
+import DDC
+
+/// Wraps reitermarkus/DDC.swift for Intel Macs. Apple Silicon uses
+/// `Arm64DDCBackend` instead (DDC.swift's `IOFBGetI2CInterfaceCount`
+/// path does not work on arm64).
+struct IntelDDCBackend: DDCBackend {
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        return DDC(for: displayID) != nil
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        await Task.detached(priority: .userInitiated) {
+            guard let ddc = DDC(for: displayID),
+                  let (current, _) = ddc.read(command: vcp) else { return UInt16?.none }
+            return current
+        }.value
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            guard let ddc = DDC(for: displayID) else {
+                throw NSError(domain: "IntelDDC", code: -1,
+                              userInfo: [NSLocalizedDescriptionKey: "DDC unavailable"])
+            }
+            let ok = ddc.write(command: vcp, value: value)
+            if !ok {
+                throw NSError(domain: "IntelDDC", code: -2,
+                              userInfo: [NSLocalizedDescriptionKey: "DDC write failed"])
+            }
+        }.value
+    }
+}
+#endif

--- a/Sources/AnyDoor/Services/Brightness/OSDBridge.swift
+++ b/Sources/AnyDoor/Services/Brightness/OSDBridge.swift
@@ -58,8 +58,12 @@ enum OSDBridge {
             return
         }
         // +sharedManager is a class method, so look it up on the metaclass.
+        // Guard with class_respondsToSelector: class_getMethodImplementation
+        // returns _objc_msgForward (a forwarding trampoline) — NOT nil — when
+        // the method is absent. Calling that via unsafeBitCast would crash.
         let sharedSel = NSSelectorFromString("sharedManager")
         guard let metaclass = object_getClass(managerClass),
+              class_respondsToSelector(metaclass, sharedSel),
               let sharedIMP = class_getMethodImplementation(metaclass, sharedSel) else {
             logger.debug("OSDManager +sharedManager IMP not found; skipping OSD")
             return
@@ -73,7 +77,9 @@ enum OSDBridge {
         let showSel = NSSelectorFromString(
             "showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:"
         )
-        guard let showIMP = class_getMethodImplementation(managerClass, showSel) else {
+        // Same guard for the instance method: forwarding trampoline avoidance.
+        guard class_respondsToSelector(managerClass, showSel),
+              let showIMP = class_getMethodImplementation(managerClass, showSel) else {
             logger.debug("OSDManager chiclet IMP not found; skipping OSD")
             return
         }

--- a/Sources/AnyDoor/Services/Brightness/OSDBridge.swift
+++ b/Sources/AnyDoor/Services/Brightness/OSDBridge.swift
@@ -1,0 +1,103 @@
+import Foundation
+import CoreGraphics
+import ObjectiveC
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "osd.bridge")
+
+/// Triggers macOS's native chiclet brightness OSD via the private
+/// `OSDManager.sharedManager()` API resident in `OSD.framework`.
+///
+/// Best-effort: every failure path silently no-ops. DDC writes still
+/// take effect on the display regardless of whether the OSD shows.
+///
+/// Implementation note: we resolve `+sharedManager` and the chiclet
+/// selector at runtime via `class_getMethodImplementation` and call
+/// them through `unsafeBitCast`'d C function pointers, avoiding the
+/// long-deprecated `NSInvocation` bridging dance.
+enum OSDBridge {
+    private static let frameworkPath =
+        "/System/Library/PrivateFrameworks/OSD.framework/OSD"
+
+    /// `OSDGraphic.brightness` — the chiclet image identifier used by
+    /// the system brightness HUD.
+    private static let brightnessImageID: Int64 = 1
+    private static let totalChiclets: UInt32 = 16
+    private static let msecUntilFade: UInt32 = 1500
+    private static let priority: UInt32 = 0x0
+
+    /// `dlopen` the private framework once. `nonisolated(unsafe)` is
+    /// safe here: `dlopen` is thread-safe and the handle is only ever
+    /// read, never reassigned.
+    nonisolated(unsafe) private static let loadedHandle: UnsafeMutableRawPointer? = {
+        dlopen(frameworkPath, RTLD_LAZY)
+    }()
+
+    /// `showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:`
+    /// Primitive args only — no NSObjects to bridge.
+    private typealias ShowImageIMP = @convention(c) (
+        AnyObject, Selector,
+        Int64,        // imageID
+        UInt32,       // displayID
+        UInt32,       // priority
+        UInt32,       // msecUntilFade
+        UInt32,       // filledChiclets
+        UInt32,       // totalChiclets
+        ObjCBool      // locked
+    ) -> Void
+
+    private typealias SharedManagerIMP = @convention(c) (AnyClass, Selector) -> AnyObject?
+
+    static func showBrightness(_ value: Float, on displayID: CGDirectDisplayID) {
+        guard loadedHandle != nil else {
+            logger.debug("OSD.framework not loaded; skipping OSD")
+            return
+        }
+        guard let managerClass = NSClassFromString("OSDManager") else {
+            logger.debug("OSDManager class not found; skipping OSD")
+            return
+        }
+        // +sharedManager is a class method, so look it up on the metaclass.
+        let sharedSel = NSSelectorFromString("sharedManager")
+        guard let metaclass = object_getClass(managerClass),
+              let sharedIMP = class_getMethodImplementation(metaclass, sharedSel) else {
+            logger.debug("OSDManager +sharedManager IMP not found; skipping OSD")
+            return
+        }
+        let sharedFn = unsafeBitCast(sharedIMP, to: SharedManagerIMP.self)
+        guard let manager = sharedFn(managerClass, sharedSel) else {
+            logger.debug("OSDManager.sharedManager returned nil; skipping OSD")
+            return
+        }
+
+        let showSel = NSSelectorFromString(
+            "showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:"
+        )
+        guard let showIMP = class_getMethodImplementation(managerClass, showSel) else {
+            logger.debug("OSDManager chiclet IMP not found; skipping OSD")
+            return
+        }
+        // Sanity check: confirm the instance actually responds. If a future
+        // macOS renames this selector, bail silently rather than calling a
+        // garbage IMP returned from the forwarding machinery.
+        if let manager = manager as? NSObject, !manager.responds(to: showSel) {
+            logger.debug("OSDManager does not respond to chiclet selector; skipping OSD")
+            return
+        }
+        let showFn = unsafeBitCast(showIMP, to: ShowImageIMP.self)
+        let clamped = max(0, min(1, value))
+        let filled = UInt32((clamped * Float(totalChiclets)).rounded())
+
+        showFn(
+            manager,
+            showSel,
+            brightnessImageID,
+            UInt32(displayID),
+            priority,
+            msecUntilFade,
+            filled,
+            totalChiclets,
+            ObjCBool(false)
+        )
+    }
+}

--- a/Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift
+++ b/Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift
@@ -25,7 +25,7 @@ enum BuiltinPreferenceSeeder {
                 let order = existing.isEmpty ? item.defaultOrder : addedAt
                 let pref = BuiltinPreference(
                     itemKey: item.rawValue,
-                    isVisible: true,
+                    isVisible: item.defaultVisibility,
                     displayOrder: order,
                     keyCode: nil,
                     modifierFlags: nil

--- a/Sources/AnyDoor/Services/PanelStore.swift
+++ b/Sources/AnyDoor/Services/PanelStore.swift
@@ -181,6 +181,10 @@ final class PanelStore {
         case .runBuiltin(let key):
             guard let item = BuiltinItem(rawValue: key) else { return }
             Task { await self.run(item) }
+        case .brightnessUp:
+            break  // TODO(Task 6): forward to DisplayBrightnessService.bump(.up)
+        case .brightnessDown:
+            break  // TODO(Task 6): forward to DisplayBrightnessService.bump(.down)
         }
     }
 

--- a/Sources/AnyDoor/Services/PanelStore.swift
+++ b/Sources/AnyDoor/Services/PanelStore.swift
@@ -407,13 +407,3 @@ final class PanelStore {
         rebuildHotkeySnapshots()
     }
 }
-
-// MARK: - Temporary stub until DisplayBrightnessService lands (Task 11)
-// This stub keeps the build green during incremental implementation.
-// DELETE THIS BLOCK in Task 11 when the real service is added.
-@MainActor
-enum DisplayBrightnessService {
-    static let shared = Self.self
-    enum BumpTarget { case displayUnderMouse }
-    static func bump(_ delta: Float, target: BumpTarget) { _ = (delta, target) }
-}

--- a/Sources/AnyDoor/Services/PanelStore.swift
+++ b/Sources/AnyDoor/Services/PanelStore.swift
@@ -248,6 +248,19 @@ final class PanelStore {
         return try? context.fetch(descriptor).first
     }
 
+    /// Look up the current hotkey assigned to a built-in item, if any.
+    /// Reads from SwiftData rather than `topLevelEntries` so it works for
+    /// hidden-hotkey items (e.g., brightness ±).
+    func hotkeyForBuiltin(_ item: BuiltinItem) -> HotkeyDescriptor? {
+        guard let container = modelContainer else { return nil }
+        let key = item.rawValue
+        guard let pref = try? container.mainContext.fetch(
+            FetchDescriptor<BuiltinPreference>(predicate: #Predicate { $0.itemKey == key })
+        ).first,
+        let code = pref.keyCode, let mods = pref.modifierFlags else { return nil }
+        return HotkeyDescriptor(keyCode: code, modifierFlags: mods)
+    }
+
     // MARK: - Mutations
 
     /// Update visibility for a built-in.

--- a/Sources/AnyDoor/Services/PanelStore.swift
+++ b/Sources/AnyDoor/Services/PanelStore.swift
@@ -57,6 +57,7 @@ final class PanelStore {
         ) {
             for pref in prefs {
                 guard let item = BuiltinItem(rawValue: pref.itemKey) else { continue }
+                if item.kind == .hiddenHotkey { continue }
                 let hotkey = pref.keyCode.flatMap { code in
                     pref.modifierFlags.map { mods in
                         HotkeyDescriptor(keyCode: code, modifierFlags: mods)
@@ -182,9 +183,9 @@ final class PanelStore {
             guard let item = BuiltinItem(rawValue: key) else { return }
             Task { await self.run(item) }
         case .brightnessUp:
-            break  // TODO(Task 6): forward to DisplayBrightnessService.bump(.up)
+            DisplayBrightnessService.shared.bump(+1.0 / 16.0, target: .displayUnderMouse)
         case .brightnessDown:
-            break  // TODO(Task 6): forward to DisplayBrightnessService.bump(.down)
+            DisplayBrightnessService.shared.bump(-1.0 / 16.0, target: .displayUnderMouse)
         }
     }
 
@@ -212,11 +213,22 @@ final class PanelStore {
             for pref in prefs {
                 guard let item = BuiltinItem(rawValue: pref.itemKey),
                       let code = pref.keyCode,
-                      let mods = pref.modifierFlags,
-                      item.kind != .submenu else { continue }
-                let action: HotkeyAction = item.kind == .toggle
-                    ? .toggleBuiltin(itemKey: item.rawValue)
-                    : .runBuiltin(itemKey: item.rawValue)
+                      let mods = pref.modifierFlags else { continue }
+                let action: HotkeyAction
+                switch item.kind {
+                case .toggle:
+                    action = .toggleBuiltin(itemKey: item.rawValue)
+                case .action:
+                    action = .runBuiltin(itemKey: item.rawValue)
+                case .submenu, .brightnessControl:
+                    continue   // hover-opened items don't bind a top-level hotkey
+                case .hiddenHotkey:
+                    switch item {
+                    case .brightnessUp:   action = .brightnessUp
+                    case .brightnessDown: action = .brightnessDown
+                    default: continue
+                    }
+                }
                 out.append(HotkeySnapshot(
                     keyCode: code,
                     modifierFlags: mods,
@@ -321,8 +333,40 @@ final class PanelStore {
     }
 
     /// Find which entry currently owns a given hotkey (used for conflict detection).
+    ///
+    /// Scans visible top-level rows + visible app shortcut children + hidden-hotkey
+    /// built-ins (e.g., brightness ±) so all hotkey bindings participate in conflict
+    /// detection regardless of whether they render as a panel row.
     func entryUsingHotkey(_ hotkey: HotkeyDescriptor, excluding: PanelEntry.Source? = nil) -> PanelEntry? {
-        for entry in topLevelEntries + appShortcutChildren {
+        var pool = topLevelEntries + appShortcutChildren
+
+        if let container = modelContainer {
+            let context = container.mainContext
+            if let prefs = try? context.fetch(FetchDescriptor<BuiltinPreference>()) {
+                for pref in prefs {
+                    guard let item = BuiltinItem(rawValue: pref.itemKey),
+                          item.kind == .hiddenHotkey,
+                          let code = pref.keyCode,
+                          let mods = pref.modifierFlags else { continue }
+                    let entry = PanelEntry(
+                        id: PanelEntry.id(for: .builtin(item)),
+                        source: .builtin(item),
+                        displayOrder: pref.displayOrder,
+                        isVisible: false,
+                        hotkey: HotkeyDescriptor(keyCode: code, modifierFlags: mods),
+                        title: item.title,
+                        subtitle: nil,
+                        symbol: item.symbol,
+                        kind: .hiddenHotkey,
+                        toggleState: nil,
+                        permission: .notRequired
+                    )
+                    pool.append(entry)
+                }
+            }
+        }
+
+        for entry in pool {
             if entry.source == excluding { continue }
             if entry.hotkey == hotkey { return entry }
         }
@@ -362,4 +406,14 @@ final class PanelStore {
         rebuild()
         rebuildHotkeySnapshots()
     }
+}
+
+// MARK: - Temporary stub until DisplayBrightnessService lands (Task 11)
+// This stub keeps the build green during incremental implementation.
+// DELETE THIS BLOCK in Task 11 when the real service is added.
+@MainActor
+enum DisplayBrightnessService {
+    static let shared = Self.self
+    enum BumpTarget { case displayUnderMouse }
+    static func bump(_ delta: Float, target: BumpTarget) { _ = (delta, target) }
 }

--- a/Sources/AnyDoor/Views/BrightnessPopoverView.swift
+++ b/Sources/AnyDoor/Views/BrightnessPopoverView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import CoreGraphics
+
+struct BrightnessPopoverView: View {
+    @State private var service = DisplayBrightnessService.shared
+    var onHoverChange: (Bool) -> Void = { _ in }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if service.displays.isEmpty {
+                emptyState(text: "未检测到外置显示器", symbol: "display")
+            } else if service.displays.allSatisfy({ !$0.supportsDDC }) {
+                VStack(alignment: .leading, spacing: 4) {
+                    emptyState(text: "未检测到支持 DDC 的外置显示器", symbol: "display.slash")
+                    Text("DisplayPort/HDMI 通常可用，部分 USB-C 转接线不支持")
+                        .font(.caption2).foregroundStyle(.tertiary)
+                }
+            } else {
+                ForEach(service.displays) { info in
+                    DisplayBrightnessCard(info: info, service: service)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 320)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .onAppear {
+            Task { await service.refresh() }
+        }
+        .onHover { onHoverChange($0) }
+    }
+
+    private func emptyState(text: String, symbol: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol).foregroundStyle(.secondary)
+            Text(text).font(.callout).foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct DisplayBrightnessCard: View {
+    let info: DisplayInfo
+    @Bindable var service: DisplayBrightnessService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(info.name).font(.headline)
+                if !info.supportsDDC {
+                    Text("不支持 DDC")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                if service.isLoading.contains(info.id) {
+                    ProgressView().controlSize(.mini)
+                }
+            }
+            HStack(spacing: 8) {
+                Image(systemName: "sun.max.fill").foregroundStyle(.secondary)
+                Slider(
+                    value: Binding(
+                        get: { Double(service.levels[info.id] ?? 0.5) },
+                        set: { service.setBrightness(Float($0), for: info.id) }
+                    ),
+                    in: 0...1
+                )
+                .controlSize(.large)
+                .disabled(!info.supportsDDC)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .opacity(info.supportsDDC ? 1.0 : 0.55)
+    }
+}

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -10,6 +10,7 @@ import AppKit
 private enum HoverPopoverTarget: Hashable {
     case submenu(BuiltinItem)
     case history(ClipboardHistoryKind)
+    case brightnessControl(BuiltinItem)
 }
 
 struct MenuBarView: View {
@@ -121,6 +122,23 @@ struct MenuBarView: View {
                 onToggle: {},
                 onAction: {},
                 onSubmenu: { triggerSubmenu(item) },
+                onPermission: openPermissionsSettings
+            )
+            .background(
+                ScreenFrameReader { frame in
+                    triggerFrames[target] = frame
+                }
+            )
+            .onHover { hovered in
+                triggerHover(hovered, target: target)
+            }
+        } else if case let .builtin(item) = entry.source, item.kind == .brightnessControl {
+            let target = HoverPopoverTarget.brightnessControl(item)
+            PanelRowView(
+                entry: entry,
+                onToggle: {},
+                onAction: {},
+                onSubmenu: {},
                 onPermission: openPermissionsSettings
             )
             .background(
@@ -252,6 +270,12 @@ struct MenuBarView: View {
                 )
             }
             Task { await PortInventory.shared.refresh() }
+            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+        case .brightnessControl:
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                BrightnessPopoverView(onHoverChange: { gate.popoverHover($0) })
+            }
             popover.show(anchoredTo: convertedTriggerFrame(for: target))
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.

--- a/Sources/AnyDoor/Views/PanelRowView.swift
+++ b/Sources/AnyDoor/Views/PanelRowView.swift
@@ -53,6 +53,8 @@ struct PanelRowView: View {
             case .toggle:  onToggle()
             case .submenu: onSubmenu()
             case .action:  onAction()
+            case .brightnessControl: break          // click is intentionally a no-op (hover-only UI)
+            case .hiddenHotkey: break                // never reaches PanelRowView; defensive only
             }
         }
     }
@@ -119,6 +121,13 @@ struct PanelRowView: View {
             Image(systemName: "chevron.right")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
+        case .brightnessControl:
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .frame(width: 12)
+        case .hiddenHotkey:
+            EmptyView()
         }
     }
 }

--- a/Sources/AnyDoor/Views/PanelSettingsView.swift
+++ b/Sources/AnyDoor/Views/PanelSettingsView.swift
@@ -84,15 +84,19 @@ struct PanelSettingsView: View {
         case .toggle:  return "系统"
         case .action:  return "系统 · 动作"
         case .submenu: return "系统 · 子菜单"
+        case .brightnessControl: return "系统 · 亮度"
+        case .hiddenHotkey:      return "系统 · 全局动作"
         }
     }
 
     @ViewBuilder
     private func hotkeyField(for entry: PanelEntry) -> some View {
-        // Any submenu-kind builtin has no hotkey (children carry their own, or
-        // the submenu is opened by hovering). Reserve the column width so the
-        // grid stays aligned.
-        if case let .builtin(item) = entry.source, item.kind == .submenu {
+        // Items that do not get a row-level hotkey recorder:
+        //   - .submenu: opened by hover (children carry their own hotkeys)
+        //   - .brightnessControl: bumps are bound inline below the row
+        //   - .hiddenHotkey: never rendered in the settings grid
+        if case let .builtin(item) = entry.source,
+           item.kind == .submenu || item.kind == .brightnessControl || item.kind == .hiddenHotkey {
             Color.clear.frame(width: 150)
         } else {
             HotkeyRecorder(hotkey: .constant(entry.hotkey)) { newValue in

--- a/Sources/AnyDoor/Views/PanelSettingsView.swift
+++ b/Sources/AnyDoor/Views/PanelSettingsView.swift
@@ -51,8 +51,53 @@ struct PanelSettingsView: View {
                 appShortcutChildren()
                 addAppButton()
             }
+            if case .builtin(.brightness) = entry.source {
+                brightnessHotkeyRecorders()
+            }
         }
         .opacity(entry.isVisible ? 1.0 : 0.5)
+    }
+
+    @ViewBuilder
+    private func brightnessHotkeyRecorders() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            brightnessHotkeyRow(item: .brightnessUp, label: "亮度 +")
+            brightnessHotkeyRow(item: .brightnessDown, label: "亮度 −")
+        }
+        .padding(.leading, 36)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func brightnessHotkeyRow(item: BuiltinItem, label: String) -> some View {
+        HStack {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            HotkeyRecorder(hotkey: .constant(PanelStore.shared.hotkeyForBuiltin(item))) { newValue in
+                handleBrightnessHotkeyChange(item: item, newValue: newValue)
+            }
+            .frame(width: 150, alignment: .trailing)
+        }
+    }
+
+    private func handleBrightnessHotkeyChange(item: BuiltinItem, newValue: HotkeyDescriptor?) {
+        if let new = newValue,
+           let existing = PanelStore.shared.entryUsingHotkey(new, excluding: .builtin(item)) {
+            conflictAlert = ConflictAlert(
+                hotkey: new,
+                existingTitle: existing.title,
+                onReplace: {
+                    if case let .builtin(other) = existing.source {
+                        PanelStore.shared.setBuiltinHotkey(other, hotkey: nil)
+                    } else if case let .appShortcut(id) = existing.source {
+                        PanelStore.shared.updateAppShortcut(id: id, hotkey: nil)
+                    }
+                    PanelStore.shared.setBuiltinHotkey(item, hotkey: new)
+                }
+            )
+        } else {
+            PanelStore.shared.setBuiltinHotkey(item, hotkey: newValue)
+        }
     }
 
     private func mainRow(_ entry: PanelEntry) -> some View {

--- a/Tests/AnyDoorTests/BrightnessControllerTests.swift
+++ b/Tests/AnyDoorTests/BrightnessControllerTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import CoreGraphics
+@testable import AnyDoor
+
+final class BrightnessControllerTests: XCTestCase {
+    func testProbeReturnsTrueWhenTransportReady() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let result = await controller.probe(displayID: displayID)
+        XCTAssertTrue(result)
+    }
+
+    func testProbeReturnsFalseWhenTransportMissing() async {
+        let backend = MockDDCBackend(transportSupported: [])
+        let controller = BrightnessController(backend: backend)
+        let result = await controller.probe(displayID: 1)
+        XCTAssertFalse(result)
+    }
+
+    func testReadNormalizesToZeroOne() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: 50])
+        let controller = BrightnessController(backend: backend)
+        let value = await controller.read(displayID: displayID)
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value!, 0.5, accuracy: 0.01)
+    }
+
+    func testReadReturnsNilOnBackendNil() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: nil])
+        let controller = BrightnessController(backend: backend)
+        let value = await controller.read(displayID: displayID)
+        XCTAssertNil(value)
+    }
+
+    func testWriteRetriesOnceOnFailure() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = FlakyBackend(failuresBeforeSuccess: 1, supports: [displayID])
+        let controller = BrightnessController(backend: backend)
+        try? await controller.write(displayID: displayID, value: 0.75)
+        XCTAssertEqual(backend.writeCount, 2)
+    }
+
+    func testWriteThrowsAfterTwoFailures() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = FlakyBackend(failuresBeforeSuccess: .max, supports: [displayID])
+        let controller = BrightnessController(backend: backend)
+        do {
+            try await controller.write(displayID: displayID, value: 0.5)
+            XCTFail("expected throw")
+        } catch {
+            XCTAssertEqual(backend.writeCount, 2)
+        }
+    }
+}
+
+private final class FlakyBackend: DDCBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var remainingFailures: Int
+    private let _supports: Set<CGDirectDisplayID>
+    private(set) var writeCount = 0
+
+    init(failuresBeforeSuccess: Int, supports: Set<CGDirectDisplayID>) {
+        self.remainingFailures = failuresBeforeSuccess
+        self._supports = supports
+    }
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        _supports.contains(displayID)
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? { nil }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        let shouldFail: Bool = lock.withLock {
+            writeCount += 1
+            if remainingFailures > 0 {
+                remainingFailures -= 1
+                return true
+            }
+            return false
+        }
+        if shouldFail {
+            throw NSError(domain: "flaky", code: 1)
+        }
+    }
+}

--- a/Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift
+++ b/Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import AnyDoor
+
+final class BuiltinItemBrightnessTests: XCTestCase {
+    func testNewCasesExist() {
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightness"))
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightnessUp"))
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightnessDown"))
+    }
+
+    func testBrightnessKindIsBrightnessControl() {
+        XCTAssertEqual(BuiltinItem.brightness.kind, .brightnessControl)
+    }
+
+    func testBumpHotkeysAreHiddenKind() {
+        XCTAssertEqual(BuiltinItem.brightnessUp.kind, .hiddenHotkey)
+        XCTAssertEqual(BuiltinItem.brightnessDown.kind, .hiddenHotkey)
+    }
+
+    func testDefaultVisibilityFalseForHiddenHotkeys() {
+        XCTAssertFalse(BuiltinItem.brightnessUp.defaultVisibility)
+        XCTAssertFalse(BuiltinItem.brightnessDown.defaultVisibility)
+    }
+
+    func testDefaultVisibilityTrueForRegularItems() {
+        XCTAssertTrue(BuiltinItem.brightness.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.keepAwake.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.appShortcuts.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.ocr.defaultVisibility)
+    }
+
+    func testBrightnessTitleAndSymbol() {
+        XCTAssertEqual(BuiltinItem.brightness.title, "屏幕亮度")
+        XCTAssertEqual(BuiltinItem.brightness.symbol, "sun.max")
+    }
+
+    func testBumpRowsExcludedFromAllCasesIteration() {
+        // Sanity: they are in allCases so .allCases iteration in seeder picks them up
+        XCTAssertTrue(BuiltinItem.allCases.contains(.brightnessUp))
+        XCTAssertTrue(BuiltinItem.allCases.contains(.brightnessDown))
+    }
+}

--- a/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
+++ b/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+@MainActor
+final class BuiltinPreferenceSeederTests: XCTestCase {
+    private func makeInMemoryContext() throws -> ModelContext {
+        let schema = Schema([
+            KeyBinding.self,
+            BuiltinPreference.self,
+            ClipboardHistoryItem.self,
+        ])
+        let config = ModelConfiguration(
+            isStoredInMemoryOnly: true,
+            allowsSave: true
+        )
+        let container = try ModelContainer(for: schema, configurations: [config])
+        return container.mainContext
+    }
+
+    func testHiddenHotkeyItemsAreSeededInvisible() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let prefs = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+        let up = try XCTUnwrap(prefs.first { $0.itemKey == "brightnessUp" })
+        let down = try XCTUnwrap(prefs.first { $0.itemKey == "brightnessDown" })
+        XCTAssertFalse(up.isVisible)
+        XCTAssertFalse(down.isVisible)
+    }
+
+    func testRegularItemsAreSeededVisible() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let prefs = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+        let brightness = try XCTUnwrap(prefs.first { $0.itemKey == "brightness" })
+        let keepAwake = try XCTUnwrap(prefs.first { $0.itemKey == "keepAwake" })
+        XCTAssertTrue(brightness.isVisible)
+        XCTAssertTrue(keepAwake.isVisible)
+    }
+
+    func testSeederIsIdempotent() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+        let first = try ctx.fetch(FetchDescriptor<BuiltinPreference>()).count
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+        let second = try ctx.fetch(FetchDescriptor<BuiltinPreference>()).count
+        XCTAssertEqual(first, second)
+    }
+}

--- a/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
+++ b/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import SwiftData
 @testable import AnyDoor
 
-@MainActor
 final class BuiltinPreferenceSeederTests: XCTestCase {
     private func makeInMemoryContext() throws -> ModelContext {
         let schema = Schema([
@@ -15,9 +14,10 @@ final class BuiltinPreferenceSeederTests: XCTestCase {
             allowsSave: true
         )
         let container = try ModelContainer(for: schema, configurations: [config])
-        return container.mainContext
+        return ModelContext(container)
     }
 
+    @MainActor
     func testHiddenHotkeyItemsAreSeededInvisible() throws {
         let ctx = try makeInMemoryContext()
         BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
@@ -29,6 +29,7 @@ final class BuiltinPreferenceSeederTests: XCTestCase {
         XCTAssertFalse(down.isVisible)
     }
 
+    @MainActor
     func testRegularItemsAreSeededVisible() throws {
         let ctx = try makeInMemoryContext()
         BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
@@ -40,6 +41,7 @@ final class BuiltinPreferenceSeederTests: XCTestCase {
         XCTAssertTrue(keepAwake.isVisible)
     }
 
+    @MainActor
     func testSeederIsIdempotent() throws {
         let ctx = try makeInMemoryContext()
         BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)

--- a/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
+++ b/Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
@@ -50,4 +50,42 @@ final class BuiltinPreferenceSeederTests: XCTestCase {
         let second = try ctx.fetch(FetchDescriptor<BuiltinPreference>()).count
         XCTAssertEqual(first, second)
     }
+
+    @MainActor
+    func testSeedsAllItemsOnEmptyStore() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let rows = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+        XCTAssertEqual(rows.count, BuiltinItem.allCases.count)
+
+        let keys = Set(rows.map(\.itemKey))
+        for item in BuiltinItem.allCases {
+            XCTAssertTrue(keys.contains(item.rawValue), "missing \(item.rawValue)")
+        }
+    }
+
+    @MainActor
+    func testSeedingAppendsNewItemsAtEnd() throws {
+        let ctx = try makeInMemoryContext()
+
+        // Pre-populate with one item to simulate prior state.
+        ctx.insert(BuiltinPreference(itemKey: BuiltinItem.keepAwake.rawValue,
+                                     isVisible: true,
+                                     displayOrder: 50))
+        try ctx.save()
+
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let rows = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+            .sorted { $0.displayOrder < $1.displayOrder }
+
+        // Pre-existing row should still be at order 50.
+        XCTAssertEqual(rows.first?.itemKey, BuiltinItem.keepAwake.rawValue)
+        XCTAssertEqual(rows.first?.displayOrder, 50)
+        // New rows should all have order > 50.
+        for row in rows.dropFirst() {
+            XCTAssertGreaterThan(row.displayOrder, 50)
+        }
+    }
 }

--- a/Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift
+++ b/Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import CoreGraphics
+@testable import AnyDoor
+
+@MainActor
+final class DisplayBrightnessServiceTests: XCTestCase {
+    func testSetBrightnessUpdatesLevelsImmediately() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setBrightness(0.42, for: displayID)
+        XCTAssertEqual(service.levels[displayID], 0.42)
+    }
+
+    func testSetBrightnessDebouncesWrites() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setBrightness(0.1, for: displayID)
+        service.setBrightness(0.2, for: displayID)
+        service.setBrightness(0.3, for: displayID)
+        // wait for debounce window (30 ms) + execution slack
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(backend.writeCalls.count, 1, "expected one consolidated write")
+        XCTAssertEqual(backend.writeCalls.last?.value, 30) // 0.3 * 100
+    }
+
+    func testBumpUsesFallbackBaselineWhenNil() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        // levels[displayID] starts nil → bump uses 0.5 + 0.0625 = 0.5625
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 0.5625, accuracy: 0.001)
+    }
+
+    func testBumpClampsToZeroOne() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setLevelForTesting(0.95, for: displayID)
+        service.bumpForTesting(+0.5, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 1.0, accuracy: 0.001)
+
+        service.setLevelForTesting(0.05, for: displayID)
+        service.bumpForTesting(-0.5, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 0.0, accuracy: 0.001)
+    }
+
+    func testGenerationTokenInvalidatesBackfill() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: 80])  // real device value
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        // levels[id] nil → triggers backfill after write
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        let immediate = service.levels[displayID]
+        XCTAssertEqual(immediate!, 0.5625, accuracy: 0.001)
+
+        // Before backfill completes, user nudges again → generation bumps,
+        // backfill must not clobber.
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        let post = service.levels[displayID]
+        XCTAssertEqual(post!, 0.625, accuracy: 0.001)
+
+        // Give the backfill ample time to (incorrectly) overwrite.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Generation guard wins → still 0.625, NOT 0.8 (backfill discarded).
+        XCTAssertEqual(service.levels[displayID]!, 0.625, accuracy: 0.001)
+    }
+}

--- a/Tests/AnyDoorTests/MigrationTests.swift
+++ b/Tests/AnyDoorTests/MigrationTests.swift
@@ -137,64 +137,6 @@ final class KeyBindingOrderBackfillTests: XCTestCase {
     }
 }
 
-final class BuiltinPreferenceSeederTests: XCTestCase {
-    @MainActor
-    func testSeedsAllItemsOnEmptyStore() throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: BuiltinPreference.self, configurations: config)
-        let context = ModelContext(container)
-
-        BuiltinPreferenceSeeder.seedIfNeeded(in: context)
-
-        let rows = try context.fetch(FetchDescriptor<BuiltinPreference>())
-        XCTAssertEqual(rows.count, BuiltinItem.allCases.count)
-
-        let keys = Set(rows.map(\.itemKey))
-        for item in BuiltinItem.allCases {
-            XCTAssertTrue(keys.contains(item.rawValue), "missing \(item.rawValue)")
-        }
-    }
-
-    @MainActor
-    func testSeedingIsIdempotent() throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: BuiltinPreference.self, configurations: config)
-        let context = ModelContext(container)
-
-        BuiltinPreferenceSeeder.seedIfNeeded(in: context)
-        BuiltinPreferenceSeeder.seedIfNeeded(in: context)
-
-        let rows = try context.fetch(FetchDescriptor<BuiltinPreference>())
-        XCTAssertEqual(rows.count, BuiltinItem.allCases.count)
-    }
-
-    @MainActor
-    func testSeedingAppendsNewItemsAtEnd() throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: BuiltinPreference.self, configurations: config)
-        let context = ModelContext(container)
-
-        // Pre-populate with one item to simulate prior state
-        context.insert(BuiltinPreference(itemKey: BuiltinItem.keepAwake.rawValue,
-                                          isVisible: true,
-                                          displayOrder: 50))
-        try context.save()
-
-        BuiltinPreferenceSeeder.seedIfNeeded(in: context)
-
-        let rows = try context.fetch(FetchDescriptor<BuiltinPreference>())
-            .sorted { $0.displayOrder < $1.displayOrder }
-
-        // Pre-existing row should still be at order 50
-        XCTAssertEqual(rows.first?.itemKey, BuiltinItem.keepAwake.rawValue)
-        XCTAssertEqual(rows.first?.displayOrder, 50)
-        // New rows should all have order > 50
-        for row in rows.dropFirst() {
-            XCTAssertGreaterThan(row.displayOrder, 50)
-        }
-    }
-}
-
 final class ClipboardHistoryItemModelTests: XCTestCase {
     func testClipboardHistoryKindMetadata() {
         XCTAssertEqual(ClipboardHistoryKind.ocr.title, "屏幕取词")

--- a/Tests/AnyDoorTests/PanelStoreTests.swift
+++ b/Tests/AnyDoorTests/PanelStoreTests.swift
@@ -34,7 +34,10 @@ final class PanelStoreTests: XCTestCase {
         let store = PanelStore.shared
         store.bootstrap(modelContainer: container, providers: [])
 
-        XCTAssertEqual(store.topLevelEntries.count, BuiltinItem.allCases.count)
+        // hiddenHotkey items (brightnessUp/brightnessDown) are seeded but
+        // filtered out of topLevelEntries — they own a hotkey, not a row.
+        let expectedVisibleKinds = BuiltinItem.allCases.filter { $0.kind != .hiddenHotkey }
+        XCTAssertEqual(store.topLevelEntries.count, expectedVisibleKinds.count)
         // Order should follow defaultOrder
         let titles = store.topLevelEntries.map(\.title)
         XCTAssertEqual(titles.first, BuiltinItem.keepAwake.title) // defaultOrder 100 is smallest

--- a/docs/superpowers/plans/2026-05-24-display-brightness-plan.md
+++ b/docs/superpowers/plans/2026-05-24-display-brightness-plan.md
@@ -1,0 +1,2193 @@
+# Display Brightness Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a hover-popover "屏幕亮度" panel entry that controls external DDC/CI display brightness on both Intel and Apple Silicon Macs, plus assignable ± hotkeys that fire the native macOS OSD.
+
+**Architecture:** A new `DisplayBrightnessService` (@MainActor @Observable) sits between the SwiftUI hover popover and a `BrightnessController` actor. The controller talks to displays through a `DDCBackend` protocol with two production implementations chosen at compile time: `IntelDDCBackend` (wraps `reitermarkus/DDC.swift`, MIT) on Intel, and a clean-room `Arm64DDCBackend` (calls private `IOAVServiceReadI2C` / `IOAVServiceWriteI2C` symbols) on Apple Silicon. The hover popover plugs into the existing `MenuBarView` hover-routing via a new `HoverPopoverTarget` case. Brightness ± hotkeys are modelled as proper `BuiltinItem` cases with a new `.hiddenHotkey` Kind so they participate in conflict detection without rendering as panel rows.
+
+**Tech Stack:** Swift 6.2, SwiftUI, SwiftData, IOKit (Intel: `IOKit.i2c`; Apple Silicon: private `IOAVService`), CoreDisplay, AppKit (`NSScreen`, `NSEvent.mouseLocation`), private `OSD.framework`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-24-display-brightness-design.md`](../specs/2026-05-24-display-brightness-design.md)
+
+---
+
+## File Map
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `Sources/AnyDoor/Services/Brightness/DDCBackend.swift` | Protocol + `MockDDCBackend` (always available). |
+| `Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift` | `#if arch(arm64)` IOAVService clean-room backend. |
+| `Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift` | `#if !arch(arm64)` wraps DDC.swift. |
+| `Sources/AnyDoor/Services/Brightness/BrightnessController.swift` | Actor: serializes I2C, exposes probe/read/write. |
+| `Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift` | @MainActor @Observable: enumerates displays, owns `levels` / `levelGeneration`, debounces writes, handles hotkey bumps. |
+| `Sources/AnyDoor/Services/Brightness/OSDBridge.swift` | dlopen-based native OSD trigger; silent no-op on failure. |
+| `Sources/AnyDoor/Views/BrightnessPopoverView.swift` | Hover popover content + per-display `DisplayBrightnessCard`. |
+| `Tests/AnyDoorTests/BrightnessControllerTests.swift` | Probe / read / write / retry / clamp / normalization via `MockDDCBackend`. |
+| `Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift` | Debounce, generation token, nil-baseline backfill, fallback display resolution. |
+| `Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift` | New cases + Kind + defaultVisibility. |
+| `Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift` | Seeded `.hiddenHotkey` rows have `isVisible == false`. |
+
+### Modified files
+
+| Path | What changes |
+|---|---|
+| `Package.swift` | Add `reitermarkus/DDC.swift` dependency (unconditional; arch gating is at source level). |
+| `Sources/AnyDoor/Models/BuiltinItem.swift` | New cases `.brightness` / `.brightnessUp` / `.brightnessDown`, new `Kind` cases `.brightnessControl` / `.hiddenHotkey`, `defaultVisibility` property, plus updates to all per-case switches. |
+| `Sources/AnyDoor/Models/HotkeyAction.swift` | Add `.brightnessUp` / `.brightnessDown` cases. |
+| `Sources/AnyDoor/Services/PanelStore.swift` | `rebuild()` filters `.hiddenHotkey`; `entryUsingHotkey` also scans hidden-hotkey items; `rebuildHotkeySnapshots` emits brightness actions; `dispatch` routes ± to service. |
+| `Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift` | Use `item.defaultVisibility` instead of hardcoded `true`. |
+| `Sources/AnyDoor/Views/PanelRowView.swift` | Two switches grow `.brightnessControl` and `.hiddenHotkey` arms. |
+| `Sources/AnyDoor/Views/PanelSettingsView.swift` | `typeBadge` and `hotkeyField` switches grow new arms; inline brightness ± recorder below the brightness row. |
+| `Sources/AnyDoor/Views/MenuBarView.swift` | `HoverPopoverTarget` gains `.brightnessControl(BuiltinItem)`; `rowView(for:)` registers the trigger; `mountPopoverContent` mounts `BrightnessPopoverView`. |
+| `Sources/AnyDoor/AppDelegate.swift` | Build controller + service, call `bootstrap`, schedule background pre-warm refresh. |
+| `README.md` / `README.zh-CN.md` | DDC.swift attribution line. |
+
+---
+
+## Task 1 — Add DDC.swift dependency to Package.swift
+
+**Files:**
+- Modify: `Package.swift`
+
+- [ ] **Step 1.1: Add dependency and product**
+
+Open `Package.swift`. In the `dependencies:` array (after the Sparkle entry) add:
+
+```swift
+.package(
+    url: "https://github.com/reitermarkus/DDC.swift",
+    from: "0.0.1"
+),
+```
+
+In the `AnyDoor` executable target's `dependencies:` array add:
+
+```swift
+.product(name: "DDC", package: "DDC.swift"),
+```
+
+Resulting `targets:` block looks like:
+
+```swift
+.executableTarget(
+    name: "AnyDoor",
+    dependencies: [
+        .product(name: "AskForPermission", package: "AskForPermission"),
+        .product(name: "Sparkle", package: "Sparkle"),
+        .product(name: "DDC", package: "DDC.swift"),
+    ],
+    swiftSettings: [
+        .swiftLanguageMode(.v6),
+    ]
+),
+```
+
+Leave the dependency unconditional. Per the spec, `Package.swift` `#if arch(...)` is host-evaluated and would break universal builds.
+
+- [ ] **Step 1.2: Resolve & verify build**
+
+```bash
+swift package update DDC.swift
+swift build 2>&1 | tail -20
+```
+
+Expected: build succeeds (no usage yet, so no source-level errors). `Package.resolved` updates.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add Package.swift Package.resolved
+git commit -m "feat(brightness): add DDC.swift dependency for external display DDC/CI control"
+```
+
+---
+
+## Task 2 — Extend `BuiltinItem` with brightness cases, Kind values, and `defaultVisibility`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/BuiltinItem.swift`
+- Create: `Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class BuiltinItemBrightnessTests: XCTestCase {
+    func testNewCasesExist() {
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightness"))
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightnessUp"))
+        XCTAssertNotNil(BuiltinItem(rawValue: "brightnessDown"))
+    }
+
+    func testBrightnessKindIsBrightnessControl() {
+        XCTAssertEqual(BuiltinItem.brightness.kind, .brightnessControl)
+    }
+
+    func testBumpHotkeysAreHiddenKind() {
+        XCTAssertEqual(BuiltinItem.brightnessUp.kind, .hiddenHotkey)
+        XCTAssertEqual(BuiltinItem.brightnessDown.kind, .hiddenHotkey)
+    }
+
+    func testDefaultVisibilityFalseForHiddenHotkeys() {
+        XCTAssertFalse(BuiltinItem.brightnessUp.defaultVisibility)
+        XCTAssertFalse(BuiltinItem.brightnessDown.defaultVisibility)
+    }
+
+    func testDefaultVisibilityTrueForRegularItems() {
+        XCTAssertTrue(BuiltinItem.brightness.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.keepAwake.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.appShortcuts.defaultVisibility)
+        XCTAssertTrue(BuiltinItem.ocr.defaultVisibility)
+    }
+
+    func testBrightnessTitleAndSymbol() {
+        XCTAssertEqual(BuiltinItem.brightness.title, "屏幕亮度")
+        XCTAssertEqual(BuiltinItem.brightness.symbol, "sun.max")
+    }
+
+    func testBumpRowsExcludedFromAllCasesIteration() {
+        // Sanity: they are in allCases so .allCases iteration in seeder picks them up
+        XCTAssertTrue(BuiltinItem.allCases.contains(.brightnessUp))
+        XCTAssertTrue(BuiltinItem.allCases.contains(.brightnessDown))
+    }
+}
+```
+
+- [ ] **Step 2.2: Run tests; verify they fail**
+
+```bash
+swift test --filter BuiltinItemBrightnessTests 2>&1 | tail -20
+```
+
+Expected: compile errors ("type 'BuiltinItem' has no member 'brightness'") or test failures.
+
+- [ ] **Step 2.3: Add the three new cases**
+
+Edit `Sources/AnyDoor/Models/BuiltinItem.swift`. Append three cases to the `enum BuiltinItem` declaration (after line 27 `case qrcode`):
+
+```swift
+    case brightness
+    case brightnessUp
+    case brightnessDown
+```
+
+- [ ] **Step 2.4: Add the two new `Kind` cases**
+
+In the `enum Kind: Sendable` block (around line 29) add two cases:
+
+```swift
+    enum Kind: Sendable {
+        case toggle
+        case action
+        case submenu
+        case brightnessControl
+        case hiddenHotkey
+    }
+```
+
+- [ ] **Step 2.5: Update the `kind` switch**
+
+Update the `kind` computed property switch to route the new cases. The full switch becomes:
+
+```swift
+    var kind: Kind {
+        switch self {
+        case .appShortcuts, .portManager: return .submenu
+        case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
+             .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
+        case .lockScreen, .emptyTrash, .screenshot, .ocr, .qrcode, .pickColor, .displaySleep, .systemSleep,
+             .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+        case .brightness: return .brightnessControl
+        case .brightnessUp, .brightnessDown: return .hiddenHotkey
+        }
+    }
+```
+
+- [ ] **Step 2.6: Add title / symbol / defaultOrder for the new cases**
+
+Update three switches. In `title`, add:
+
+```swift
+        case .brightness: return "屏幕亮度"
+        case .brightnessUp: return "亮度 +"
+        case .brightnessDown: return "亮度 −"
+```
+
+In `symbol`, add:
+
+```swift
+        case .brightness: return "sun.max"
+        case .brightnessUp: return "sun.max"
+        case .brightnessDown: return "sun.min"
+```
+
+In `defaultOrder`, add (placing `.brightness` adjacent to display-related items, sentinel for hidden):
+
+```swift
+        case .brightness: return 650
+        case .brightnessUp: return 999_998
+        case .brightnessDown: return 999_999
+```
+
+- [ ] **Step 2.7: Add `defaultVisibility` computed property**
+
+After the `feedbackSound` property (line 155), add:
+
+```swift
+    /// Whether this item should default to being shown in the menu bar panel when first seeded.
+    /// False only for hidden-hotkey items (brightness ± live on the brightness row only).
+    var defaultVisibility: Bool {
+        switch self.kind {
+        case .toggle, .action, .submenu, .brightnessControl: return true
+        case .hiddenHotkey:                                   return false
+        }
+    }
+```
+
+- [ ] **Step 2.8: Run tests**
+
+```bash
+swift test --filter BuiltinItemBrightnessTests 2>&1 | tail -20
+```
+
+Expected: all 7 tests pass. Note: `swift build` (full) will still fail because exhaustive switches downstream (`PanelRowView`, `PanelSettingsView`) haven't been updated yet. That's intentional — Task 5 fixes them.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/BuiltinItem.swift Tests/AnyDoorTests/BuiltinItemBrightnessTests.swift
+git commit -m "feat(brightness): add brightness BuiltinItem cases and Kind values"
+```
+
+---
+
+## Task 3 — Update `BuiltinPreferenceSeeder` to use `defaultVisibility`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift:26-32`
+- Create: `Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift`
+
+- [ ] **Step 3.1: Write the failing test**
+
+Create `Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift`:
+
+```swift
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+@MainActor
+final class BuiltinPreferenceSeederTests: XCTestCase {
+    private func makeInMemoryContext() throws -> ModelContext {
+        let schema = Schema([
+            KeyBinding.self,
+            BuiltinPreference.self,
+            ClipboardHistoryItem.self,
+        ])
+        let config = ModelConfiguration(
+            isStoredInMemoryOnly: true,
+            allowsSave: true
+        )
+        let container = try ModelContainer(for: schema, configurations: [config])
+        return container.mainContext
+    }
+
+    func testHiddenHotkeyItemsAreSeededInvisible() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let prefs = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+        let up = try XCTUnwrap(prefs.first { $0.itemKey == "brightnessUp" })
+        let down = try XCTUnwrap(prefs.first { $0.itemKey == "brightnessDown" })
+        XCTAssertFalse(up.isVisible)
+        XCTAssertFalse(down.isVisible)
+    }
+
+    func testRegularItemsAreSeededVisible() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+
+        let prefs = try ctx.fetch(FetchDescriptor<BuiltinPreference>())
+        let brightness = try XCTUnwrap(prefs.first { $0.itemKey == "brightness" })
+        let keepAwake = try XCTUnwrap(prefs.first { $0.itemKey == "keepAwake" })
+        XCTAssertTrue(brightness.isVisible)
+        XCTAssertTrue(keepAwake.isVisible)
+    }
+
+    func testSeederIsIdempotent() throws {
+        let ctx = try makeInMemoryContext()
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+        let first = try ctx.fetch(FetchDescriptor<BuiltinPreference>()).count
+        BuiltinPreferenceSeeder.seedIfNeeded(in: ctx)
+        let second = try ctx.fetch(FetchDescriptor<BuiltinPreference>()).count
+        XCTAssertEqual(first, second)
+    }
+}
+```
+
+- [ ] **Step 3.2: Modify the seeder**
+
+In `Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift` change the `BuiltinPreference(...)` initializer at line 26-32 from:
+
+```swift
+                let pref = BuiltinPreference(
+                    itemKey: item.rawValue,
+                    isVisible: true,
+                    displayOrder: order,
+                    keyCode: nil,
+                    modifierFlags: nil
+                )
+```
+
+to:
+
+```swift
+                let pref = BuiltinPreference(
+                    itemKey: item.rawValue,
+                    isVisible: item.defaultVisibility,
+                    displayOrder: order,
+                    keyCode: nil,
+                    modifierFlags: nil
+                )
+```
+
+- [ ] **Step 3.3: Run the seeder tests**
+
+```bash
+swift test --filter BuiltinPreferenceSeederTests 2>&1 | tail -20
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/BuiltinPreferenceSeeder.swift Tests/AnyDoorTests/BuiltinPreferenceSeederTests.swift
+git commit -m "feat(brightness): seeder honours BuiltinItem.defaultVisibility"
+```
+
+---
+
+## Task 4 — Extend `HotkeyAction` enum
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/HotkeyAction.swift`
+
+- [ ] **Step 4.1: Add the two new cases**
+
+Replace the `HotkeyAction` enum body to:
+
+```swift
+enum HotkeyAction: Sendable, Hashable {
+    case launchApp(bundleID: String, path: String)
+    case toggleBuiltin(itemKey: String)
+    case runBuiltin(itemKey: String)
+    case brightnessUp
+    case brightnessDown
+}
+```
+
+- [ ] **Step 4.2: Verify build (file in isolation)**
+
+```bash
+swift build 2>&1 | grep -E "(HotkeyAction|error:)" | head -20
+```
+
+Errors about exhaustive switches in `PanelStore.swift:174` are expected; they will be addressed in Task 6. Other errors should not appear.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/HotkeyAction.swift
+git commit -m "feat(brightness): add brightnessUp/Down HotkeyAction cases"
+```
+
+---
+
+## Task 5 — Patch every exhaustive switch on `BuiltinItem.Kind`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/PanelRowView.swift:52-56`
+- Modify: `Sources/AnyDoor/Views/PanelRowView.swift:86`
+- Modify: `Sources/AnyDoor/Views/PanelSettingsView.swift:83-87`
+- Modify: `Sources/AnyDoor/Views/PanelSettingsView.swift:95`
+
+- [ ] **Step 5.1: Patch `PanelRowView` onTapGesture switch**
+
+In `Sources/AnyDoor/Views/PanelRowView.swift` the `.onTapGesture` switch (around line 52) becomes:
+
+```swift
+            switch entry.kind {
+            case .toggle:  onToggle()
+            case .submenu: onSubmenu()
+            case .action:  onAction()
+            case .brightnessControl: break          // click is intentionally a no-op (hover-only UI)
+            case .hiddenHotkey: break                // never reaches PanelRowView; defensive only
+            }
+```
+
+- [ ] **Step 5.2: Patch `PanelRowView` trailing view switch**
+
+Find the `trailing` view's `switch entry.kind` (around line 86). Add at the end of the switch (before its closing brace), inside the `@ViewBuilder` block:
+
+```swift
+        case .brightnessControl:
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .frame(width: 12)
+        case .hiddenHotkey:
+            EmptyView()
+```
+
+If the existing switch doesn't have `.toggle`, `.submenu`, `.action` as bare cases (they currently use complex bodies), keep their bodies unchanged and only add the two new cases. Verify by reading lines 86-160 of the file first.
+
+- [ ] **Step 5.3: Patch `PanelSettingsView.typeBadge`**
+
+In `Sources/AnyDoor/Views/PanelSettingsView.swift` the `typeBadge` method (lines 82-88) becomes:
+
+```swift
+    private func typeBadge(for entry: PanelEntry) -> String {
+        switch entry.kind {
+        case .toggle:  return "系统"
+        case .action:  return "系统 · 动作"
+        case .submenu: return "系统 · 子菜单"
+        case .brightnessControl: return "系统 · 亮度"
+        case .hiddenHotkey:      return "系统 · 全局动作"
+        }
+    }
+```
+
+- [ ] **Step 5.4: Patch `PanelSettingsView.hotkeyField`**
+
+Replace the `hotkeyField` method (lines 90-103) with:
+
+```swift
+    @ViewBuilder
+    private func hotkeyField(for entry: PanelEntry) -> some View {
+        // Items that do not get a row-level hotkey recorder:
+        //   - .submenu: opened by hover (children carry their own hotkeys)
+        //   - .brightnessControl: bumps are bound inline below the row
+        //   - .hiddenHotkey: never rendered in the settings grid
+        if case let .builtin(item) = entry.source,
+           item.kind == .submenu || item.kind == .brightnessControl || item.kind == .hiddenHotkey {
+            Color.clear.frame(width: 150)
+        } else {
+            HotkeyRecorder(hotkey: .constant(entry.hotkey)) { newValue in
+                handleHotkeyChange(entry: entry, newValue: newValue)
+            }
+            .frame(width: 150, alignment: .trailing)
+        }
+    }
+```
+
+- [ ] **Step 5.5: Verify full build**
+
+```bash
+swift build 2>&1 | tail -30
+```
+
+Expected: build succeeds. No more "switch must be exhaustive" or "missing case" errors. (If a different switch on `Kind` somewhere else fires, patch it the same way.)
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PanelRowView.swift Sources/AnyDoor/Views/PanelSettingsView.swift
+git commit -m "feat(brightness): extend Kind exhaustive switches for new cases"
+```
+
+---
+
+## Task 6 — Update `PanelStore` for hidden hotkeys + brightness dispatch
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift:49-108` (rebuild)
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift:174-185` (dispatch)
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift:189-225` (rebuildHotkeySnapshots)
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift:320-326` (entryUsingHotkey)
+
+- [ ] **Step 6.1: Filter `.hiddenHotkey` out of `topLevelEntries`**
+
+Inside `rebuild()`, just after the line:
+
+```swift
+                guard let item = BuiltinItem(rawValue: pref.itemKey) else { continue }
+```
+
+add:
+
+```swift
+                if item.kind == .hiddenHotkey { continue }
+```
+
+- [ ] **Step 6.2: Extend `entryUsingHotkey`**
+
+Replace the existing method (`entryUsingHotkey` at line 320) with:
+
+```swift
+    /// Find which entry currently owns a given hotkey (used for conflict detection).
+    ///
+    /// Scans visible top-level rows + visible app shortcut children + hidden-hotkey
+    /// built-ins (e.g., brightness ±) so all hotkey bindings participate in conflict
+    /// detection regardless of whether they render as a panel row.
+    func entryUsingHotkey(_ hotkey: HotkeyDescriptor, excluding: PanelEntry.Source? = nil) -> PanelEntry? {
+        var pool = topLevelEntries + appShortcutChildren
+
+        if let container = modelContainer {
+            let context = container.mainContext
+            if let prefs = try? context.fetch(FetchDescriptor<BuiltinPreference>()) {
+                for pref in prefs {
+                    guard let item = BuiltinItem(rawValue: pref.itemKey),
+                          item.kind == .hiddenHotkey,
+                          let code = pref.keyCode,
+                          let mods = pref.modifierFlags else { continue }
+                    let entry = PanelEntry(
+                        id: PanelEntry.id(for: .builtin(item)),
+                        source: .builtin(item),
+                        displayOrder: pref.displayOrder,
+                        isVisible: false,
+                        hotkey: HotkeyDescriptor(keyCode: code, modifierFlags: mods),
+                        title: item.title,
+                        subtitle: nil,
+                        symbol: item.symbol,
+                        kind: .hiddenHotkey,
+                        toggleState: nil,
+                        permission: .notRequired
+                    )
+                    pool.append(entry)
+                }
+            }
+        }
+
+        for entry in pool {
+            if entry.source == excluding { continue }
+            if entry.hotkey == hotkey { return entry }
+        }
+        return nil
+    }
+```
+
+- [ ] **Step 6.3: Emit brightness snapshots from `rebuildHotkeySnapshots`**
+
+In `rebuildHotkeySnapshots()` the inner BuiltinPreference loop currently skips `.submenu`. Replace that loop (around line 207-221) with:
+
+```swift
+        if let prefs = try? context.fetch(FetchDescriptor<BuiltinPreference>()) {
+            for pref in prefs {
+                guard let item = BuiltinItem(rawValue: pref.itemKey),
+                      let code = pref.keyCode,
+                      let mods = pref.modifierFlags else { continue }
+                let action: HotkeyAction
+                switch item.kind {
+                case .toggle:
+                    action = .toggleBuiltin(itemKey: item.rawValue)
+                case .action:
+                    action = .runBuiltin(itemKey: item.rawValue)
+                case .submenu, .brightnessControl:
+                    continue   // hover-opened items don't bind a top-level hotkey
+                case .hiddenHotkey:
+                    switch item {
+                    case .brightnessUp:   action = .brightnessUp
+                    case .brightnessDown: action = .brightnessDown
+                    default: continue
+                    }
+                }
+                out.append(HotkeySnapshot(
+                    keyCode: code,
+                    modifierFlags: mods,
+                    action: action
+                ))
+            }
+        }
+```
+
+- [ ] **Step 6.4: Extend `dispatch` to route brightness actions**
+
+Replace `dispatch(_:)` (line 174-185) with:
+
+```swift
+    /// Handle a matched hotkey. Called on the main thread by HotkeyService.
+    func dispatch(_ action: HotkeyAction) {
+        switch action {
+        case .launchApp(let bundleID, let path):
+            AppSwitcher.toggle(bundleID: bundleID, appPath: path)
+        case .toggleBuiltin(let key):
+            guard let item = BuiltinItem(rawValue: key) else { return }
+            Task { await self.toggle(item) }
+        case .runBuiltin(let key):
+            guard let item = BuiltinItem(rawValue: key) else { return }
+            Task { await self.run(item) }
+        case .brightnessUp:
+            DisplayBrightnessService.shared.bump(+1.0 / 16.0, target: .displayUnderMouse)
+        case .brightnessDown:
+            DisplayBrightnessService.shared.bump(-1.0 / 16.0, target: .displayUnderMouse)
+        }
+    }
+```
+
+- [ ] **Step 6.5: Add a setter for the brightness ± hotkeys**
+
+`setBuiltinHotkey(_:hotkey:)` (line 253) already works for any `BuiltinItem` raw value, including `.brightnessUp` / `.brightnessDown`. No new method required — the settings UI in Task 14 will call `panel.setBuiltinHotkey(.brightnessUp, hotkey: ...)`.
+
+- [ ] **Step 6.6: Verify build (with a stubbed service)**
+
+`DisplayBrightnessService.shared.bump(...)` is not yet defined. Add a temporary stub at the bottom of `PanelStore.swift` (will be replaced when Task 11 lands the real service):
+
+Open `Sources/AnyDoor/Services/PanelStore.swift` and append at end-of-file (BEFORE the final closing brace if any — append after the last closing brace of the class):
+
+```swift
+// MARK: - Temporary stub until DisplayBrightnessService lands (Task 11)
+// This stub keeps the build green during incremental implementation.
+// DELETE THIS BLOCK in Task 11 when the real service is added.
+@MainActor
+enum DisplayBrightnessService {
+    static let shared = Self.self
+    enum BumpTarget { case displayUnderMouse }
+    static func bump(_ delta: Float, target: BumpTarget) { _ = (delta, target) }
+}
+```
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/PanelStore.swift
+git commit -m "feat(brightness): PanelStore dispatches hidden-hotkey brightness actions"
+```
+
+---
+
+## Task 7 — `DDCBackend` protocol + `MockDDCBackend`
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/DDCBackend.swift`
+
+- [ ] **Step 7.1: Create the directory**
+
+```bash
+mkdir -p Sources/AnyDoor/Services/Brightness
+```
+
+- [ ] **Step 7.2: Write the protocol + mock**
+
+Create `Sources/AnyDoor/Services/Brightness/DDCBackend.swift`:
+
+```swift
+import Foundation
+import CoreGraphics
+
+/// Abstract DDC/CI transport. Two production implementations exist
+/// (`IntelDDCBackend` and `Arm64DDCBackend`), selected per slice via
+/// `#if arch(arm64)` in the wiring code. `MockDDCBackend` is used by tests.
+protocol DDCBackend: Sendable {
+    /// Fast, side-effect-free check: is the I2C / IOAVService transport
+    /// reachable for this display? Does NOT issue a VCP read.
+    func transportReady(displayID: CGDirectDisplayID) -> Bool
+
+    /// Issue a VCP read. Returns nil on timeout / NACK / unsupported VCP.
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16?
+
+    /// Issue a VCP write. Throws on I/O failure.
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws
+}
+
+/// In-memory mock for unit tests. Scripted return values + recording of calls.
+final class MockDDCBackend: DDCBackend, @unchecked Sendable {
+    struct ReadCall: Equatable { let displayID: CGDirectDisplayID; let vcp: UInt8 }
+    struct WriteCall: Equatable { let displayID: CGDirectDisplayID; let vcp: UInt8; let value: UInt16 }
+
+    private let lock = NSLock()
+    private var _transportSupported: Set<CGDirectDisplayID>
+    private var _readResults: [CGDirectDisplayID: UInt16?]
+    private var _writeError: Error?
+    private(set) var readCalls: [ReadCall] = []
+    private(set) var writeCalls: [WriteCall] = []
+
+    init(transportSupported: Set<CGDirectDisplayID> = [],
+         readResults: [CGDirectDisplayID: UInt16?] = [:],
+         writeError: Error? = nil) {
+        self._transportSupported = transportSupported
+        self._readResults = readResults
+        self._writeError = writeError
+    }
+
+    func setReadResult(_ value: UInt16?, for displayID: CGDirectDisplayID) {
+        lock.lock(); defer { lock.unlock() }
+        _readResults[displayID] = value
+    }
+
+    func setWriteError(_ error: Error?) {
+        lock.lock(); defer { lock.unlock() }
+        _writeError = error
+    }
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _transportSupported.contains(displayID)
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        lock.lock()
+        readCalls.append(ReadCall(displayID: displayID, vcp: vcp))
+        let result = _readResults[displayID] ?? nil
+        lock.unlock()
+        return result
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        lock.lock()
+        writeCalls.append(WriteCall(displayID: displayID, vcp: vcp, value: value))
+        let err = _writeError
+        lock.unlock()
+        if let err { throw err }
+    }
+}
+```
+
+- [ ] **Step 7.3: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/DDCBackend.swift
+git commit -m "feat(brightness): add DDCBackend protocol and MockDDCBackend"
+```
+
+---
+
+## Task 8 — `Arm64DDCBackend` (clean-room IOAVService)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift`
+
+This file is `#if arch(arm64)`-gated. All API surface comes from publicly documented IOKit calls plus three private symbols (`IOAVServiceCreate`, `IOAVServiceReadI2C`, `IOAVServiceWriteI2C`) accessed via `@_silgen_name`. No MonitorControl GPL code is copied.
+
+- [ ] **Step 8.1: Create the file**
+
+Create `Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift`:
+
+```swift
+#if arch(arm64)
+import Foundation
+import IOKit
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "ddc.arm64")
+
+// MARK: - Private IOAVService symbol declarations
+//
+// These three symbols live in CoreDisplay/IOKit's private surface. Function
+// signatures are not copyrightable; the calling convention is documented in
+// public Apple sample code (AVCustomEdit, AVScreenShack) and in Apple's
+// open-source IOAVService headers shipped historically with xnu.
+
+@_silgen_name("IOAVServiceCreate")
+private func IOAVServiceCreate(_ allocator: CFAllocator?) -> Unmanaged<AnyObject>?
+
+@_silgen_name("IOAVServiceCreateWithService")
+private func IOAVServiceCreateWithService(
+    _ allocator: CFAllocator?,
+    _ service: io_service_t
+) -> Unmanaged<AnyObject>?
+
+@_silgen_name("IOAVServiceReadI2C")
+private func IOAVServiceReadI2C(
+    _ service: AnyObject,
+    _ chipAddress: UInt32,
+    _ offset: UInt32,
+    _ buffer: UnsafeMutableRawPointer,
+    _ length: UInt32
+) -> IOReturn
+
+@_silgen_name("IOAVServiceWriteI2C")
+private func IOAVServiceWriteI2C(
+    _ service: AnyObject,
+    _ chipAddress: UInt32,
+    _ offset: UInt32,
+    _ buffer: UnsafeRawPointer,
+    _ length: UInt32
+) -> IOReturn
+
+// MARK: - Backend
+
+struct Arm64DDCBackend: DDCBackend {
+    /// Per-process cache: displayID -> IOAVService object. Invalidated by
+    /// the caller (DisplayBrightnessService) on screen-change notifications.
+    private static let cache = AVServiceCache()
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        return Self.cache.service(for: displayID) != nil
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        guard let service = Self.cache.service(for: displayID) else { return nil }
+        return await Task.detached(priority: .userInitiated) { () -> UInt16? in
+            // DDC read request packet: [src=0x51, len=0x82, op=0x01, vcp, chksum]
+            // followed by a separate read of the 11-byte reply.
+            var request: [UInt8] = [0x51, 0x82, 0x01, vcp]
+            request.append(checksum(destination: 0x6E, bytes: request))
+
+            let writeResult = request.withUnsafeBufferPointer { buf -> IOReturn in
+                IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard writeResult == KERN_SUCCESS else { return nil }
+
+            // Per DDC/CI: the source must wait at least 40 ms before reading the reply.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+
+            var reply = [UInt8](repeating: 0, count: 11)
+            let readResult = reply.withUnsafeMutableBufferPointer { buf -> IOReturn in
+                IOAVServiceReadI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard readResult == KERN_SUCCESS, reply[0] == 0x6E, reply[1] == 0x88,
+                  reply[2] == 0x02, reply[3] == 0x00, reply[4] == vcp else {
+                return nil
+            }
+            let current = (UInt16(reply[8]) << 8) | UInt16(reply[9])
+            return current
+        }.value
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        guard let service = Self.cache.service(for: displayID) else {
+            throw NSError(domain: "Arm64DDC", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "transport not ready"])
+        }
+        try await Task.detached(priority: .userInitiated) {
+            // DDC write packet: [src=0x51, len=0x84, op=0x03, vcp, valHi, valLo, chksum]
+            var packet: [UInt8] = [0x51, 0x84, 0x03, vcp,
+                                   UInt8((value >> 8) & 0xFF),
+                                   UInt8(value & 0xFF)]
+            packet.append(checksum(destination: 0x6E, bytes: packet))
+
+            let result = packet.withUnsafeBufferPointer { buf -> IOReturn in
+                IOAVServiceWriteI2C(service, 0x37, 0x51, buf.baseAddress!, UInt32(buf.count))
+            }
+            guard result == KERN_SUCCESS else {
+                throw NSError(domain: "Arm64DDC", code: Int(result),
+                              userInfo: [NSLocalizedDescriptionKey: "I2C write failed"])
+            }
+        }.value
+    }
+}
+
+private func checksum(destination: UInt8, bytes: [UInt8]) -> UInt8 {
+    var sum = destination
+    for byte in bytes { sum ^= byte }
+    return sum
+}
+
+/// Per-displayID IOAVService lookup, cached for the process lifetime.
+/// Higher layers must drop entries on screen-change notifications.
+private final class AVServiceCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var map: [CGDirectDisplayID: AnyObject] = [:]
+
+    func service(for displayID: CGDirectDisplayID) -> AnyObject? {
+        lock.lock(); defer { lock.unlock() }
+        if let s = map[displayID] { return s }
+        guard let s = locateService(for: displayID) else { return nil }
+        map[displayID] = s
+        return s
+    }
+
+    func invalidate() {
+        lock.lock(); defer { lock.unlock() }
+        map.removeAll()
+    }
+
+    /// Walks IORegistry for IOAVService entries; matches by the IOAVService's
+    /// "VendorID" / "ProductID" / "AlphanumericSerialNumber" against
+    /// `CGDisplayVendorNumber` / `CGDisplayModelNumber` / `CGDisplaySerialNumber`.
+    private func locateService(for displayID: CGDirectDisplayID) -> AnyObject? {
+        let vendor = CGDisplayVendorNumber(displayID)
+        let model = CGDisplayModelNumber(displayID)
+        let serial = CGDisplaySerialNumber(displayID)
+        guard vendor != 0 || model != 0 else { return nil }
+
+        var iter: io_iterator_t = 0
+        let matching = IOServiceMatching("IOAVService")
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter) == KERN_SUCCESS else {
+            return nil
+        }
+        defer { IOObjectRelease(iter) }
+
+        var match: AnyObject?
+        while case let service = IOIteratorNext(iter), service != 0 {
+            defer { IOObjectRelease(service) }
+            guard let props = serviceProperties(service) else { continue }
+            let v = (props["VendorID"] as? UInt32) ?? 0
+            let m = (props["ProductID"] as? UInt32) ?? 0
+            let s = (props["AlphanumericSerialNumber"] as? String).flatMap(UInt32.init) ?? 0
+            if v == vendor && m == model && (serial == 0 || s == serial) {
+                if let av = IOAVServiceCreateWithService(kCFAllocatorDefault, service)?.takeRetainedValue() {
+                    match = av
+                    break
+                }
+            }
+        }
+        return match
+    }
+
+    private func serviceProperties(_ service: io_service_t) -> [String: Any]? {
+        var unmanaged: Unmanaged<CFMutableDictionary>?
+        let result = IORegistryEntryCreateCFProperties(service, &unmanaged, kCFAllocatorDefault, 0)
+        guard result == KERN_SUCCESS, let dict = unmanaged?.takeRetainedValue() else { return nil }
+        return dict as? [String: Any]
+    }
+}
+
+#endif
+```
+
+- [ ] **Step 8.2: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds on this Apple Silicon machine. The file is unused so far.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/Arm64DDCBackend.swift
+git commit -m "feat(brightness): clean-room Arm64DDCBackend via IOAVService"
+```
+
+> **Note for QA:** matching displays to `IOAVService` entries is approximation-based; some monitors expose `VendorID` 0 or share `ProductID`. If a real-world display fails to match, fall back to walking by display index. Defer this hardening until QA flags a specific monitor.
+
+---
+
+## Task 9 — `IntelDDCBackend` (wraps DDC.swift)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift`
+
+- [ ] **Step 9.1: Create the file**
+
+Create `Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift`:
+
+```swift
+#if !arch(arm64)
+import Foundation
+import CoreGraphics
+import DDC
+
+struct IntelDDCBackend: DDCBackend {
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        return DDC(for: displayID) != nil
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
+        await Task.detached(priority: .userInitiated) {
+            guard let ddc = DDC(for: displayID) else { return UInt16?.none }
+            guard let result = ddc.read(command: DDC.Command(rawValue: vcp) ?? .brightness) else {
+                return nil
+            }
+            return UInt16(result.current)
+        }.value
+    }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            guard let ddc = DDC(for: displayID) else {
+                throw NSError(domain: "IntelDDC", code: -1,
+                              userInfo: [NSLocalizedDescriptionKey: "DDC unavailable"])
+            }
+            let ok = ddc.write(command: DDC.Command(rawValue: vcp) ?? .brightness,
+                                value: value)
+            if !ok {
+                throw NSError(domain: "IntelDDC", code: -2,
+                              userInfo: [NSLocalizedDescriptionKey: "DDC write failed"])
+            }
+        }.value
+    }
+}
+#endif
+```
+
+> **API note:** If the actual DDC.swift API differs from `DDC(for:)` / `.read(command:)` / `.write(command:value:)`, adjust to match. Look at `swift package describe` or open `~/.swiftpm/...` checkout for the real signatures. The wrapper boundary is small so updates are localized.
+
+- [ ] **Step 9.2: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds (file is wrapped in `#if !arch(arm64)` so on Apple Silicon it is empty; the SPM dependency still resolves).
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift
+git commit -m "feat(brightness): IntelDDCBackend wrapping DDC.swift"
+```
+
+---
+
+## Task 10 — `BrightnessController` actor
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/BrightnessController.swift`
+- Create: `Tests/AnyDoorTests/BrightnessControllerTests.swift`
+
+- [ ] **Step 10.1: Write the failing tests**
+
+Create `Tests/AnyDoorTests/BrightnessControllerTests.swift`:
+
+```swift
+import XCTest
+import CoreGraphics
+@testable import AnyDoor
+
+final class BrightnessControllerTests: XCTestCase {
+    func testProbeReturnsTrueWhenTransportReady() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let result = await controller.probe(displayID: displayID)
+        XCTAssertTrue(result)
+    }
+
+    func testProbeReturnsFalseWhenTransportMissing() async {
+        let backend = MockDDCBackend(transportSupported: [])
+        let controller = BrightnessController(backend: backend)
+        let result = await controller.probe(displayID: 1)
+        XCTAssertFalse(result)
+    }
+
+    func testReadNormalizesToZeroOne() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: 50])
+        let controller = BrightnessController(backend: backend)
+        let value = await controller.read(displayID: displayID)
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value!, 0.5, accuracy: 0.01)
+    }
+
+    func testReadReturnsNilOnBackendNil() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: nil])
+        let controller = BrightnessController(backend: backend)
+        let value = await controller.read(displayID: displayID)
+        XCTAssertNil(value)
+    }
+
+    func testWriteRetriesOnceOnFailure() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = FlakyBackend(failuresBeforeSuccess: 1, supports: [displayID])
+        let controller = BrightnessController(backend: backend)
+        try? await controller.write(displayID: displayID, value: 0.75)
+        XCTAssertEqual(backend.writeCount, 2)
+    }
+
+    func testWriteThrowsAfterTwoFailures() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = FlakyBackend(failuresBeforeSuccess: .max, supports: [displayID])
+        let controller = BrightnessController(backend: backend)
+        do {
+            try await controller.write(displayID: displayID, value: 0.5)
+            XCTFail("expected throw")
+        } catch {
+            XCTAssertEqual(backend.writeCount, 2)
+        }
+    }
+}
+
+private final class FlakyBackend: DDCBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var remainingFailures: Int
+    private let _supports: Set<CGDirectDisplayID>
+    private(set) var writeCount = 0
+
+    init(failuresBeforeSuccess: Int, supports: Set<CGDirectDisplayID>) {
+        self.remainingFailures = failuresBeforeSuccess
+        self._supports = supports
+    }
+
+    func transportReady(displayID: CGDirectDisplayID) -> Bool {
+        _supports.contains(displayID)
+    }
+
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? { nil }
+
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
+        lock.lock()
+        writeCount += 1
+        let shouldFail = remainingFailures > 0
+        if shouldFail { remainingFailures -= 1 }
+        lock.unlock()
+        if shouldFail {
+            throw NSError(domain: "flaky", code: 1)
+        }
+    }
+}
+```
+
+- [ ] **Step 10.2: Run tests; verify they fail**
+
+```bash
+swift test --filter BrightnessControllerTests 2>&1 | tail -10
+```
+
+Expected: compile errors ("cannot find 'BrightnessController' in scope").
+
+- [ ] **Step 10.3: Implement `BrightnessController`**
+
+Create `Sources/AnyDoor/Services/Brightness/BrightnessController.swift`:
+
+```swift
+import Foundation
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "brightness.controller")
+
+/// Serialises VCP 0x10 I/O for one or more displays. One write retry on failure.
+/// Read/write timeouts handled by the underlying backend.
+///
+/// Always operates on VCP 0x10 (brightness). Values are normalised to 0.0...1.0
+/// on the public API; internally converted to the DDC byte range 0...100.
+actor BrightnessController {
+    enum Failure: Error { case transportUnavailable, writeFailed }
+
+    private let backend: DDCBackend
+    private static let vcpBrightness: UInt8 = 0x10
+    /// DDC standard: brightness max value byte for VCP 0x10 on essentially every
+    /// monitor. A VCP-max handshake is deferred (see spec § "Out-of-scope failure modes").
+    private static let maxValue: UInt16 = 100
+
+    init(backend: DDCBackend) {
+        self.backend = backend
+    }
+
+    /// Transport probe — fast, no VCP query. Returns true iff the backend reports
+    /// the display reachable. A subsequent read or write may still time out.
+    func probe(displayID: CGDirectDisplayID) async -> Bool {
+        return backend.transportReady(displayID: displayID)
+    }
+
+    /// Reads current brightness, normalised 0.0...1.0; nil on backend nil.
+    func read(displayID: CGDirectDisplayID) async -> Float? {
+        guard let raw = await backend.read(displayID: displayID, vcp: Self.vcpBrightness) else {
+            return nil
+        }
+        return Float(min(raw, Self.maxValue)) / Float(Self.maxValue)
+    }
+
+    /// Writes brightness (0.0...1.0). Throws `Failure.writeFailed` after exactly
+    /// one retry on transient failure.
+    func write(displayID: CGDirectDisplayID, value: Float) async throws {
+        let clamped = max(0, min(1, value))
+        let raw = UInt16((clamped * Float(Self.maxValue)).rounded())
+        do {
+            try await backend.write(displayID: displayID, vcp: Self.vcpBrightness, value: raw)
+        } catch {
+            logger.debug("DDC write retry for display \(displayID, privacy: .public)")
+            do {
+                try await backend.write(displayID: displayID, vcp: Self.vcpBrightness, value: raw)
+            } catch {
+                throw Failure.writeFailed
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 10.4: Run tests**
+
+```bash
+swift test --filter BrightnessControllerTests 2>&1 | tail -15
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/BrightnessController.swift Tests/AnyDoorTests/BrightnessControllerTests.swift
+git commit -m "feat(brightness): BrightnessController actor with retry semantics"
+```
+
+---
+
+## Task 11 — `DisplayBrightnessService` (replaces the stub from Task 6)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift`
+- Create: `Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift`
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift` (remove Task 6 stub)
+
+- [ ] **Step 11.1: Write the failing tests**
+
+Create `Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift`:
+
+```swift
+import XCTest
+import CoreGraphics
+@testable import AnyDoor
+
+@MainActor
+final class DisplayBrightnessServiceTests: XCTestCase {
+    func testSetBrightnessUpdatesLevelsImmediately() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setBrightness(0.42, for: displayID)
+        XCTAssertEqual(service.levels[displayID], 0.42)
+    }
+
+    func testSetBrightnessDebouncesWrites() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setBrightness(0.1, for: displayID)
+        service.setBrightness(0.2, for: displayID)
+        service.setBrightness(0.3, for: displayID)
+        // wait for debounce window (30 ms) + execution slack
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(backend.writeCalls.count, 1, "expected one consolidated write")
+        XCTAssertEqual(backend.writeCalls.last?.value, 30) // 0.3 * 100
+    }
+
+    func testBumpUsesFallbackBaselineWhenNil() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        // levels[displayID] starts nil → bump uses 0.5 + 0.0625 = 0.5625
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 0.5625, accuracy: 0.001)
+    }
+
+    func testBumpClampsToZeroOne() async {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID])
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        service.setLevelForTesting(0.95, for: displayID)
+        service.bumpForTesting(+0.5, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 1.0, accuracy: 0.001)
+
+        service.setLevelForTesting(0.05, for: displayID)
+        service.bumpForTesting(-0.5, displayID: displayID)
+        XCTAssertEqual(service.levels[displayID]!, 0.0, accuracy: 0.001)
+    }
+
+    func testGenerationTokenInvalidatesBackfill() async throws {
+        let displayID: CGDirectDisplayID = 1
+        let backend = MockDDCBackend(transportSupported: [displayID],
+                                     readResults: [displayID: 80])  // real device value
+        let controller = BrightnessController(backend: backend)
+        let service = DisplayBrightnessService()
+        service.bootstrap(controller: controller)
+        service.injectDisplaysForTesting([
+            DisplayInfo(id: displayID, name: "Test", supportsDDC: true)
+        ])
+
+        // levels[id] nil → triggers backfill after write
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        let immediate = service.levels[displayID]
+        XCTAssertEqual(immediate!, 0.5625, accuracy: 0.001)
+
+        // Before backfill completes, user nudges again → generation bumps,
+        // backfill must not clobber.
+        service.bumpForTesting(+0.0625, displayID: displayID)
+        let post = service.levels[displayID]
+        XCTAssertEqual(post!, 0.625, accuracy: 0.001)
+
+        // Give the backfill ample time to (incorrectly) overwrite.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Generation guard wins → still 0.625, NOT 0.8 (backfill discarded).
+        XCTAssertEqual(service.levels[displayID]!, 0.625, accuracy: 0.001)
+    }
+}
+```
+
+- [ ] **Step 11.2: Run tests; verify they fail**
+
+```bash
+swift test --filter DisplayBrightnessServiceTests 2>&1 | tail -15
+```
+
+Expected: compile errors.
+
+- [ ] **Step 11.3: Remove the Task 6 stub from PanelStore.swift**
+
+Delete the block at the bottom of `Sources/AnyDoor/Services/PanelStore.swift` that begins with `// MARK: - Temporary stub until DisplayBrightnessService lands (Task 11)`.
+
+- [ ] **Step 11.4: Implement the service**
+
+Create `Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift`:
+
+```swift
+import Foundation
+import AppKit
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "brightness.service")
+
+struct DisplayInfo: Identifiable, Hashable, Sendable {
+    let id: CGDirectDisplayID
+    let name: String
+    let supportsDDC: Bool
+}
+
+@MainActor
+@Observable
+final class DisplayBrightnessService {
+    static let shared = DisplayBrightnessService()
+
+    private(set) var displays: [DisplayInfo] = []
+    private(set) var levels: [CGDirectDisplayID: Float] = [:]
+    private(set) var isLoading: Set<CGDirectDisplayID> = []
+
+    /// Monotonic counter per display, incremented on every level mutation.
+    /// Used by deferred backfill reads to drop themselves when a newer user
+    /// action has superseded them.
+    private var levelGeneration: [CGDirectDisplayID: UInt64] = [:]
+
+    private var controller: BrightnessController?
+    private var screenChangeObserver: NSObjectProtocol?
+    private var pendingWrites: [CGDirectDisplayID: Task<Void, Never>] = [:]
+    private static let writeDebounceNanos: UInt64 = 30_000_000   // 30 ms
+
+    enum BumpTarget: Sendable { case displayUnderMouse }
+
+    init() {}
+
+    func bootstrap(controller: BrightnessController) {
+        self.controller = controller
+        installScreenObserver()
+    }
+
+    private func installScreenObserver() {
+        if let observer = screenChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor [weak self] in await self?.refresh() }
+        }
+    }
+
+    /// Re-enumerate NSScreen.screens; probe + read every external display.
+    func refresh() async {
+        guard let controller else { return }
+
+        let externalIDs = Self.externalDisplayIDs()
+        var newDisplays: [DisplayInfo] = []
+        var rawNames: [(CGDirectDisplayID, String)] = []
+
+        for id in externalIDs {
+            let baseName = Self.localizedName(for: id) ?? "Display \(id)"
+            rawNames.append((id, baseName))
+        }
+
+        let dedupedNames = Self.dedupedNames(rawNames)
+
+        for (id, name) in zip(externalIDs, dedupedNames) {
+            isLoading.insert(id)
+            let supports = await controller.probe(displayID: id)
+            newDisplays.append(DisplayInfo(id: id, name: name, supportsDDC: supports))
+            if supports {
+                if let value = await controller.read(displayID: id) {
+                    levels[id] = value
+                }
+            }
+            isLoading.remove(id)
+        }
+
+        // Drop entries for unplugged displays.
+        let present = Set(newDisplays.map(\.id))
+        for stale in levels.keys where !present.contains(stale) { levels.removeValue(forKey: stale) }
+
+        displays = newDisplays
+    }
+
+    /// Slider drag entry. Updates UI immediately; debounces DDC write.
+    func setBrightness(_ value: Float, for displayID: CGDirectDisplayID) {
+        guard let controller else { return }
+        let clamped = max(0, min(1, value))
+        levels[displayID] = clamped
+        bumpGeneration(displayID)
+        pendingWrites[displayID]?.cancel()
+        pendingWrites[displayID] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.writeDebounceNanos)
+            if Task.isCancelled { return }
+            try? await controller.write(displayID: displayID, value: clamped)
+            await MainActor.run { [weak self] in
+                self?.pendingWrites[displayID] = nil
+            }
+        }
+    }
+
+    /// Hotkey bump entry.
+    func bump(_ delta: Float, target: BumpTarget) {
+        guard let displayID = resolveTarget(target) else { return }
+        bumpInternal(delta, displayID: displayID, showOSD: true)
+    }
+
+    // MARK: - Internal (also reused by test seams)
+
+    fileprivate func bumpInternal(_ delta: Float, displayID: CGDirectDisplayID, showOSD: Bool) {
+        guard let controller else { return }
+        let usedFallback = (levels[displayID] == nil)
+        let baseline = levels[displayID] ?? 0.5
+        let newValue = max(0, min(1, baseline + delta))
+        bumpGeneration(displayID)
+        let gen = levelGeneration[displayID] ?? 0
+        levels[displayID] = newValue
+
+        if showOSD {
+            OSDBridge.showBrightness(newValue, on: displayID)
+        }
+
+        // Task started from a @MainActor method in Swift 6 inherits MainActor
+        // isolation. The actor `await controller.write/read` hops away and back
+        // automatically, so direct `self.levelGeneration[...]` checks are
+        // MainActor-safe without explicit MainActor.run wrappers.
+        Task { [weak self] in
+            do {
+                try await controller.write(displayID: displayID, value: newValue)
+            } catch {
+                return
+            }
+            guard let self else { return }
+            guard usedFallback else { return }
+            guard self.levelGeneration[displayID] == gen else { return }
+            guard let real = await controller.read(displayID: displayID) else { return }
+            guard self.levelGeneration[displayID] == gen else { return }
+            self.levels[displayID] = real
+        }
+    }
+
+    private func bumpGeneration(_ id: CGDirectDisplayID) {
+        levelGeneration[id, default: 0] &+= 1
+    }
+
+    private func resolveTarget(_ target: BumpTarget) -> CGDirectDisplayID? {
+        switch target {
+        case .displayUnderMouse:
+            return Self.displayUnderMouse(displays: displays) ?? Self.mainDisplayIfSupported(displays: displays)
+        }
+    }
+
+    // MARK: - Static helpers (pure functions, no MainActor state)
+
+    private static func externalDisplayIDs() -> [CGDirectDisplayID] {
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        return ids.filter { CGDisplayIsBuiltin($0) == 0 }
+    }
+
+    private static func localizedName(for displayID: CGDirectDisplayID) -> String? {
+        // CoreDisplay_DisplayCreateInfoDictionary is private; the lazy path is
+        // NSScreen's localizedName from macOS 11+. Match the display via
+        // NSScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")].
+        for screen in NSScreen.screens {
+            let key = NSDeviceDescriptionKey("NSScreenNumber")
+            if let number = screen.deviceDescription[key] as? NSNumber,
+               number.uint32Value == displayID {
+                return screen.localizedName
+            }
+        }
+        return nil
+    }
+
+    fileprivate static func dedupedNames(_ pairs: [(CGDirectDisplayID, String)]) -> [String] {
+        var counts: [String: Int] = [:]
+        // Stable: first occurrence keeps the bare name, subsequent get " (n)".
+        let sorted = pairs.sorted { $0.0 < $1.0 }
+        var result = Array(repeating: "", count: pairs.count)
+        var assigned: [CGDirectDisplayID: String] = [:]
+        for (id, name) in sorted {
+            let n = counts[name] ?? 0
+            assigned[id] = (n == 0) ? name : "\(name) (\(n))"
+            counts[name] = n + 1
+        }
+        for (i, pair) in pairs.enumerated() { result[i] = assigned[pair.0] ?? pair.1 }
+        return result
+    }
+
+    private static func displayUnderMouse(displays: [DisplayInfo]) -> CGDirectDisplayID? {
+        let mouse = NSEvent.mouseLocation
+        for screen in NSScreen.screens where screen.frame.contains(mouse) {
+            let key = NSDeviceDescriptionKey("NSScreenNumber")
+            if let number = screen.deviceDescription[key] as? NSNumber {
+                let id = number.uint32Value
+                if displays.contains(where: { $0.id == id && $0.supportsDDC }) { return id }
+            }
+        }
+        return nil
+    }
+
+    private static func mainDisplayIfSupported(displays: [DisplayInfo]) -> CGDirectDisplayID? {
+        let id = CGMainDisplayID()
+        return displays.contains(where: { $0.id == id && $0.supportsDDC }) ? id : nil
+    }
+}
+
+// MARK: - Test seams (XCTest @testable import)
+
+extension DisplayBrightnessService {
+    func injectDisplaysForTesting(_ d: [DisplayInfo]) { self.displays = d }
+    func setLevelForTesting(_ v: Float, for id: CGDirectDisplayID) { levels[id] = v }
+    func bumpForTesting(_ delta: Float, displayID: CGDirectDisplayID) {
+        bumpInternal(delta, displayID: displayID, showOSD: false)
+    }
+}
+```
+
+- [ ] **Step 11.5: Run tests**
+
+```bash
+swift test --filter DisplayBrightnessServiceTests 2>&1 | tail -15
+```
+
+Expected: all 5 tests pass. `swift build` also passes.
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/DisplayBrightnessService.swift \
+        Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift \
+        Sources/AnyDoor/Services/PanelStore.swift
+git commit -m "feat(brightness): DisplayBrightnessService with debounce + generation token"
+```
+
+---
+
+## Task 12 — `OSDBridge`
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Brightness/OSDBridge.swift`
+
+- [ ] **Step 12.1: Implement the bridge**
+
+Create `Sources/AnyDoor/Services/Brightness/OSDBridge.swift`:
+
+```swift
+import Foundation
+import CoreGraphics
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "osd.bridge")
+
+/// Triggers macOS's native chiclet brightness OSD via the private
+/// `OSDManager.sharedManager()` API resident in `OSD.framework`.
+/// Best-effort; silent no-op on any failure path. Brightness still
+/// takes effect at the display via DDC regardless.
+enum OSDBridge {
+    private static let frameworkPath =
+        "/System/Library/PrivateFrameworks/OSD.framework/OSD"
+    private static let brightnessImageID: Int64 = 1   // OSDGraphic.brightness
+    private static let totalChiclets: UInt32 = 16
+    private static let msecUntilFade: UInt32 = 1500
+    private static let priority: UInt32 = 0x0
+
+    private static let loadedHandle: UnsafeMutableRawPointer? = {
+        dlopen(frameworkPath, RTLD_LAZY)
+    }()
+
+    static func showBrightness(_ value: Float, on displayID: CGDirectDisplayID) {
+        guard loadedHandle != nil else {
+            logger.debug("OSD.framework not loaded; skipping OSD")
+            return
+        }
+        guard let managerClass = NSClassFromString("OSDManager") as? NSObject.Type else {
+            logger.debug("OSDManager class not found; skipping OSD")
+            return
+        }
+        let manager = managerClass.perform(NSSelectorFromString("sharedManager"))?
+            .takeUnretainedValue()
+        guard let manager = manager as? NSObject else {
+            logger.debug("OSDManager.sharedManager returned nil; skipping OSD")
+            return
+        }
+        let selector = NSSelectorFromString(
+            "showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:"
+        )
+        guard manager.responds(to: selector) else {
+            logger.debug("OSDManager does not respond to chiclet selector; skipping OSD")
+            return
+        }
+        let filled = UInt32((max(0, min(1, value)) * Float(totalChiclets)).rounded())
+
+        // Build an Obj-C invocation with the exact method signature so we can
+        // pass primitive (non-object) arguments.
+        let signature: NSMethodSignature? = manager.method(for: selector).flatMap { _ in
+            (manager as AnyObject).methodSignature(for: selector)
+        }
+        guard let signature else {
+            logger.debug("OSDManager method signature missing; skipping OSD")
+            return
+        }
+        let invocation = NSInvocation.invocation(with: signature)
+        invocation.target = manager
+        invocation.selector = selector
+        var image: Int64 = brightnessImageID
+        var did: UInt32 = displayID
+        var prio: UInt32 = priority
+        var fade: UInt32 = msecUntilFade
+        var f: UInt32 = filled
+        var t: UInt32 = totalChiclets
+        var locked: ObjCBool = false
+        invocation.setArgument(&image, at: 2)
+        invocation.setArgument(&did, at: 3)
+        invocation.setArgument(&prio, at: 4)
+        invocation.setArgument(&fade, at: 5)
+        invocation.setArgument(&f, at: 6)
+        invocation.setArgument(&t, at: 7)
+        invocation.setArgument(&locked, at: 8)
+        invocation.invoke()
+    }
+}
+
+// MARK: - NSInvocation Swift-friendly bridge
+
+private extension NSObject {
+    @objc func methodSignature(for selector: Selector) -> NSMethodSignature? {
+        let cls: AnyClass = type(of: self)
+        return cls.instanceMethodSignature(for: selector)
+    }
+}
+
+private extension AnyClass {
+    static func instanceMethodSignature(for selector: Selector) -> NSMethodSignature? {
+        // NSObject conforms; method_getTypeEncoding on the IMP yields the signature.
+        guard let method = class_getInstanceMethod(self, selector),
+              let encoding = method_getTypeEncoding(method) else { return nil }
+        return NSMethodSignature.signature(withObjCTypes: encoding)
+    }
+}
+
+private extension NSMethodSignature {
+    static func signature(withObjCTypes encoding: UnsafePointer<CChar>) -> NSMethodSignature? {
+        // The +signatureWithObjCTypes: selector is non-public to Swift; access via
+        // performSelector on the metatype.
+        let sel = NSSelectorFromString("signatureWithObjCTypes:")
+        guard let meta = NSMethodSignature.self as AnyObject as? NSObjectProtocol,
+              meta.responds(to: sel) else { return nil }
+        let unmanaged = meta.perform(sel, with: encoding)
+        return unmanaged?.takeUnretainedValue() as? NSMethodSignature
+    }
+}
+
+private extension NSInvocation {
+    static func invocation(with signature: NSMethodSignature) -> NSInvocation {
+        let sel = NSSelectorFromString("invocationWithMethodSignature:")
+        let cls: AnyClass = NSInvocation.self as AnyClass
+        let meta: AnyObject = cls
+        return (meta as AnyObject).perform(sel, with: signature)!
+            .takeUnretainedValue() as! NSInvocation
+    }
+}
+```
+
+> **Note on Swift+NSInvocation:** Swift does not expose `NSInvocation` directly, but the runtime is reachable via `NSSelectorFromString` + `perform`. The boilerplate above is one-time and isolated to this file. If a future macOS removes any of these private classes / selectors, the failure mode is silent no-op (graceful degradation).
+
+- [ ] **Step 12.2: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Brightness/OSDBridge.swift
+git commit -m "feat(brightness): OSDBridge wrapping private OSD.framework"
+```
+
+---
+
+## Task 13 — `BrightnessPopoverView` + `DisplayBrightnessCard`
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/BrightnessPopoverView.swift`
+
+- [ ] **Step 13.1: Implement the views**
+
+Create `Sources/AnyDoor/Views/BrightnessPopoverView.swift`:
+
+```swift
+import SwiftUI
+import CoreGraphics
+
+struct BrightnessPopoverView: View {
+    @State private var service = DisplayBrightnessService.shared
+    var onHoverChange: (Bool) -> Void = { _ in }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if service.displays.isEmpty {
+                emptyState(text: "未检测到外置显示器", symbol: "display")
+            } else if service.displays.allSatisfy({ !$0.supportsDDC }) {
+                VStack(alignment: .leading, spacing: 4) {
+                    emptyState(text: "未检测到支持 DDC 的外置显示器", symbol: "display.slash")
+                    Text("DisplayPort/HDMI 通常可用，部分 USB-C 转接线不支持")
+                        .font(.caption2).foregroundStyle(.tertiary)
+                }
+            } else {
+                ForEach(service.displays) { info in
+                    DisplayBrightnessCard(info: info, service: service)
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 320)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .onAppear {
+            Task { await service.refresh() }
+        }
+        .onHover { onHoverChange($0) }
+    }
+
+    private func emptyState(text: String, symbol: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol).foregroundStyle(.secondary)
+            Text(text).font(.callout).foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct DisplayBrightnessCard: View {
+    let info: DisplayInfo
+    @Bindable var service: DisplayBrightnessService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(info.name).font(.headline)
+                if !info.supportsDDC {
+                    Text("不支持 DDC")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                if service.isLoading.contains(info.id) {
+                    ProgressView().controlSize(.mini)
+                }
+            }
+            HStack(spacing: 8) {
+                Image(systemName: "sun.max.fill").foregroundStyle(.secondary)
+                Slider(
+                    value: Binding(
+                        get: { Double(service.levels[info.id] ?? 0.5) },
+                        set: { service.setBrightness(Float($0), for: info.id) }
+                    ),
+                    in: 0...1
+                )
+                .controlSize(.large)
+                .disabled(!info.supportsDDC)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .opacity(info.supportsDDC ? 1.0 : 0.55)
+    }
+}
+```
+
+- [ ] **Step 13.2: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/BrightnessPopoverView.swift
+git commit -m "feat(brightness): BrightnessPopoverView and DisplayBrightnessCard"
+```
+
+---
+
+## Task 14 — Wire the popover into `MenuBarView`
+
+**Files:**
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift:10-13` (HoverPopoverTarget)
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift:115-172` (rowView)
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift:215-290` (mountPopoverContent)
+
+- [ ] **Step 14.1: Extend `HoverPopoverTarget`**
+
+Replace the enum at lines 10-13 with:
+
+```swift
+private enum HoverPopoverTarget: Hashable {
+    case submenu(BuiltinItem)
+    case history(ClipboardHistoryKind)
+    case brightnessControl(BuiltinItem)
+}
+```
+
+- [ ] **Step 14.2: Register the trigger in `rowView`**
+
+In the `rowView(for:)` function, locate the existing `if case let .builtin(item) = entry.source, item.kind == .submenu` branch (around line 117). After its closing brace and BEFORE the `} else if case let .builtin(item) = entry.source, item.kind == .action, ...` branch, add a new branch:
+
+```swift
+        } else if case let .builtin(item) = entry.source, item.kind == .brightnessControl {
+            let target = HoverPopoverTarget.brightnessControl(item)
+            PanelRowView(
+                entry: entry,
+                onToggle: {},
+                onAction: {},
+                onSubmenu: {},
+                onPermission: openPermissionsSettings
+            )
+            .background(
+                ScreenFrameReader { frame in
+                    triggerFrames[target] = frame
+                }
+            )
+            .onHover { hovered in
+                triggerHover(hovered, target: target)
+            }
+```
+
+- [ ] **Step 14.3: Add the `mountPopoverContent` branch**
+
+Inside `mountPopoverContent(for:)` (around line 215), add a new case **before** the `case .submenu:` fallthrough comment-case (line 256):
+
+```swift
+        case .brightnessControl:
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                BrightnessPopoverView(onHoverChange: { gate.popoverHover($0) })
+            }
+            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+```
+
+- [ ] **Step 14.4: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/MenuBarView.swift
+git commit -m "feat(brightness): wire brightness popover into MenuBarView hover routing"
+```
+
+---
+
+## Task 15 — Inline ± hotkey recorder under the brightness row in Panel Settings
+
+**Files:**
+- Modify: `Sources/AnyDoor/Services/PanelStore.swift` (add `hotkeyForBuiltin` helper)
+- Modify: `Sources/AnyDoor/Views/PanelSettingsView.swift:46-56` (row builder)
+
+- [ ] **Step 15.1: Add `hotkeyForBuiltin` to `PanelStore`**
+
+In `Sources/AnyDoor/Services/PanelStore.swift`, add a public helper near the other public helpers (after `binding(id:)` at line 233):
+
+```swift
+    /// Look up the current hotkey assigned to a built-in item, if any.
+    /// Reads from SwiftData rather than `topLevelEntries` so it works for
+    /// hidden-hotkey items (e.g., brightness ±).
+    func hotkeyForBuiltin(_ item: BuiltinItem) -> HotkeyDescriptor? {
+        guard let container = modelContainer else { return nil }
+        let key = item.rawValue
+        guard let pref = try? container.mainContext.fetch(
+            FetchDescriptor<BuiltinPreference>(predicate: #Predicate { $0.itemKey == key })
+        ).first,
+        let code = pref.keyCode, let mods = pref.modifierFlags else { return nil }
+        return HotkeyDescriptor(keyCode: code, modifierFlags: mods)
+    }
+```
+
+Build verification:
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: succeeds.
+
+- [ ] **Step 15.2: Add the inline expansion to `PanelSettingsView`**
+
+Replace the `row(for:)` method (lines 46-56) with:
+
+```swift
+    @ViewBuilder
+    private func row(for entry: PanelEntry) -> some View {
+        VStack(spacing: 0) {
+            mainRow(entry)
+            if case .builtin(.appShortcuts) = entry.source {
+                appShortcutChildren()
+                addAppButton()
+            }
+            if case .builtin(.brightness) = entry.source {
+                brightnessHotkeyRecorders()
+            }
+        }
+        .opacity(entry.isVisible ? 1.0 : 0.5)
+    }
+
+    @ViewBuilder
+    private func brightnessHotkeyRecorders() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            brightnessHotkeyRow(item: .brightnessUp, label: "亮度 +")
+            brightnessHotkeyRow(item: .brightnessDown, label: "亮度 −")
+        }
+        .padding(.leading, 36)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func brightnessHotkeyRow(item: BuiltinItem, label: String) -> some View {
+        HStack {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            HotkeyRecorder(hotkey: .constant(PanelStore.shared.hotkeyForBuiltin(item))) { newValue in
+                handleBrightnessHotkeyChange(item: item, newValue: newValue)
+            }
+            .frame(width: 150, alignment: .trailing)
+        }
+    }
+
+    private func handleBrightnessHotkeyChange(item: BuiltinItem, newValue: HotkeyDescriptor?) {
+        if let new = newValue,
+           let existing = PanelStore.shared.entryUsingHotkey(new, excluding: .builtin(item)) {
+            conflictAlert = ConflictAlert(
+                hotkey: new,
+                existingTitle: existing.title,
+                onReplace: {
+                    if case let .builtin(other) = existing.source {
+                        PanelStore.shared.setBuiltinHotkey(other, hotkey: nil)
+                    } else if case let .appShortcut(id) = existing.source {
+                        PanelStore.shared.updateAppShortcut(id: id, hotkey: nil)
+                    }
+                    PanelStore.shared.setBuiltinHotkey(item, hotkey: new)
+                }
+            )
+        } else {
+            PanelStore.shared.setBuiltinHotkey(item, hotkey: newValue)
+        }
+    }
+```
+
+Build verification:
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: succeeds.
+
+- [ ] **Step 15.3: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/PanelSettingsView.swift Sources/AnyDoor/Services/PanelStore.swift
+git commit -m "feat(brightness): inline brightness +/- hotkey recorders in panel settings"
+```
+
+---
+
+## Task 16 — Bootstrap from `AppDelegate`
+
+**Files:**
+- Modify: `Sources/AnyDoor/AppDelegate.swift:75-101`
+
+- [ ] **Step 16.1: Build and bootstrap the service before HotkeyService.start()**
+
+In `Sources/AnyDoor/AppDelegate.swift`, after the line `PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)` (line 75) add:
+
+```swift
+        // Brightness control (external DDC/CI displays). Arch-selected backend.
+        #if arch(arm64)
+        let ddcBackend: any DDCBackend = Arm64DDCBackend()
+        #else
+        let ddcBackend: any DDCBackend = IntelDDCBackend()
+        #endif
+        let brightnessController = BrightnessController(backend: ddcBackend)
+        DisplayBrightnessService.shared.bootstrap(controller: brightnessController)
+
+        // Pre-warm the brightness service so the first hover finds data cached.
+        Task.detached(priority: .utility) {
+            await DisplayBrightnessService.shared.refresh()
+        }
+```
+
+- [ ] **Step 16.2: Build verification**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 16.3: Smoke run**
+
+```bash
+swift run 2>&1 | head -30 &
+RUNPID=$!
+sleep 5
+kill $RUNPID 2>/dev/null
+wait 2>/dev/null
+```
+
+Expected: app starts, no crash in the first 5 seconds. The menu-bar item appears in the system menu bar (visible during the 5s window). Hover over "屏幕亮度" to verify the popover renders. Manual verification only — automate nothing here.
+
+- [ ] **Step 16.4: Commit**
+
+```bash
+git add Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(brightness): bootstrap DisplayBrightnessService and pre-warm refresh"
+```
+
+---
+
+## Task 17 — README attribution
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+- [ ] **Step 17.1: Find the right section**
+
+Both README files likely have an "Acknowledgements" / "致谢" / "Built with" section. If not, create one at the end:
+
+In `README.md` (English):
+
+```markdown
+## Acknowledgements
+
+- [DDC.swift](https://github.com/reitermarkus/DDC.swift) (MIT) — DDC/CI
+  brightness control for external displays on Intel Macs.
+- [AskForPermission](https://github.com/riko2chen/AskForPermission) — macOS
+  accessibility permission helper.
+- [Sparkle](https://sparkle-project.org/) — application auto-update.
+```
+
+In `README.zh-CN.md` (Chinese):
+
+```markdown
+## 致谢
+
+- [DDC.swift](https://github.com/reitermarkus/DDC.swift) (MIT) — Intel Mac
+  上外置显示器的 DDC/CI 亮度控制。
+- [AskForPermission](https://github.com/riko2chen/AskForPermission) — macOS
+  辅助功能权限助手。
+- [Sparkle](https://sparkle-project.org/) — 应用自动更新。
+```
+
+If a section already exists, append the DDC.swift bullet only. Do not duplicate the AskForPermission or Sparkle entries.
+
+- [ ] **Step 17.2: Commit**
+
+```bash
+git add README.md README.zh-CN.md
+git commit -m "docs: credit DDC.swift in README acknowledgements"
+```
+
+---
+
+## Task 18 — Final verification
+
+**Files:** none
+
+- [ ] **Step 18.1: Full test suite**
+
+```bash
+swift test 2>&1 | tail -20
+```
+
+Expected: all tests pass. If any pre-existing test fails, investigate (do not paper over by editing the test).
+
+- [ ] **Step 18.2: Clean build**
+
+```bash
+swift build -c release 2>&1 | tail -10
+```
+
+Expected: succeeds.
+
+- [ ] **Step 18.3: Manual QA checklist (recorded only; pass/fail per item)**
+
+Record results in the PR description. Each item is a separate observable check:
+
+- [ ] Single supported external display: hover panel shows correct current brightness; drag slider updates display.
+- [ ] Display reporting no DDC: card visible, greyed, slider disabled.
+- [ ] Mixed (one supported, one not): per-card behaviour correct.
+- [ ] Hot-plug a display while popover is open: list updates within ~1 s.
+- [ ] Bind brightness ± hotkey in panel settings, conflict alert shows on collision.
+- [ ] Hotkey press: native chiclet OSD appears; brightness changes on the display under the mouse.
+- [ ] Hotkey press with cursor on built-in display: falls back to main external display.
+- [ ] Popover open + hotkey press: slider value updates live.
+- [ ] Restart AnyDoor: brightness on displays NOT overwritten (matches whatever the user / monitor was at).
+
+- [ ] **Step 18.4: Final commit (optional, only if QA reveals trivial fixes)**
+
+If QA pass requires any small fixes, batch them and commit:
+
+```bash
+git add .
+git commit -m "fix(brightness): QA round-1 polish"
+```

--- a/docs/superpowers/specs/2026-05-24-display-brightness-design.md
+++ b/docs/superpowers/specs/2026-05-24-display-brightness-design.md
@@ -182,19 +182,32 @@ built-in hotkeys. Modelling them as real `BuiltinItem` cases that flow
 through normal `BuiltinPreference` storage and snapshot rebuild keeps
 conflict detection honest.
 
+### Updates to existing exhaustive-switch consumers
+
+Adding new `Kind` cases breaks compile at every exhaustive switch on
+`BuiltinItem.Kind`. The full list of consumers (as of `seattle-v1` HEAD)
+and the required arm per site:
+
+| Site | Existing arms | Add for `.brightnessControl` | Add for `.hiddenHotkey` |
+|---|---|---|---|
+| `PanelRowView.swift:52` — `.onTapGesture` switch | `.toggle / .submenu / .action` | `case .brightnessControl: break` (intentional no-op) | `case .hiddenHotkey: break` (defensive; entry never reaches the row) |
+| `PanelRowView.swift:86` — `trailing` view switch | toggle shows switch; submenu shows chevron; action shows hotkey | `case .brightnessControl:` — show a small `chevron.right` chevron to advertise hover-popover affordance (same idiom as `.submenu`) | `case .hiddenHotkey: EmptyView()` (never rendered) |
+| `PanelSettingsView.swift:83` — `typeBadge` | `.toggle → "系统"`, `.action → "系统 · 动作"`, `.submenu → "系统 · 子菜单"` | `case .brightnessControl: return "系统 · 亮度"` | `case .hiddenHotkey: return "系统 · 全局动作"` (only shown if the row ever surfaces, which it doesn't in v1) |
+| `PanelSettingsView.swift:95` — `hotkeyField` row-level recorder gate | matches only `.submenu` → renders empty `Color.clear` | extend the guard: `if item.kind == .submenu || item.kind == .brightnessControl { Color.clear.frame(width: 150) }` — the brightness row gets its hotkey UI inline below (see "Settings (Panel tab)" section), NOT in the row's trailing column | extend the same guard to include `.hiddenHotkey` for symmetry, even though hidden rows aren't rendered |
+
+If any future switch on `Kind` is added, the same pattern applies; the
+compiler enforces it.
+
 ### Changes to `PanelStore`
 
 ```swift
-// PanelRowView click switch gains:
-case .brightnessControl: break              // intentional no-op
-// (.hiddenHotkey never reaches PanelRowView — it's filtered out of
-//  topLevelEntries during rebuild.)
-
 // rebuild(): when assembling topLevelEntries, skip items whose kind is
-// .hiddenHotkey. (They still own a BuiltinPreference row for hotkey storage.)
+// .hiddenHotkey. (They still own a BuiltinPreference row for hotkey storage,
+// but never appear in the menu bar list nor in PanelSettingsView's grid.)
 
 // entryUsingHotkey(_:excluding:): scan extended to include hidden-hotkey
-// entries:
+// entries so brightness ± conflicts with existing app / built-in hotkeys
+// are detected:
 let hiddenHotkeyEntries = BuiltinItem.allCases
     .filter { $0.kind == .hiddenHotkey }
     .compactMap { makeEntry(for: $0) }
@@ -214,13 +227,43 @@ table everything else uses; no special-case storage.
 
 `BuiltinPreference` already stores one hotkey per `BuiltinItem` raw value. The
 new cases `.brightnessUp` and `.brightnessDown` get their own
-`BuiltinPreference` rows, seeded by `BuiltinPreferenceSeeder`. They use
-`isVisible: false` (no panel row), but unlike the previous draft they are
-proper `BuiltinItem` cases, so `PanelStore` discovers them through
-`BuiltinItem.allCases`-based scans (see "Changes to `PanelStore`" above).
+`BuiltinPreference` rows, seeded by `BuiltinPreferenceSeeder`. They should
+have `isVisible: false` (they own only a hotkey, not a panel row), but
+unlike the previous draft they are proper `BuiltinItem` cases, so
+`PanelStore` discovers them through `BuiltinItem.allCases`-based scans
+(see "Changes to `PanelStore`" above).
+
+**Seeder change required**: `BuiltinPreferenceSeeder.swift:28` currently
+hardcodes `isVisible: true`. That has been correct so far because every
+existing BuiltinItem is meant to be visible by default. The new
+`.hiddenHotkey` kind breaks that assumption — if the seeder runs with the
+hardcoded value, the brightness ± rows are persisted with `isVisible: true`,
+which is data-semantics-incorrect even though `PanelStore.rebuild()` filters
+them out by kind.
+
+Fix: add a computed property on `BuiltinItem`:
+
+```swift
+extension BuiltinItem {
+    /// Whether this item should default to being shown in the menu bar
+    /// panel when first seeded. False only for hidden-hotkey items.
+    var defaultVisibility: Bool {
+        switch self.kind {
+        case .toggle, .action, .submenu, .brightnessControl: return true
+        case .hiddenHotkey:                                   return false
+        }
+    }
+}
+```
+
+`BuiltinPreferenceSeeder` then uses `item.defaultVisibility` instead of the
+literal `true`. This keeps the seeder a single code path and lets future
+hidden-hotkey-style items inherit the right default for free.
 
 The Panel Settings UI surfaces these two preferences inline under the
-"屏幕亮度" row using the existing `HotkeyRecorder` component.
+"屏幕亮度" row using the existing `HotkeyRecorder` component (writes go
+through a new `PanelStore.setBrightnessHotkey(direction:keyCode:modifierFlags:)`
+method that saves to SwiftData and calls `rebuildHotkeySnapshots()`).
 
 ### Runtime state (in-memory only)
 
@@ -236,6 +279,11 @@ final class DisplayBrightnessService {
     private(set) var displays: [DisplayInfo] = []
     private(set) var levels:   [CGDirectDisplayID: Float] = [:]   // 0...1
     private(set) var isLoading: Set<CGDirectDisplayID> = []
+
+    /// Monotonic counter per display, incremented on every level mutation
+    /// (setBrightness / bump). Used by deferred backfill reads to drop
+    /// themselves when a newer user action has superseded them.
+    private var levelGeneration: [CGDirectDisplayID: UInt64] = [:]
 }
 ```
 
@@ -339,19 +387,33 @@ final class DisplayBrightnessService {
 ```
 
 Behavioural rules:
-- `setBrightness` updates `levels[id]` synchronously; cancels any in-flight
-  write Task for that displayID; schedules a new Task that sleeps 30 ms and
-  then calls `controller.write`.
+- `setBrightness` increments `levelGeneration[id]`, updates `levels[id]`
+  synchronously, cancels any in-flight write Task for that displayID, and
+  schedules a new Task that sleeps 30 ms then calls `controller.write`.
+  (The generation bump also invalidates any pending backfill read from a
+  prior `bump` — see "Backfill read" below.)
 - `bump` resolves displayID via mouse cursor → falls back to
   `NSScreen.main` if cursor is over the built-in / unsupported display; if
   fallback is also unsupported, the bump is a no-op.
 - **Baseline when `levels[id] == nil`** (read previously timed out on a
   transport-ready display): `bump` treats the current level as `0.5` for
-  the purpose of `clamp(current + delta, 0...1)`. After the write is
-  scheduled, the service issues a fresh `controller.read` (best-effort) so
-  later nudges have a real baseline. Rationale: keeps hotkey UX snappy,
-  avoids ignoring user input; 6.25% nudge from a wrong baseline self-corrects
-  within ~4 keypresses.
+  the purpose of `clamp(current + delta, 0...1)`. Rationale: keeps hotkey
+  UX snappy, avoids ignoring user input; 6.25% nudge from a wrong baseline
+  self-corrects within ~4 keypresses.
+- **Backfill read after fallback bump** (replacing the naive Flow C step):
+  Only triggered when the bump used the `0.5` fallback. The backfill must
+  not race with the write nor clobber a fresher optimistic value. Rules:
+  1. Maintain `var levelGeneration: [CGDirectDisplayID: UInt64]` on the
+     service, incremented on every `setBrightness` / `bump` for a given id.
+  2. Capture `gen = levelGeneration[id]` at the moment of the bump.
+  3. Schedule the backfill as a continuation of the write Task, not in
+     parallel: `Task { try? await controller.write(id, newValue); if
+     levelGeneration[id] == gen, let real = await controller.read(id),
+     levelGeneration[id] == gen { levels[id] = real } }`. The double
+     generation check brackets the read so an intervening bump always
+     wins.
+  4. If `controller.write` throws, do not attempt the backfill (the
+     display is in an unknown state; next user action will set it).
 - **OSD timing**: `bump` fires `OSDBridge.showBrightness(newValue, on: id)`
   *optimistically*, immediately after spawning the write Task — not after
   the write resolves. Rationale: DDC writes can take 50-200 ms; deferring
@@ -464,14 +526,21 @@ notification has fired since, skip step 4.
 4. service:
    a. Resolve displayID via NSEvent.mouseLocation + NSScreen.screens;
       fallback NSScreen.main; bail if still unsupported.
-   b. baseline = levels[id] ?? 0.5     (see "Baseline when nil" above)
-   c. newValue = clamp(baseline + delta, 0...1)
-   d. levels[id] = newValue            (popover, if open, updates live)
-   e. Task { try await controller.write(id, newValue) }
-   f. OSDBridge.showBrightness(newValue, on: id)   (optimistic; pre-await)
-   g. If baseline came from the 0.5 fallback: Task {
-         if let real = await controller.read(id) { levels[id] = real }
-      }                                  (best-effort backfill for next bump)
+   b. usedFallback = (levels[id] == nil)
+   c. baseline = levels[id] ?? 0.5
+   d. newValue = clamp(baseline + delta, 0...1)
+   e. levelGeneration[id] &+= 1; let gen = levelGeneration[id]
+   f. levels[id] = newValue          (popover updates live if open)
+   g. OSDBridge.showBrightness(newValue, on: id)   (optimistic; pre-await)
+   h. Task {
+         do {
+            try await controller.write(id, newValue)
+         } catch { return }                       // no backfill on failure
+         guard usedFallback, levelGeneration[id] == gen else { return }
+         guard let real = await controller.read(id) else { return }
+         guard levelGeneration[id] == gen else { return }   // newer bump wins
+         levels[id] = real
+      }
 ```
 
 ### Flow D — Display hot-plug
@@ -587,7 +656,8 @@ Under the existing "屏幕亮度" row, a chevron-expandable inline section:
 | Module                          | Test focus                                                                                                              |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `BrightnessController`          | Inject `MockDDCBackend`; verify probe behaviour, read normalisation (0...100 → 0...1), write retry on failure, timeout. |
-| `DisplayBrightnessService`      | Inject mock controller; verify ① debounce only emits the final write per displayID; ② `bump` clamps to 0...1; ③ NSScreen notification rebuilds `displays`; ④ `displayUnderMouse` falls back to main screen when cursor is over an unsupported display. |
+| `DisplayBrightnessService`      | Inject mock controller; verify ① debounce only emits the final write per displayID; ② `bump` clamps to 0...1; ③ NSScreen notification rebuilds `displays`; ④ `displayUnderMouse` falls back to main screen when cursor is over an unsupported display; ⑤ nil-baseline bump uses 0.5 and only backfills when subsequent generation matches (test with: a) successful backfill, b) interleaved bump invalidates backfill, c) interleaved setBrightness invalidates backfill, d) write failure suppresses backfill). |
+| `BuiltinPreferenceSeeder`       | After adding `.brightnessUp` / `.brightnessDown`, verify their seeded `BuiltinPreference` rows have `isVisible == false` (via the new `defaultVisibility` property), and existing items still seed `isVisible == true`. |
 | `PanelStore.dispatch`           | Feed `.brightnessUp` / `.brightnessDown`; assert `bump` called with correct delta and target.                           |
 | `DisplayInfo` name deduplication| Three displays named "DELL U2720QM" yield "DELL U2720QM", "DELL U2720QM (1)", "DELL U2720QM (2)", stable across calls.  |
 

--- a/docs/superpowers/specs/2026-05-24-display-brightness-design.md
+++ b/docs/superpowers/specs/2026-05-24-display-brightness-design.md
@@ -1,0 +1,520 @@
+# Display Brightness Control — Design
+
+**Date**: 2026-05-24
+**Status**: Approved (design phase)
+**Author**: Brainstorming session
+
+## Summary
+
+Add a "屏幕亮度" entry to the AnyDoor menu-bar panel that lets users adjust the
+brightness of external DDC/CI displays. Hovering the entry opens a side
+popover containing one card per detected external display, each with a
+horizontal slider bound to that display's brightness (VCP 0x10). Two global
+hotkeys ("亮度 +" / "亮度 −") adjust the brightness of the display under the
+mouse cursor by ±1/16 (≈6.25%, matching the macOS system step) and trigger the
+native macOS OSD via a private `OSDUIHelper` bridge.
+
+v1 is intentionally scoped to **external DDC/CI displays, brightness only**,
+on **both Intel and Apple Silicon** Macs. The MacBook built-in display is
+excluded (system F1/F2 already covers it). Per-display volume/contrast and
+internal-display control are deferred.
+
+DDC I/O is delegated to [`reitermarkus/DDC.swift`](https://github.com/reitermarkus/DDC.swift)
+(MIT, vendored via SPM), which already abstracts the Intel `IOAVService` and
+Apple Silicon `Arm64DDC` code paths. AnyDoor wraps it in a small actor that
+exposes `read`/`write` against a `DDCBackend` protocol so tests can inject a
+mock.
+
+## Goals
+
+- Show one card per external display in a hover popover; per-display
+  brightness slider with live drag feedback.
+- Two configurable global hotkeys for brightness up/down that affect the
+  display under the mouse cursor and surface the native macOS OSD.
+- Work on both Intel and Apple Silicon Macs.
+- Gracefully handle displays that do not support DDC: card is visible but
+  greyed out; slider disabled.
+- Hot-plug aware: list updates immediately when displays are connected or
+  disconnected.
+- Reuse existing AnyDoor infrastructure: `PanelStore`, `BuiltinItem`,
+  `BuiltinPreference`, `HotkeyService`, `HoverPopover`, `HotkeyRecorder`.
+
+## Non-goals (v1)
+
+- **No volume control.** Per-display DDC volume (VCP 0x62) is unreliable
+  across vendors and only affects the monitor's built-in speakers. Deferred
+  to v2.
+- **No contrast / RGB / input-source controls.** Out of scope.
+- **No MacBook built-in display control.** Requires `DisplayServices`
+  private framework; system F1/F2 already works for built-in.
+- **No persistence of brightness across launches.** Brightness lives only in
+  memory; AnyDoor reads from the display on startup and on hot-plug.
+- **No persisted "remember last brightness and restore on connect" behaviour.**
+  Avoids the UX trap of overriding manual OSD adjustments.
+- **No error dialogs/toasts.** DDC failures are logged; the slider thumb
+  briefly greys to signal a transient write failure.
+- **No App Store submission compatibility.** The native OSD path uses
+  `OSDUIHelper` (private framework); this is acceptable given AnyDoor's
+  distribution model.
+- **No exposure of the DDC backend from view code.** Views never touch
+  `DDC.swift` directly.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Views                                                  │
+│  ├─ MenuBarView                                         │
+│  │   └─ PanelRowView (kind: .brightnessControl)         │
+│  │       └─ hover → HoverPopover                        │
+│  │                    └─ BrightnessPopoverView          │
+│  │                         └─ ForEach displays:         │
+│  │                              DisplayBrightnessCard   │
+│  └─ SettingsView → PanelSettingsView                    │
+│       (inline expansion: brightness +/- hotkey rows)    │
+├─────────────────────────────────────────────────────────┤
+│  PanelStore (@MainActor)                                │
+│  └─ BuiltinItem.kind extended with .brightnessControl   │
+│      dispatch(.brightnessUp/Down) → service.bump(...)   │
+├─────────────────────────────────────────────────────────┤
+│  DisplayBrightnessService (@MainActor @Observable)      │
+│  ├─ displays: [DisplayInfo]                             │
+│  ├─ levels:   [CGDirectDisplayID: Float]                │
+│  ├─ refresh / setBrightness / bump                      │
+│  └─ NSScreen.didChangeScreenParameters observer         │
+├─────────────────────────────────────────────────────────┤
+│  BrightnessController (actor)                           │
+│  └─ probe / read / write via DDCBackend protocol        │
+│      ├─ DDCSwiftBackend  (production, wraps DDC.swift)  │
+│      └─ MockDDCBackend   (tests)                        │
+├─────────────────────────────────────────────────────────┤
+│  HotkeyService (existing) + HotkeyAction (extended)     │
+│  └─ .brightnessUp / .brightnessDown                     │
+├─────────────────────────────────────────────────────────┤
+│  OSDBridge (enum, stateless)                            │
+│  └─ dlopen OSDUIHelper → native brightness OSD          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Layer responsibilities
+
+- **`BrightnessController` (actor)** — serialises I2C writes per displayID;
+  retries failed writes once. Knows nothing about UI or screens, only
+  display IDs and 0...1 floats. Constructor takes a `DDCBackend` for
+  injection.
+- **`DisplayBrightnessService` (@MainActor @Observable)** — single source of
+  truth for the brightness UI: tracks detected external displays, their
+  current brightness, and orchestrates refresh / debounced writes /
+  bump-by-delta. Owns the NSScreen observer.
+- **`OSDBridge` (enum)** — wraps the private `OSDUIHelper`
+  `showImageAtPath:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:` call.
+  Stateless; failures silent.
+- **`PanelStore`** — adds two cases to `dispatch(_:)`, routes brightness
+  hotkeys to the service. Does not own brightness state.
+- **Views** — read-only on the service; write only via the service's public
+  mutation methods.
+
+## Data model
+
+### Code-defined enum extension
+
+`BuiltinItem` is an enum-of-cases (one case per built-in panel item). Add a
+new case and route it to a new `Kind`:
+
+```swift
+// Models/BuiltinItem.swift
+enum BuiltinItem: String, CaseIterable {
+    // ... existing cases (keepAwake, muteAudio, ..., qrcode) ...
+    case brightness                       // new
+}
+
+extension BuiltinItem {
+    enum Kind {
+        case toggle
+        case action
+        case submenu                      // existing: click locks popover
+        case brightnessControl            // new: hover-only, click is no-op
+    }
+
+    var kind: Kind {
+        switch self {
+        // ... existing routing ...
+        case .brightness: return .brightnessControl
+        }
+    }
+}
+```
+
+Position of the `.brightness` case in `defaultOrder`: placed adjacent to
+display-related entries (after `.darkMode` is a reasonable default). Final
+position is decided at implementation time and can be re-ordered by the user
+via Panel Settings.
+
+A new `.brightnessControl` Kind (rather than reusing `.submenu`) is
+deliberate: `.submenu`'s click handler locks the popover (`onSubmenu()`,
+see `PanelRowView.swift`), whereas the brightness row's click must be a
+no-op per the chosen UX. The new Kind keeps that branch local to one
+switch case in `PanelRowView`.
+
+`PanelRowView.body`'s `.onTapGesture` switch gains:
+
+```swift
+case .brightnessControl: break   // click is intentionally a no-op
+```
+
+Hotkey binding for the main row is not applicable — there is no single
+"toggle brightness" action. The two ± hotkeys live on separate hidden
+`BuiltinPreference` rows (see below).
+
+### SwiftData (`BuiltinPreference`) — no schema change
+
+Reuse the existing `BuiltinPreference` model. Add two hidden preference
+entries to store the bump hotkeys (they have no visible row of their own):
+
+| `id`                    | `isVisible` | Purpose                       |
+| ----------------------- | ----------- | ----------------------------- |
+| `brightness.hotkey.up`  | false       | Stores hotkey for brightness+ |
+| `brightness.hotkey.down`| false       | Stores hotkey for brightness− |
+
+Seeded by `BuiltinPreferenceSeeder` on first run if absent.
+
+The Panel Settings UI surfaces these two hidden preferences inline under the
+"屏幕亮度" row using the existing `HotkeyRecorder` component.
+
+### Runtime state (in-memory only)
+
+```swift
+struct DisplayInfo: Identifiable, Hashable {
+    let id: CGDirectDisplayID
+    let name: String           // CoreDisplay localizedDeviceName, deduped
+    let supportsDDC: Bool      // result of first probe
+}
+
+@MainActor @Observable
+final class DisplayBrightnessService {
+    private(set) var displays: [DisplayInfo] = []
+    private(set) var levels:   [CGDirectDisplayID: Float] = [:]   // 0...1
+    private(set) var isLoading: Set<CGDirectDisplayID> = []
+}
+```
+
+`levels` is the single source of truth for what the UI shows. It is never
+persisted.
+
+## Component contracts
+
+### `DDCBackend` protocol
+
+```swift
+protocol DDCBackend: Sendable {
+    func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16?
+    func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws
+}
+
+struct DDCSwiftBackend: DDCBackend { /* wraps reitermarkus/DDC.swift */ }
+struct MockDDCBackend: DDCBackend  { /* test fixture */ }
+```
+
+### `BrightnessController`
+
+```swift
+actor BrightnessController {
+    enum Failure: Error { case ddcUnavailable, writeFailed, readTimeout }
+
+    init(backend: DDCBackend)
+
+    /// One-shot probe: tries a read; success → supports DDC.
+    func probe(displayID: CGDirectDisplayID) async -> Bool
+
+    /// 0...1 normalised, or nil if unreadable / unsupported.
+    func read(displayID: CGDirectDisplayID) async -> Float?
+
+    /// 0...1 normalised; throws Failure.writeFailed after one retry.
+    func write(displayID: CGDirectDisplayID, value: Float) async throws
+}
+```
+
+Invariants:
+- Always operates on VCP 0x10 (brightness).
+- Internally converts 0...1 ↔ 0...100 (DDC values are bytes 0-100 for
+  brightness on virtually all monitors; max-value VCP query deferred to a
+  later iteration if any user reports a quirky display).
+- Retries `write` exactly once on failure.
+- Read timeout 500 ms (handled at backend or via `Task` timeout).
+
+### `DisplayBrightnessService`
+
+```swift
+@MainActor @Observable
+final class DisplayBrightnessService {
+    static let shared: DisplayBrightnessService
+
+    private(set) var displays: [DisplayInfo]
+    private(set) var levels:   [CGDirectDisplayID: Float]
+    private(set) var isLoading: Set<CGDirectDisplayID>
+
+    /// Re-enumerates NSScreen.screens, probes/reads DDC per display.
+    func refresh() async
+
+    /// Debounced write (~30 ms). Updates `levels` immediately.
+    func setBrightness(_ value: Float, for displayID: CGDirectDisplayID)
+
+    /// Hotkey path: ±delta on resolved target. No debounce.
+    func bump(_ delta: Float, target: BumpTarget)
+
+    enum BumpTarget { case displayUnderMouse }   // v1: single mode
+}
+```
+
+Behavioural rules:
+- `setBrightness` updates `levels[id]` synchronously; cancels any in-flight
+  write Task for that displayID; schedules a new Task that sleeps 30 ms and
+  then calls `controller.write`.
+- `bump` resolves displayID via mouse cursor → falls back to
+  `NSScreen.main` if cursor is over the built-in / unsupported display; if
+  fallback is also unsupported, the bump is a no-op.
+- `bump` always fires `OSDBridge.showBrightness(newValue, on: displayID)`
+  after a successful write.
+- `bump` is rate-naturally-limited by user keyboard repeat; no extra
+  debouncing.
+
+### `OSDBridge`
+
+```swift
+enum OSDBridge {
+    /// Best-effort. Silently no-ops on failure.
+    static func showBrightness(_ value: Float, on displayID: CGDirectDisplayID)
+}
+```
+
+- Uses `dlopen` on
+  `/System/Library/PrivateFrameworks/OSDUIHelper.framework/OSDUIHelper`
+  and `dlsym` to resolve the relevant Obj-C selector.
+- Renders the brightness chiclet count (16 chiclets, filled = `round(value*16)`).
+- Never throws; never blocks the caller.
+
+### `HotkeyAction` extension
+
+```swift
+enum HotkeyAction {
+    case toggle(BuiltinKey)
+    case action(BuiltinKey)
+    case appShortcut(...)
+    case brightnessUp         // new
+    case brightnessDown       // new
+}
+```
+
+`PanelStore.dispatch(_:)` adds two cases that call
+`DisplayBrightnessService.shared.bump(±1.0/16.0, target: .displayUnderMouse)`.
+
+`PanelStore.rebuildHotkeySnapshots()` reads the two hidden brightness
+preferences and emits `HotkeySnapshot`s carrying `.brightnessUp` /
+`.brightnessDown`.
+
+## Data flow
+
+### Flow A — User hovers the "屏幕亮度" row
+
+```
+1. PanelRowView detects hover (existing HoverGate timing)
+2. HoverPopover.show(content: BrightnessPopoverView())
+3. BrightnessPopoverView.onAppear → Task { await service.refresh() }
+4. service.refresh():
+   a. Enumerate NSScreen.screens, filter out CGDisplayIsBuiltin
+   b. Resolve each name via CoreDisplay (localizedDeviceName)
+   c. Dedupe identical names with suffix " (1)", " (2)", ...
+   d. Concurrently probe + read each external display
+   e. Update displays / levels → @Observable triggers SwiftUI re-render
+5. Cards appear with ProgressView placeholders, fill in as reads complete
+```
+
+Cached refresh: if the last refresh succeeded < 30 s ago AND no screen-change
+notification has fired since, skip step 4.
+
+### Flow B — User drags a slider
+
+```
+1. Slider onChanged(value) → service.setBrightness(value, for: id)
+2. service: levels[id] = value           (UI feedback immediate)
+3. service: cancel any pending writeTask for id
+4. service: spawn writeTask { sleep 30ms; try await controller.write(id, value) }
+5. Next onChanged cancels (4) and spawns a fresh one
+6. Drag ends → final write lands
+7. If write throws: log, briefly grey the slider thumb (transient state on
+   the card), no alert
+```
+
+### Flow C — Brightness ± hotkey
+
+```
+1. CGEvent tap matches the snapshot for .brightnessUp / .brightnessDown
+2. DispatchQueue.main.async → PanelStore.dispatch(action)
+3. PanelStore → service.bump(±0.0625, target: .displayUnderMouse)
+4. service:
+   a. Resolve displayID via NSEvent.mouseLocation + NSScreen.screens;
+      fallback NSScreen.main; bail if still unsupported.
+   b. newValue = clamp(levels[id] + delta, 0...1)
+   c. levels[id] = newValue          (popover, if open, updates live)
+   d. Task { try await controller.write(id, newValue) }
+   e. OSDBridge.showBrightness(newValue, on: id)
+```
+
+### Flow D — Display hot-plug
+
+```
+1. NSApplication.didChangeScreenParametersNotification observer fires
+2. service.refresh() invalidates cache + re-enumerates
+3. Removed displays drop out of `displays` and `levels`
+4. Open popover re-renders automatically (SwiftUI diff)
+```
+
+### Flow E — Application launch
+
+```
+AppDelegate.applicationDidFinishLaunching:
+1. Build BrightnessController(backend: DDCSwiftBackend())
+2. Build DisplayBrightnessService(controller:)  → register as shared
+3. Register NSScreen observer inside the service
+4. Wire PanelStore dispatcher cases to service.bump
+5. Task.detached { await DisplayBrightnessService.shared.refresh() }
+   → first hover finds data already cached
+```
+
+## UI
+
+### `BrightnessPopoverView`
+
+- Vertical stack of `DisplayBrightnessCard`s separated by 12 pt.
+- Outer container width ≈ 320 pt; height auto.
+
+### `DisplayBrightnessCard`
+
+- Background: `.regularMaterial`; cornerRadius 16.
+- Title: display name, `.headline`.
+- Slider: SwiftUI **system `Slider(value:in:0...1)`** with
+  `.controlSize(.large)` and a leading `Image(systemName: "sun.max.fill")`
+  outside the slider proper. Native macOS slider styling — does not attempt
+  to clone the capsule mockup pixel-for-pixel.
+- If `supportsDDC == false`: card visible, slider disabled, opacity 0.4, a
+  small "不支持 DDC" caption beneath the title.
+- If `isLoading.contains(id)`: the slider is disabled and a small
+  `ProgressView()` is rendered to the right of the slider until the first
+  read returns; once `levels[id]` is populated the spinner is removed and
+  the slider becomes interactive.
+- Transient write-failure feedback: thumb tint flashes grey for ~250 ms then
+  restores (visual only; no text).
+
+### Empty states
+
+- Zero external displays detected: a single line "未检测到外置显示器", with
+  a small `display` SF Symbol, centred.
+- External displays found but none DDC-capable: "未检测到支持 DDC 的外置显示器"
+  with a one-line hint "DisplayPort/HDMI 通常可用，部分 USB-C 转接线不支持".
+
+### Popover behaviour
+
+- Hover-only open; existing `HoverGate` semantics, 200 ms close delay.
+- Click on the panel row itself: no-op (does **not** close the popover).
+- ESC closes the popover.
+
+### Settings (Panel tab)
+
+Under the existing "屏幕亮度" row, a chevron-expandable inline section:
+
+```
+┌─ 屏幕亮度                       [visible ✓] ≡ ›─┐
+│  └─ Expanded:                                   │
+│      亮度 +    [⌥⇧F2]   [录入]                  │
+│      亮度 −    [⌥⇧F1]   [录入]                  │
+└─────────────────────────────────────────────────┘
+```
+
+- Reuses `HotkeyRecorder`.
+- Recorder calls `HotkeyService.suspend()` / `resume()` as elsewhere.
+- Writes to the two hidden `BuiltinPreference` rows via a new
+  `PanelStore.setBrightnessHotkey(direction:keyCode:modifierFlags:)` method
+  (which saves to SwiftData and calls `rebuildHotkeySnapshots()`).
+
+## Error handling and edge cases
+
+| Scenario                                  | Behaviour                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Display does not support DDC              | `supportsDDC = false`; card visible but greyed out; slider disabled; no further read/write attempts.   |
+| DDC read timeout (>500 ms)                | `levels[id]` stays `nil`; slider shows at midpoint but is interactive (drag triggers write normally).  |
+| DDC write failure                         | Actor retries once; on second failure, log; thumb greys for ~250 ms; no alert.                         |
+| `bump` with mouse on built-in / unsupported| Fallback to `NSScreen.main`. If that is also unsupported, bump becomes a no-op (no OSD, no write).     |
+| Hot-unplug during in-flight write         | Actor's next write throws (invalid IOAVService); caught silently; UI removes the card on next refresh. |
+| Hot-unplug→replug (displayID reuse/change)| `didChangeScreenParameters` triggers full refresh; stale entries replaced.                             |
+| Two displays with identical names         | Deduplicated by appending ` (n)` keyed by `CGDirectDisplayID` ordering for stability.                  |
+| MacBook clamshell (lid closed, external)  | `NSScreen.screens` naturally only contains externals; built-in filter is unaffected.                   |
+| Accessibility permission missing          | DDC does **not** require it. Hotkey path requires it (existing AnyDoor onboarding handles this).       |
+| `OSDBridge.dlopen` fails                  | Silent no-op; brightness change still takes effect at the display.                                     |
+| First hover before pre-warm finishes      | Popover shows ProgressView placeholders; cards populate as `refresh()` completes.                      |
+| `@Observable` re-render frequency         | `levels` dict is small (typically ≤ 4 external displays); SwiftUI diff cost is negligible.             |
+
+### Out-of-scope failure modes
+
+- Brightness validation (e.g., monitor reports 73 when we wrote 75): not
+  checked. We trust the write and update `levels` optimistically.
+- VCP max-value handshake (some monitors report a max ≠ 100): not done in
+  v1. If a user reports a misbehaving display, add VCP 0x10 max read to a
+  later iteration.
+
+## Testing strategy
+
+### Unit tests (XCTest, runnable in CI)
+
+| Module                          | Test focus                                                                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `BrightnessController`          | Inject `MockDDCBackend`; verify probe behaviour, read normalisation (0...100 → 0...1), write retry on failure, timeout. |
+| `DisplayBrightnessService`      | Inject mock controller; verify ① debounce only emits the final write per displayID; ② `bump` clamps to 0...1; ③ NSScreen notification rebuilds `displays`; ④ `displayUnderMouse` falls back to main screen when cursor is over an unsupported display. |
+| `PanelStore.dispatch`           | Feed `.brightnessUp` / `.brightnessDown`; assert `bump` called with correct delta and target.                           |
+| `DisplayInfo` name deduplication| Three displays named "DELL U2720QM" yield "DELL U2720QM", "DELL U2720QM (1)", "DELL U2720QM (2)", stable across calls.  |
+
+### Manual QA checklist (pre-release)
+
+Captured separately when the implementation lands; covers:
+
+- [ ] Single supported display: hover reads correct brightness; drag updates display.
+- [ ] Single unsupported display: card greyed; slider inert.
+- [ ] Mixed (one supported, one not): per-card behaviour correct.
+- [ ] Hot-plug: list updates; drag-during-unplug does not crash.
+- [ ] Hotkey on display A vs display B: routes by cursor position.
+- [ ] Hotkey when cursor on built-in: falls back to `NSScreen.main`.
+- [ ] Hotkey triggers native OSD overlay.
+- [ ] Popover open + hotkey pressed: slider updates live.
+- [ ] M1 / M2 / Intel Mac smoke test.
+- [ ] MacBook clamshell mode.
+- [ ] Restart AnyDoor: brightness on displays is not overwritten.
+
+### Excluded from testing
+
+- Live DDC communication unit tests (require hardware; brittle).
+- SwiftUI snapshot tests (low value, high cost for this UI).
+- `OSDBridge` tests (private API; silent-failure semantics make assertions meaningless).
+
+## Dependencies
+
+### New SPM dependency
+
+- `https://github.com/reitermarkus/DDC.swift` (MIT) — added to
+  `Package.swift`. Copyright/notice surfaced in the project README's
+  acknowledgements list and (eventually) in an in-app "About" view.
+
+### System frameworks (already linked or trivially available)
+
+- `IOKit` / `CoreDisplay` / `AppKit` — already used by AnyDoor.
+- `OSDUIHelper` (private) — loaded dynamically via `dlopen`; not linked at
+  build time.
+
+## Open follow-ups (post-v1)
+
+- VCP 0x10 max-value handshake for non-standard monitors.
+- Per-display volume slider (VCP 0x62) — pending validation of how many
+  users actually use the monitor's built-in speakers.
+- MacBook built-in display support via `DisplayServices`.
+- Persist last brightness per display and restore on AnyDoor launch (opt-in).
+- `BumpTarget.all` for "adjust every display simultaneously".
+- Self-drawn capsule slider that matches the original mockup, if the system
+  slider proves too visually inconsistent with the panel aesthetic.

--- a/docs/superpowers/specs/2026-05-24-display-brightness-design.md
+++ b/docs/superpowers/specs/2026-05-24-display-brightness-design.md
@@ -12,7 +12,7 @@ popover containing one card per detected external display, each with a
 horizontal slider bound to that display's brightness (VCP 0x10). Two global
 hotkeys ("亮度 +" / "亮度 −") adjust the brightness of the display under the
 mouse cursor by ±1/16 (≈6.25%, matching the macOS system step) and trigger the
-native macOS OSD via a private `OSDUIHelper` bridge.
+native macOS OSD via a private-framework bridge (`OSD.framework`).
 
 v1 is intentionally scoped to **external DDC/CI displays, brightness only**,
 on **both Intel and Apple Silicon** Macs. The MacBook built-in display is
@@ -29,8 +29,12 @@ which is not the path arm64 displays use), so AnyDoor includes a
 directly. The MonitorControl project (GPLv3) is referenced for the *approach*
 but no GPL code is copied — function signatures and IORegistry matching
 strategy for IOAVService are not copyrightable. Both backends conform to a
-single `DDCBackend` protocol; runtime picks one based on
-`#if arch(arm64)` (with a runtime guard for fat builds).
+single `DDCBackend` protocol; the production typealias is selected per
+slice by `#if arch(arm64)` in source code (each slice of a universal
+binary compiles independently, so per-slice selection works correctly).
+The SPM dependency on DDC.swift is declared unconditionally — see
+"Dependencies" for why arch-conditioning the manifest breaks
+universal builds.
 
 ## Goals
 
@@ -61,7 +65,7 @@ single `DDCBackend` protocol; runtime picks one based on
 - **No error dialogs/toasts.** DDC failures are logged; the slider thumb
   briefly greys to signal a transient write failure.
 - **No App Store submission compatibility.** The native OSD path uses
-  `OSDUIHelper` (private framework); this is acceptable given AnyDoor's
+  the private `OSD.framework`; this is acceptable given AnyDoor's
   distribution model.
 - **No exposure of the DDC backend from view code.** Views never touch
   `DDC.swift` directly.
@@ -100,7 +104,8 @@ single `DDCBackend` protocol; runtime picks one based on
 │  └─ .brightnessUp / .brightnessDown                     │
 ├─────────────────────────────────────────────────────────┤
 │  OSDBridge (enum, stateless)                            │
-│  └─ dlopen OSDUIHelper → native brightness OSD          │
+│  └─ dlopen OSD.framework → OSDManager.sharedManager()   │
+│      → native brightness OSD                            │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -114,8 +119,9 @@ single `DDCBackend` protocol; runtime picks one based on
   truth for the brightness UI: tracks detected external displays, their
   current brightness, and orchestrates refresh / debounced writes /
   bump-by-delta. Owns the NSScreen observer.
-- **`OSDBridge` (enum)** — wraps the private `OSDUIHelper`
-  `showImageAtPath:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:` call.
+- **`OSDBridge` (enum)** — `dlopen`s `/System/Library/PrivateFrameworks/OSD.framework/OSD`,
+  resolves the `OSDManager` class via `NSClassFromString`, calls
+  `+sharedManager` then `-showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:`.
   Stateless; failures silent.
 - **`PanelStore`** — adds two cases to `dispatch(_:)`, routes brightness
   hotkeys to the service. Does not own brightness state.
@@ -339,9 +345,20 @@ Behavioural rules:
 - `bump` resolves displayID via mouse cursor → falls back to
   `NSScreen.main` if cursor is over the built-in / unsupported display; if
   fallback is also unsupported, the bump is a no-op.
-- `bump` always fires `OSDBridge.showBrightness(newValue, on: displayID)`
-  after a successful write.
-- `bump` is rate-naturally-limited by user keyboard repeat; no extra
+- **Baseline when `levels[id] == nil`** (read previously timed out on a
+  transport-ready display): `bump` treats the current level as `0.5` for
+  the purpose of `clamp(current + delta, 0...1)`. After the write is
+  scheduled, the service issues a fresh `controller.read` (best-effort) so
+  later nudges have a real baseline. Rationale: keeps hotkey UX snappy,
+  avoids ignoring user input; 6.25% nudge from a wrong baseline self-corrects
+  within ~4 keypresses.
+- **OSD timing**: `bump` fires `OSDBridge.showBrightness(newValue, on: id)`
+  *optimistically*, immediately after spawning the write Task — not after
+  the write resolves. Rationale: DDC writes can take 50-200 ms; deferring
+  the OSD until after `write` returns makes the chiclet feel laggy relative
+  to the keystroke. If the write later fails, we do NOT undo the OSD
+  (acceptable: nudges are tiny and the OSD is transient).
+- `bump` is rate-naturally-limited by keyboard repeat; no extra
   debouncing.
 
 ### `OSDBridge`
@@ -353,20 +370,27 @@ enum OSDBridge {
 }
 ```
 
-- Loads `/System/Library/PrivateFrameworks/OSDUIHub.framework/OSDUIHub` (the
-  current daemon process owning the OSD UI) and resolves the chiclet
-  display selector
-  `showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:`
-  on `OSDManager`.
-- Brightness uses OSD image ID `OSDGraphic.brightness` (raw value `1` in
-  the private enum); chiclet count = 16, `filled = round(value * 16)`.
-- Selector and image-id values are based on MonitorControl's published
-  bridging-header constants (`showImage:` for chiclets;
+- Loads `/System/Library/PrivateFrameworks/OSD.framework/OSD` via `dlopen`.
+  Verified path on macOS 26.5 (`OSDUIHelper.framework` /
+  `OSDUIHub.framework` from older macOS docs do **not** exist on current
+  systems). The on-disk binary is a stub symlink resolved from the dyld
+  shared cache; `dlopen` succeeds because dyld services symbols from the
+  cache rather than the on-disk file.
+- Resolves `OSDManager` via `NSClassFromString("OSDManager")`, calls
+  `+sharedManager` (returns an `NSObject` that internally manages the XPC
+  connection to `OSDUIHelper.app` in `/System/Library/CoreServices`),
+  then invokes the chiclet display selector
+  `showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:`.
+- Brightness uses OSD image id `OSDGraphic.brightness` (raw value `1` in
+  the published private enum). Chiclet count = 16,
+  `filled = round(value * 16)`.
+- Selector name confirmed against MonitorControl's bridging header.
   `showImageAtPath:withText:...` is a *different* selector used for
-  text-bearing OSDs and is **not** used here).
-- Never throws; never blocks the caller. If `dlopen`, the class lookup, or
-  `responds(to:)` fails, the call returns silently and brightness still
-  takes effect at the display.
+  text-bearing OSDs and is **not** used here.
+- Never throws; never blocks the caller. If `dlopen`, `NSClassFromString`,
+  `+sharedManager`, or `responds(to:)` fails (e.g., the framework path or
+  selector changes in a future macOS), the call returns silently and the
+  DDC write still takes effect at the display.
 
 ### `HotkeyAction` extension
 
@@ -440,10 +464,14 @@ notification has fired since, skip step 4.
 4. service:
    a. Resolve displayID via NSEvent.mouseLocation + NSScreen.screens;
       fallback NSScreen.main; bail if still unsupported.
-   b. newValue = clamp(levels[id] + delta, 0...1)
-   c. levels[id] = newValue          (popover, if open, updates live)
-   d. Task { try await controller.write(id, newValue) }
-   e. OSDBridge.showBrightness(newValue, on: id)
+   b. baseline = levels[id] ?? 0.5     (see "Baseline when nil" above)
+   c. newValue = clamp(baseline + delta, 0...1)
+   d. levels[id] = newValue            (popover, if open, updates live)
+   e. Task { try await controller.write(id, newValue) }
+   f. OSDBridge.showBrightness(newValue, on: id)   (optimistic; pre-await)
+   g. If baseline came from the 0.5 fallback: Task {
+         if let real = await controller.read(id) { levels[id] = real }
+      }                                  (best-effort backfill for next bump)
 ```
 
 ### Flow D — Display hot-plug
@@ -532,7 +560,7 @@ Under the existing "屏幕亮度" row, a chevron-expandable inline section:
 | Scenario                                  | Behaviour                                                                                              |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | Display has no DDC transport (`transportReady == false`) | `supportsDDC = false`; card visible but greyed out; slider disabled; no further read/write attempts. This is the only path that sets `supportsDDC = false`. |
-| DDC value read timeout (>500 ms) on a transport-ready display | `supportsDDC` stays `true`; `levels[id]` stays `nil`; slider shows at midpoint but remains interactive (drag triggers write normally — many monitors accept writes but refuse VCP reads). |
+| DDC value read timeout (>500 ms) on a transport-ready display | `supportsDDC` stays `true`; `levels[id]` stays `nil`; slider shows at midpoint but remains interactive (drag triggers write normally — many monitors accept writes but refuse VCP reads). Hotkey bump uses 0.5 as baseline (see service rules) and schedules a backfill read after the write. |
 | DDC write failure                         | Actor retries once; on second failure, log; thumb greys for ~250 ms; no alert.                         |
 | `bump` with mouse on built-in / unsupported| Fallback to `NSScreen.main`. If that is also unsupported, bump becomes a no-op (no OSD, no write).     |
 | Hot-unplug during in-flight write         | Actor's next write throws (invalid IOAVService); caught silently; UI removes the card on next refresh. |
@@ -590,9 +618,19 @@ Captured separately when the implementation lands; covers:
 ### New SPM dependency
 
 - `https://github.com/reitermarkus/DDC.swift` (MIT) — added to
-  `Package.swift`, **conditionally compiled in only for Intel builds**
-  (`#if !arch(arm64)`). Copyright/notice surfaced in README's
-  acknowledgements list and in the eventual in-app "About" view.
+  `Package.swift` **unconditionally**. SwiftPM's `Package.Dependency`
+  conditions only support `.platforms(...)`, not `arch`, and `#if arch(...)`
+  in a `Package.swift` manifest is evaluated against the **host
+  architecture**, not per slice. `scripts/release.sh:132` does a universal
+  build (`swift build -c release --arch arm64 --arch x86_64`), so any
+  host-conditioned manifest would silently drop the dependency from one
+  slice and break the universal release. The dependency is therefore
+  unconditional; the *usage* lives behind `#if !arch(arm64)` in the source
+  files that wrap it (`IntelDDCBackend`). On an arm64-only build the
+  resulting binary contains no DDC.swift symbols (dead-code stripped),
+  with only a small manifest-resolution overhead at build time.
+  Copyright/notice surfaced in README's acknowledgements list and in the
+  eventual in-app "About" view.
 
 ### New in-repo code (no third-party dependency)
 
@@ -606,9 +644,12 @@ Captured separately when the implementation lands; covers:
 ### System frameworks (already linked or trivially available)
 
 - `IOKit` / `CoreDisplay` / `AppKit` — already used by AnyDoor.
-- `OSDUIHub` (private) — loaded dynamically via `dlopen`; not linked at
-  build time. Selector resolution wrapped in defensive guards
-  (`responds(to:)`) so framework path changes degrade gracefully.
+- `OSD.framework` (private) — loaded dynamically via `dlopen` at
+  `/System/Library/PrivateFrameworks/OSD.framework/OSD`; not linked at
+  build time. Class lookup (`NSClassFromString("OSDManager")`), shared
+  instance, and selector resolution are each guarded so framework path,
+  class, or selector changes in a future macOS degrade gracefully (silent
+  no-op; DDC write still lands).
 
 ## Open follow-ups (post-v1)
 

--- a/docs/superpowers/specs/2026-05-24-display-brightness-design.md
+++ b/docs/superpowers/specs/2026-05-24-display-brightness-design.md
@@ -19,11 +19,18 @@ on **both Intel and Apple Silicon** Macs. The MacBook built-in display is
 excluded (system F1/F2 already covers it). Per-display volume/contrast and
 internal-display control are deferred.
 
-DDC I/O is delegated to [`reitermarkus/DDC.swift`](https://github.com/reitermarkus/DDC.swift)
-(MIT, vendored via SPM), which already abstracts the Intel `IOAVService` and
-Apple Silicon `Arm64DDC` code paths. AnyDoor wraps it in a small actor that
-exposes `read`/`write` against a `DDCBackend` protocol so tests can inject a
-mock.
+DDC I/O is split by architecture: on **Intel**, the
+[`reitermarkus/DDC.swift`](https://github.com/reitermarkus/DDC.swift) library
+(MIT, SPM) handles the IOKit `i2c` / `IOFramebuffer` path. On **Apple
+Silicon**, that library does not work (it uses `IOFBGetI2CInterfaceCount`,
+which is not the path arm64 displays use), so AnyDoor includes a
+**clean-room `Arm64DDCBackend`** that calls the private
+`IOAVServiceCreate` / `IOAVServiceReadI2C` / `IOAVServiceWriteI2C` symbols
+directly. The MonitorControl project (GPLv3) is referenced for the *approach*
+but no GPL code is copied — function signatures and IORegistry matching
+strategy for IOAVService are not copyrightable. Both backends conform to a
+single `DDCBackend` protocol; runtime picks one based on
+`#if arch(arm64)` (with a runtime guard for fat builds).
 
 ## Goals
 
@@ -85,7 +92,8 @@ mock.
 ├─────────────────────────────────────────────────────────┤
 │  BrightnessController (actor)                           │
 │  └─ probe / read / write via DDCBackend protocol        │
-│      ├─ DDCSwiftBackend  (production, wraps DDC.swift)  │
+│      ├─ Arm64DDCBackend  (Apple Silicon, IOAVService)   │
+│      ├─ IntelDDCBackend  (Intel, wraps DDC.swift)       │
 │      └─ MockDDCBackend   (tests)                        │
 ├─────────────────────────────────────────────────────────┤
 │  HotkeyService (existing) + HotkeyAction (extended)     │
@@ -118,14 +126,16 @@ mock.
 
 ### Code-defined enum extension
 
-`BuiltinItem` is an enum-of-cases (one case per built-in panel item). Add a
-new case and route it to a new `Kind`:
+`BuiltinItem` is an enum-of-cases (one case per built-in item). Three new
+cases and two new `Kind` values are added:
 
 ```swift
 // Models/BuiltinItem.swift
 enum BuiltinItem: String, CaseIterable {
     // ... existing cases (keepAwake, muteAudio, ..., qrcode) ...
-    case brightness                       // new
+    case brightness                       // new: the visible panel row
+    case brightnessUp                     // new: hidden, hotkey-only
+    case brightnessDown                   // new: hidden, hotkey-only
 }
 
 extension BuiltinItem {
@@ -134,51 +144,76 @@ extension BuiltinItem {
         case action
         case submenu                      // existing: click locks popover
         case brightnessControl            // new: hover-only, click is no-op
+        case hiddenHotkey                 // new: no panel row, hotkey only
     }
 
     var kind: Kind {
         switch self {
         // ... existing routing ...
-        case .brightness: return .brightnessControl
+        case .brightness:                 return .brightnessControl
+        case .brightnessUp, .brightnessDown: return .hiddenHotkey
         }
     }
 }
 ```
 
-Position of the `.brightness` case in `defaultOrder`: placed adjacent to
-display-related entries (after `.darkMode` is a reasonable default). Final
-position is decided at implementation time and can be re-ordered by the user
-via Panel Settings.
+Position of `.brightness` in `defaultOrder`: placed after `.darkMode`. Users
+can re-order via Panel Settings. `.brightnessUp` / `.brightnessDown` get
+sentinel order values and are filtered out of the panel render.
 
-A new `.brightnessControl` Kind (rather than reusing `.submenu`) is
-deliberate: `.submenu`'s click handler locks the popover (`onSubmenu()`,
-see `PanelRowView.swift`), whereas the brightness row's click must be a
-no-op per the chosen UX. The new Kind keeps that branch local to one
-switch case in `PanelRowView`.
+**Why a new `.brightnessControl` Kind** (not reuse `.submenu`): `.submenu`'s
+click handler locks the popover (`onSubmenu()` in `PanelRowView.swift`),
+whereas the brightness row's click must be a no-op per the chosen UX. New
+Kind keeps the branch local.
 
-`PanelRowView.body`'s `.onTapGesture` switch gains:
+**Why a new `.hiddenHotkey` Kind** (not "hidden `BuiltinPreference` rows"):
+the previous draft stored the ± hotkeys as `isVisible: false` preference
+rows, but `PanelStore.entryUsingHotkey()`
+(`Sources/AnyDoor/Services/PanelStore.swift:320`) only scans
+`topLevelEntries + appShortcutChildren`, which excludes invisible entries.
+That would let the brightness hotkeys silently collide with existing app /
+built-in hotkeys. Modelling them as real `BuiltinItem` cases that flow
+through normal `BuiltinPreference` storage and snapshot rebuild keeps
+conflict detection honest.
+
+### Changes to `PanelStore`
 
 ```swift
-case .brightnessControl: break   // click is intentionally a no-op
+// PanelRowView click switch gains:
+case .brightnessControl: break              // intentional no-op
+// (.hiddenHotkey never reaches PanelRowView — it's filtered out of
+//  topLevelEntries during rebuild.)
+
+// rebuild(): when assembling topLevelEntries, skip items whose kind is
+// .hiddenHotkey. (They still own a BuiltinPreference row for hotkey storage.)
+
+// entryUsingHotkey(_:excluding:): scan extended to include hidden-hotkey
+// entries:
+let hiddenHotkeyEntries = BuiltinItem.allCases
+    .filter { $0.kind == .hiddenHotkey }
+    .compactMap { makeEntry(for: $0) }
+for entry in topLevelEntries + appShortcutChildren + hiddenHotkeyEntries {
+    if entry.source == excluding { continue }
+    if entry.hotkey == hotkey { return entry }
+}
+
+// rebuildHotkeySnapshots(): also emit snapshots for hidden-hotkey
+// BuiltinPreferences, with HotkeyAction.brightnessUp / .brightnessDown.
 ```
 
-Hotkey binding for the main row is not applicable — there is no single
-"toggle brightness" action. The two ± hotkeys live on separate hidden
-`BuiltinPreference` rows (see below).
+Single source of truth: brightness hotkeys live in the same `BuiltinPreference`
+table everything else uses; no special-case storage.
 
 ### SwiftData (`BuiltinPreference`) — no schema change
 
-Reuse the existing `BuiltinPreference` model. Add two hidden preference
-entries to store the bump hotkeys (they have no visible row of their own):
+`BuiltinPreference` already stores one hotkey per `BuiltinItem` raw value. The
+new cases `.brightnessUp` and `.brightnessDown` get their own
+`BuiltinPreference` rows, seeded by `BuiltinPreferenceSeeder`. They use
+`isVisible: false` (no panel row), but unlike the previous draft they are
+proper `BuiltinItem` cases, so `PanelStore` discovers them through
+`BuiltinItem.allCases`-based scans (see "Changes to `PanelStore`" above).
 
-| `id`                    | `isVisible` | Purpose                       |
-| ----------------------- | ----------- | ----------------------------- |
-| `brightness.hotkey.up`  | false       | Stores hotkey for brightness+ |
-| `brightness.hotkey.down`| false       | Stores hotkey for brightness− |
-
-Seeded by `BuiltinPreferenceSeeder` on first run if absent.
-
-The Panel Settings UI surfaces these two hidden preferences inline under the
+The Panel Settings UI surfaces these two preferences inline under the
 "屏幕亮度" row using the existing `HotkeyRecorder` component.
 
 ### Runtime state (in-memory only)
@@ -207,13 +242,33 @@ persisted.
 
 ```swift
 protocol DDCBackend: Sendable {
+    /// Fast, side-effect-free check: is the I2C/IOAVService transport
+    /// reachable for this display? Does NOT issue a VCP read. Used by
+    /// `BrightnessController.probe`.
+    func transportReady(displayID: CGDirectDisplayID) -> Bool
+
+    /// Issue a VCP read. May time out independently of `transportReady`.
     func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16?
+
+    /// Issue a VCP write. Throws on failure.
     func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws
 }
 
-struct DDCSwiftBackend: DDCBackend { /* wraps reitermarkus/DDC.swift */ }
+#if arch(arm64)
+struct Arm64DDCBackend: DDCBackend  { /* clean-room, dlsym IOAVService */ }
+typealias ProductionDDCBackend = Arm64DDCBackend
+#else
+struct IntelDDCBackend: DDCBackend  { /* wraps reitermarkus/DDC.swift */ }
+typealias ProductionDDCBackend = IntelDDCBackend
+#endif
+
 struct MockDDCBackend: DDCBackend  { /* test fixture */ }
 ```
+
+Both production backends look up the display's IOAVService /
+IOI2CInterface object once and cache it per `CGDirectDisplayID` (refreshed
+on screen-change notifications). Cache invalidation on hot-unplug is
+handled by the higher-level service via `refresh()`.
 
 ### `BrightnessController`
 
@@ -223,7 +278,10 @@ actor BrightnessController {
 
     init(backend: DDCBackend)
 
-    /// One-shot probe: tries a read; success → supports DDC.
+    /// Transport probe — fast, no VCP query. Returns true iff the display
+    /// is reachable via IOAVService / IOI2CInterface. Used to decide whether
+    /// to render the card as supported or greyed out. A read or write may
+    /// still time out for transient reasons even when this returns true.
     func probe(displayID: CGDirectDisplayID) async -> Bool
 
     /// 0...1 normalised, or nil if unreadable / unsupported.
@@ -244,14 +302,22 @@ Invariants:
 
 ### `DisplayBrightnessService`
 
+Service follows the codebase pattern (mirror of
+`PanelStore.shared` + `bootstrap(...)`, `ClipboardHistoryStore.shared` +
+`bootstrap(...)`):
+
 ```swift
 @MainActor @Observable
 final class DisplayBrightnessService {
-    static let shared: DisplayBrightnessService
+    static let shared = DisplayBrightnessService()
 
     private(set) var displays: [DisplayInfo]
     private(set) var levels:   [CGDirectDisplayID: Float]
     private(set) var isLoading: Set<CGDirectDisplayID>
+
+    /// Called once from AppDelegate. Tests can call this with a
+    /// MockDDCBackend-backed controller to override the production wiring.
+    func bootstrap(controller: BrightnessController)
 
     /// Re-enumerates NSScreen.screens, probes/reads DDC per display.
     func refresh() async
@@ -287,11 +353,20 @@ enum OSDBridge {
 }
 ```
 
-- Uses `dlopen` on
-  `/System/Library/PrivateFrameworks/OSDUIHelper.framework/OSDUIHelper`
-  and `dlsym` to resolve the relevant Obj-C selector.
-- Renders the brightness chiclet count (16 chiclets, filled = `round(value*16)`).
-- Never throws; never blocks the caller.
+- Loads `/System/Library/PrivateFrameworks/OSDUIHub.framework/OSDUIHub` (the
+  current daemon process owning the OSD UI) and resolves the chiclet
+  display selector
+  `showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:`
+  on `OSDManager`.
+- Brightness uses OSD image ID `OSDGraphic.brightness` (raw value `1` in
+  the private enum); chiclet count = 16, `filled = round(value * 16)`.
+- Selector and image-id values are based on MonitorControl's published
+  bridging-header constants (`showImage:` for chiclets;
+  `showImageAtPath:withText:...` is a *different* selector used for
+  text-bearing OSDs and is **not** used here).
+- Never throws; never blocks the caller. If `dlopen`, the class lookup, or
+  `responds(to:)` fails, the call returns silently and brightness still
+  takes effect at the display.
 
 ### `HotkeyAction` extension
 
@@ -316,11 +391,22 @@ preferences and emits `HotkeySnapshot`s carrying `.brightnessUp` /
 
 ### Flow A — User hovers the "屏幕亮度" row
 
+Hover-popover plumbing in AnyDoor lives in `MenuBarView`, not
+`PanelRowView` (see `Sources/AnyDoor/Views/MenuBarView.swift:117-118` for
+the existing `.submenu` registration). The brightness row plugs into the
+same machinery:
+
 ```
-1. PanelRowView detects hover (existing HoverGate timing)
-2. HoverPopover.show(content: BrightnessPopoverView())
-3. BrightnessPopoverView.onAppear → Task { await service.refresh() }
-4. service.refresh():
+1. MenuBarView's hover-trigger logic registers a trigger frame for any
+   built-in row whose kind is .submenu OR .brightnessControl.
+2. When the cursor enters that frame and the HoverGate delay elapses,
+   MenuBarView sets activeHoverTarget = .brightnessControl(.brightness)
+   (new HoverPopoverTarget case).
+3. mountPopoverContent gains a new branch:
+       case .brightnessControl(.brightness):
+           HoverPopover.show(content: BrightnessPopoverView())
+4. BrightnessPopoverView.onAppear → Task { await service.refresh() }
+5. service.refresh():
    a. Enumerate NSScreen.screens, filter out CGDisplayIsBuiltin
    b. Resolve each name via CoreDisplay (localizedDeviceName)
    c. Dedupe identical names with suffix " (1)", " (2)", ...
@@ -371,12 +457,17 @@ notification has fired since, skip step 4.
 
 ### Flow E — Application launch
 
+Mirrors the existing `PanelStore.shared.bootstrap(...)` /
+`ClipboardHistoryStore.shared.bootstrap(...)` pattern:
+
 ```
 AppDelegate.applicationDidFinishLaunching:
-1. Build BrightnessController(backend: DDCSwiftBackend())
-2. Build DisplayBrightnessService(controller:)  → register as shared
-3. Register NSScreen observer inside the service
-4. Wire PanelStore dispatcher cases to service.bump
+1. let backend = ProductionDDCBackend()              // arch-selected at compile time
+2. let controller = BrightnessController(backend: backend)
+3. DisplayBrightnessService.shared.bootstrap(controller: controller)
+   // bootstrap() also installs the NSScreen observer
+4. PanelStore dispatcher already wired in existing flow; the new
+   HotkeyAction cases route to DisplayBrightnessService.shared.bump(...)
 5. Task.detached { await DisplayBrightnessService.shared.refresh() }
    → first hover finds data already cached
 ```
@@ -440,8 +531,8 @@ Under the existing "屏幕亮度" row, a chevron-expandable inline section:
 
 | Scenario                                  | Behaviour                                                                                              |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Display does not support DDC              | `supportsDDC = false`; card visible but greyed out; slider disabled; no further read/write attempts.   |
-| DDC read timeout (>500 ms)                | `levels[id]` stays `nil`; slider shows at midpoint but is interactive (drag triggers write normally).  |
+| Display has no DDC transport (`transportReady == false`) | `supportsDDC = false`; card visible but greyed out; slider disabled; no further read/write attempts. This is the only path that sets `supportsDDC = false`. |
+| DDC value read timeout (>500 ms) on a transport-ready display | `supportsDDC` stays `true`; `levels[id]` stays `nil`; slider shows at midpoint but remains interactive (drag triggers write normally — many monitors accept writes but refuse VCP reads). |
 | DDC write failure                         | Actor retries once; on second failure, log; thumb greys for ~250 ms; no alert.                         |
 | `bump` with mouse on built-in / unsupported| Fallback to `NSScreen.main`. If that is also unsupported, bump becomes a no-op (no OSD, no write).     |
 | Hot-unplug during in-flight write         | Actor's next write throws (invalid IOAVService); caught silently; UI removes the card on next refresh. |
@@ -499,14 +590,25 @@ Captured separately when the implementation lands; covers:
 ### New SPM dependency
 
 - `https://github.com/reitermarkus/DDC.swift` (MIT) — added to
-  `Package.swift`. Copyright/notice surfaced in the project README's
-  acknowledgements list and (eventually) in an in-app "About" view.
+  `Package.swift`, **conditionally compiled in only for Intel builds**
+  (`#if !arch(arm64)`). Copyright/notice surfaced in README's
+  acknowledgements list and in the eventual in-app "About" view.
+
+### New in-repo code (no third-party dependency)
+
+- `Arm64DDCBackend` — ~150-200 lines of Swift, clean-room implementation of
+  IOAVService-based DDC over I2C for Apple Silicon. Uses public IOKit calls
+  plus `dlsym`-loaded `IOAVServiceCreate`, `IOAVServiceReadI2C`,
+  `IOAVServiceWriteI2C` private symbols. The MonitorControl project's
+  Arm64DDC.swift is GPLv3 and is **not** copied; we reference only its
+  approach, which is non-copyrightable.
 
 ### System frameworks (already linked or trivially available)
 
 - `IOKit` / `CoreDisplay` / `AppKit` — already used by AnyDoor.
-- `OSDUIHelper` (private) — loaded dynamically via `dlopen`; not linked at
-  build time.
+- `OSDUIHub` (private) — loaded dynamically via `dlopen`; not linked at
+  build time. Selector resolution wrapped in defensive guards
+  (`responds(to:)`) so framework path changes degrade gracefully.
 
 ## Open follow-ups (post-v1)
 


### PR DESCRIPTION
## Summary
- Add per-display brightness sliders in a hover popover plus configurable +/- hotkeys that trigger the native macOS chiclet OSD
- Clean-room `Arm64DDCBackend` driving `IOAVService` / `DCPAVServiceProxy` (macOS 26-compatible position pairing) and `IntelDDCBackend` wrapping the MIT-licensed `DDC.swift` SPM dependency
- `DisplayBrightnessService` (MainActor, Observable) with write debounce and a monotonic generation token to drop stale backfill reads after user actions

## Test plan
- [x] `swift build` and `swift test` pass
- [x] Hover the new "屏幕亮度" row: sliders appear for each external display and dragging visibly changes brightness on Apple Silicon
- [x] Bound brightness up/down hotkeys: chiclet OSD shows, brightness steps by 1/16, repeats target the display under the mouse
- [x] Unplug + replug an external display while the app is running: list refreshes without stale entries
- [x] Internal MacBook display is not listed