### PR TITLE
feat: add window layout actions (left/right half, maximize, center)

### DIFF
--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -74,6 +74,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             OCRProvider(),
             QRCodeProvider(),
             PickColorProvider(),
+            WindowLayoutProvider(item: .windowLeftHalf, action: .leftHalf),
+            WindowLayoutProvider(item: .windowRightHalf, action: .rightHalf),
+            WindowLayoutProvider(item: .windowMaximize, action: .maximize),
+            WindowLayoutProvider(item: .windowCenter, action: .center),
         ]
         PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)
 

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -28,6 +28,10 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case brightness
     case brightnessUp
     case brightnessDown
+    case windowLeftHalf
+    case windowRightHalf
+    case windowMaximize
+    case windowCenter
 
     enum Kind: Sendable {
         case toggle
@@ -43,7 +47,8 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
         case .lockScreen, .emptyTrash, .screenshot, .ocr, .qrcode, .pickColor, .displaySleep, .systemSleep,
-             .restartFinder, .restartDock, .restartMenuBar, .flushDNS: return .action
+             .restartFinder, .restartDock, .restartMenuBar, .flushDNS,
+             .windowLeftHalf, .windowRightHalf, .windowMaximize, .windowCenter: return .action
         case .brightness: return .brightnessControl
         case .brightnessUp, .brightnessDown: return .hiddenHotkey
         }
@@ -76,6 +81,10 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .brightness:        return .builtinBrightness
         case .brightnessUp:      return .builtinBrightnessUp
         case .brightnessDown:    return .builtinBrightnessDown
+        case .windowLeftHalf:    return .builtinWindowLeftHalf
+        case .windowRightHalf:   return .builtinWindowRightHalf
+        case .windowMaximize:    return .builtinWindowMaximize
+        case .windowCenter:      return .builtinWindowCenter
         }
     }
 
@@ -106,6 +115,10 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .brightness: return "sun.max"
         case .brightnessUp: return "sun.max"
         case .brightnessDown: return "sun.min"
+        case .windowLeftHalf: return "rectangle.lefthalf.filled"
+        case .windowRightHalf: return "rectangle.righthalf.filled"
+        case .windowMaximize: return "arrow.up.left.and.arrow.down.right"
+        case .windowCenter: return "rectangle.center.inset.filled"
         }
     }
 
@@ -137,6 +150,10 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .brightness: return 650
         case .brightnessUp: return 999_998
         case .brightnessDown: return 999_999
+        case .windowLeftHalf:  return 2000
+        case .windowRightHalf: return 2010
+        case .windowMaximize:  return 2020
+        case .windowCenter:    return 2030
         }
     }
 

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -924,6 +924,62 @@
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Recognition failed" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "识别失败" } }
       }
+    },
+    "builtin.windowCenter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Center Window" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口居中" } }
+      }
+    },
+    "builtin.windowLeftHalf" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window Left Half" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口左半屏" } }
+      }
+    },
+    "builtin.windowMaximize" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Maximize Window" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口最大化" } }
+      }
+    },
+    "builtin.windowRightHalf" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window Right Half" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口右半屏" } }
+      }
+    },
+    "toast.windowLayout.failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window layout failed" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口布局失败" } }
+      }
+    },
+    "toast.windowLayout.fullScreen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Full-screen windows can't be repositioned" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "全屏窗口无法调整" } }
+      }
+    },
+    "toast.windowLayout.needsAccessibility" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enable Accessibility to manage windows" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "请开启辅助功能权限以管理窗口" } }
+      }
+    },
+    "toast.windowLayout.noWindow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No active window to arrange" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "没有可调整的当前窗口" } }
+      }
     }
   },
   "version" : "1.0"

--- a/Sources/AnyDoor/Services/Providers/WindowLayoutProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/WindowLayoutProvider.swift
@@ -1,0 +1,60 @@
+import AppKit
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "windowLayout")
+
+/// Bridges a single `WindowLayoutAction` into the panel's `ActionProvider`
+/// surface. One instance per builtin item; the underlying work is delegated
+/// to the shared `WindowLayoutService`.
+///
+/// `@MainActor` because the layout service is main-actor (it touches
+/// `NSScreen` / `NSWorkspace`). Errors are caught here and surfaced as a
+/// localized toast instead of propagating — a failed layout should never
+/// block the user or crash.
+@MainActor
+final class WindowLayoutProvider: ActionProvider {
+    let itemKey: BuiltinItem
+    private let action: WindowLayoutAction
+
+    init(item: BuiltinItem, action: WindowLayoutAction) {
+        self.itemKey = item
+        self.action = action
+    }
+
+    /// Window layout uses Accessibility, which the app already prompts for
+    /// at startup via `HotkeyService`. The row itself stays `.notRequired`
+    /// so the menu-bar UI doesn't double up on a permission badge; when AX
+    /// is actually missing at invocation time, `run()` surfaces a toast
+    /// pointing the user at the system setting.
+    var permission: PermissionStatus { .notRequired }
+
+    func run() async throws {
+        do {
+            try WindowLayoutService.shared.apply(action)
+        } catch let error as WindowLayoutError {
+            logger.error("Window layout \(self.action.rawValue) failed: \(String(describing: error))")
+            ToastPresenter.shared.show(.failure(Self.message(for: error)))
+        } catch {
+            logger.error("Window layout \(self.action.rawValue) failed: \(error)")
+            ToastPresenter.shared.show(.failure(L(.toastWindowLayoutFailed)))
+        }
+    }
+
+    /// Map a `WindowLayoutError` to the user-facing toast string. Anything
+    /// the user might be able to fix gets a specific hint; AX-internal
+    /// failures collapse into the generic "operation failed" message so
+    /// the UI doesn't leak status codes.
+    @MainActor
+    private static func message(for error: WindowLayoutError) -> String {
+        switch error {
+        case .missingAccessibilityPermission:
+            return L(.toastWindowLayoutNeedsAccessibility)
+        case .noFrontmostApplication, .noFocusedWindow:
+            return L(.toastWindowLayoutNoWindow)
+        case .fullScreenWindowNotSupported:
+            return L(.toastWindowLayoutFullScreen)
+        case .noScreenAvailable, .axCallFailed:
+            return L(.toastWindowLayoutFailed)
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/WindowLayoutService.swift
+++ b/Sources/AnyDoor/Services/WindowLayoutService.swift
@@ -1,0 +1,267 @@
+import AppKit
+import ApplicationServices
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "windowLayout")
+
+/// A single, atomic window layout operation requested by the user.
+///
+/// First version handles the four most common Rectangle-style commands
+/// against the currently focused window. Snap-to-grid, custom thirds and
+/// multi-display matching are intentionally out of scope.
+enum WindowLayoutAction: String, Sendable, CaseIterable {
+    case leftHalf
+    case rightHalf
+    case maximize
+    case center
+
+    var symbol: String {
+        switch self {
+        case .leftHalf:  return "rectangle.lefthalf.filled"
+        case .rightHalf: return "rectangle.righthalf.filled"
+        case .maximize:  return "arrow.up.left.and.arrow.down.right"
+        case .center:    return "rectangle.center.inset.filled"
+        }
+    }
+}
+
+/// Pure geometry used by the AX bridge. Kept separate so it can be unit
+/// tested without spinning up the Accessibility API or `NSScreen`.
+///
+/// Both `windowFrame` and `visibleFrame` are expected in AX coordinate
+/// space (origin top-left of the primary display, Y axis growing down).
+/// The function only manipulates rectangles — coordinate conversion is
+/// the AX bridge's job.
+enum WindowLayoutGeometry {
+    static func targetRect(
+        action: WindowLayoutAction,
+        windowFrame: CGRect,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        switch action {
+        case .leftHalf:
+            // floor() keeps left/right halves equal width even at odd or
+            // fractional visible widths, at the cost of at most a 1pt
+            // gutter — preferable to overlap.
+            let half = floor(visibleFrame.width / 2)
+            return CGRect(x: visibleFrame.minX,
+                          y: visibleFrame.minY,
+                          width: half,
+                          height: visibleFrame.height)
+        case .rightHalf:
+            let half = floor(visibleFrame.width / 2)
+            return CGRect(x: visibleFrame.maxX - half,
+                          y: visibleFrame.minY,
+                          width: half,
+                          height: visibleFrame.height)
+        case .maximize:
+            return visibleFrame
+        case .center:
+            // Clamp oversized windows to the visible region, then center
+            // the (possibly clamped) size inside it.
+            let width = min(windowFrame.width, visibleFrame.width)
+            let height = min(windowFrame.height, visibleFrame.height)
+            let x = visibleFrame.minX + (visibleFrame.width - width) / 2
+            let y = visibleFrame.minY + (visibleFrame.height - height) / 2
+            return CGRect(x: x, y: y, width: width, height: height)
+        }
+    }
+}
+
+/// Reasons a `WindowLayoutService.apply(_:)` call may fail.
+///
+/// All paths surface as `Error`s the caller can format into a toast.
+enum WindowLayoutError: Error, Sendable, Equatable {
+    case missingAccessibilityPermission
+    case noFrontmostApplication
+    case noFocusedWindow
+    case fullScreenWindowNotSupported
+    case noScreenAvailable
+    case axCallFailed(attribute: String, code: Int32)
+}
+
+/// Bridges layout actions into the Accessibility API.
+///
+/// `@MainActor`-isolated because `NSWorkspace.shared.frontmostApplication`
+/// and `NSScreen.screens` are main-actor in Swift 6 strict mode. AX calls
+/// themselves are thread-safe but cheap, so running on the main thread is
+/// fine for the latency window of a hotkey press.
+@MainActor
+final class WindowLayoutService {
+    static let shared = WindowLayoutService()
+
+    private init() {}
+
+    /// Apply `action` to the system's focused window.
+    ///
+    /// On success the function returns once `kAXPositionAttribute` and
+    /// `kAXSizeAttribute` have been written. On failure throws a
+    /// `WindowLayoutError`; callers (e.g., `WindowLayoutProvider`) are
+    /// responsible for user-facing messaging.
+    func apply(_ action: WindowLayoutAction) throws {
+        guard AXIsProcessTrusted() else {
+            throw WindowLayoutError.missingAccessibilityPermission
+        }
+        guard let app = NSWorkspace.shared.frontmostApplication else {
+            throw WindowLayoutError.noFrontmostApplication
+        }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        let window = try copyFocusedWindow(from: axApp)
+        try assertNotFullScreen(window)
+
+        let currentFrame = try readFrame(of: window)
+        let visible = try visibleFrameInAXCoords(containing: currentFrame)
+        let target = WindowLayoutGeometry.targetRect(
+            action: action,
+            windowFrame: currentFrame,
+            visibleFrame: visible
+        )
+
+        // Order matters on some apps: setting size before position avoids
+        // a transient frame where the new position lands the old size off
+        // the target display. The reverse can clip resizable insets in
+        // Catalyst windows. Position-first is the more common convention
+        // for Rectangle and works for the standard window classes we care
+        // about here.
+        try writePosition(of: window, to: target.origin)
+        try writeSize(of: window, to: target.size)
+    }
+
+    // MARK: - AX helpers
+
+    private func copyFocusedWindow(from axApp: AXUIElement) throws -> AXUIElement {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            axApp, kAXFocusedWindowAttribute as CFString, &ref
+        )
+        guard err == .success, let value = ref else {
+            // The app may simply have no focused window (e.g. Finder with
+            // the desktop frontmost). Treat any non-success as no-window.
+            throw WindowLayoutError.noFocusedWindow
+        }
+        // AX attribute returns an AXUIElement; the cast is safe because
+        // kAXFocusedWindowAttribute is documented to return one.
+        return value as! AXUIElement
+    }
+
+    private func assertNotFullScreen(_ window: AXUIElement) throws {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            window, "AXFullScreen" as CFString, &ref
+        )
+        // Attribute may legitimately be absent on apps that don't expose
+        // it. Treat that as "not full-screen" rather than an error.
+        if err == .success, let value = ref as? Bool, value {
+            throw WindowLayoutError.fullScreenWindowNotSupported
+        }
+    }
+
+    private func readFrame(of window: AXUIElement) throws -> CGRect {
+        let position = try readPoint(of: window, attribute: kAXPositionAttribute)
+        let size = try readSize(of: window, attribute: kAXSizeAttribute)
+        return CGRect(origin: position, size: size)
+    }
+
+    private func readPoint(of element: AXUIElement, attribute: String) throws -> CGPoint {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &ref)
+        guard err == .success, let value = ref else {
+            throw WindowLayoutError.axCallFailed(attribute: attribute, code: err.rawValue)
+        }
+        var point = CGPoint.zero
+        let axValue = value as! AXValue
+        guard AXValueGetValue(axValue, .cgPoint, &point) else {
+            throw WindowLayoutError.axCallFailed(attribute: attribute, code: -1)
+        }
+        return point
+    }
+
+    private func readSize(of element: AXUIElement, attribute: String) throws -> CGSize {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &ref)
+        guard err == .success, let value = ref else {
+            throw WindowLayoutError.axCallFailed(attribute: attribute, code: err.rawValue)
+        }
+        var size = CGSize.zero
+        let axValue = value as! AXValue
+        guard AXValueGetValue(axValue, .cgSize, &size) else {
+            throw WindowLayoutError.axCallFailed(attribute: attribute, code: -1)
+        }
+        return size
+    }
+
+    private func writePosition(of window: AXUIElement, to origin: CGPoint) throws {
+        var point = origin
+        guard let value = AXValueCreate(.cgPoint, &point) else {
+            throw WindowLayoutError.axCallFailed(attribute: kAXPositionAttribute, code: -1)
+        }
+        let err = AXUIElementSetAttributeValue(
+            window, kAXPositionAttribute as CFString, value
+        )
+        guard err == .success else {
+            throw WindowLayoutError.axCallFailed(attribute: kAXPositionAttribute, code: err.rawValue)
+        }
+    }
+
+    private func writeSize(of window: AXUIElement, to size: CGSize) throws {
+        var s = size
+        guard let value = AXValueCreate(.cgSize, &s) else {
+            throw WindowLayoutError.axCallFailed(attribute: kAXSizeAttribute, code: -1)
+        }
+        let err = AXUIElementSetAttributeValue(
+            window, kAXSizeAttribute as CFString, value
+        )
+        guard err == .success else {
+            throw WindowLayoutError.axCallFailed(attribute: kAXSizeAttribute, code: err.rawValue)
+        }
+    }
+
+    // MARK: - Coordinate conversion
+
+    /// Returns the visible region (Dock + menu bar excluded) of the
+    /// screen whose AX rect mostly overlaps `windowAXFrame`, converted
+    /// into AX (top-left origin) coordinates.
+    ///
+    /// Falls back to the primary screen if no overlap can be determined,
+    /// matching the "use main visibleFrame when matching is unreliable"
+    /// rule.
+    private func visibleFrameInAXCoords(containing windowAXFrame: CGRect) throws -> CGRect {
+        let screens = NSScreen.screens
+        guard let primary = screens.first else {
+            throw WindowLayoutError.noScreenAvailable
+        }
+        let primaryHeight = primary.frame.height
+
+        // Build AX rects for each screen and pick the one with the largest
+        // intersection area with the window. Equal-area ties tip to the
+        // earlier screen in `NSScreen.screens`, which matches the order
+        // macOS reports.
+        var best: (screen: NSScreen, area: CGFloat)?
+        for screen in screens {
+            let frameAX = Self.toAXCoords(rect: screen.frame, primaryHeight: primaryHeight)
+            let area = frameAX.intersection(windowAXFrame).standardized.area
+            if best == nil || area > best!.area {
+                best = (screen, area)
+            }
+        }
+
+        let chosen = best?.screen ?? primary
+        return Self.toAXCoords(rect: chosen.visibleFrame, primaryHeight: primaryHeight)
+    }
+
+    /// Convert a Cocoa-coordinate rect (origin bottom-left, Y up,
+    /// referenced to the primary display) into AX coordinates (origin
+    /// top-left of the primary display, Y down).
+    nonisolated static func toAXCoords(rect: CGRect, primaryHeight: CGFloat) -> CGRect {
+        CGRect(
+            x: rect.minX,
+            y: primaryHeight - rect.maxY,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat { isNull ? 0 : width * height }
+}

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -30,6 +30,10 @@ enum L10n {
         case builtinScreenshot = "builtin.screenshot"
         case builtinShowHiddenFiles = "builtin.showHiddenFiles"
         case builtinSystemSleep = "builtin.systemSleep"
+        case builtinWindowCenter = "builtin.windowCenter"
+        case builtinWindowLeftHalf = "builtin.windowLeftHalf"
+        case builtinWindowMaximize = "builtin.windowMaximize"
+        case builtinWindowRightHalf = "builtin.windowRightHalf"
         case menubarIconAppConnected = "menubarIcon.appConnected"
         case menubarIconBolt = "menubarIcon.bolt"
         case menubarIconCommand = "menubarIcon.command"
@@ -137,6 +141,10 @@ enum L10n {
         case toastPickColorFailed = "toast.pickColor.failed"
         case toastQrcodeNoCode = "toast.qrcode.noCode"
         case toastRecognitionFailed = "toast.recognitionFailed"
+        case toastWindowLayoutFailed = "toast.windowLayout.failed"
+        case toastWindowLayoutFullScreen = "toast.windowLayout.fullScreen"
+        case toastWindowLayoutNeedsAccessibility = "toast.windowLayout.needsAccessibility"
+        case toastWindowLayoutNoWindow = "toast.windowLayout.noWindow"
         // Migration tasks append cases here. Keep alphabetical by raw value.
     }
 }

--- a/Tests/AnyDoorTests/WindowLayoutGeometryTests.swift
+++ b/Tests/AnyDoorTests/WindowLayoutGeometryTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import AnyDoor
+
+/// Pure-function tests for `WindowLayoutGeometry.targetRect`.
+///
+/// Inputs are plain `CGRect`s in AX (top-left origin) coordinates; no
+/// Accessibility API or NSScreen access. The geometry layer is the only
+/// piece of the layout pipeline that is unit-tested — the AX bridge
+/// (`WindowLayoutService`) requires real focused windows and is exercised
+/// manually.
+final class WindowLayoutGeometryTests: XCTestCase {
+
+    // A simple primary-display visible region, top-left at (0,25) to mimic
+    // a 25pt menu bar above the visible area.
+    private let visible = CGRect(x: 0, y: 25, width: 1440, height: 875)
+
+    func testLeftHalf() {
+        let window = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let target = WindowLayoutGeometry.targetRect(
+            action: .leftHalf, windowFrame: window, visibleFrame: visible
+        )
+        XCTAssertEqual(target, CGRect(x: 0, y: 25, width: 720, height: 875))
+    }
+
+    func testRightHalf() {
+        let window = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let target = WindowLayoutGeometry.targetRect(
+            action: .rightHalf, windowFrame: window, visibleFrame: visible
+        )
+        XCTAssertEqual(target, CGRect(x: 720, y: 25, width: 720, height: 875))
+    }
+
+    func testMaximize() {
+        let window = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let target = WindowLayoutGeometry.targetRect(
+            action: .maximize, windowFrame: window, visibleFrame: visible
+        )
+        XCTAssertEqual(target, visible)
+    }
+
+    func testCenterPreservesWindowSize() {
+        let window = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let target = WindowLayoutGeometry.targetRect(
+            action: .center, windowFrame: window, visibleFrame: visible
+        )
+        // Window 400x300 inside 1440x875 visible at origin (0,25):
+        // x = 0 + (1440 - 400) / 2 = 520
+        // y = 25 + (875 - 300) / 2 = 312.5
+        XCTAssertEqual(target.width, 400)
+        XCTAssertEqual(target.height, 300)
+        XCTAssertEqual(target.minX, 520)
+        XCTAssertEqual(target.minY, 312.5)
+    }
+
+    func testCenterClampsOversizedWindow() {
+        // Window taller and wider than the visible region — center must clamp
+        // both dimensions to visibleFrame size and place the window flush
+        // with the visible region's top-left.
+        let window = CGRect(x: -200, y: -200, width: 2000, height: 1500)
+        let target = WindowLayoutGeometry.targetRect(
+            action: .center, windowFrame: window, visibleFrame: visible
+        )
+        XCTAssertEqual(target, visible)
+    }
+
+    func testOddVisibleWidthIsStableAcrossLeftAndRight() {
+        // Odd width: floor(1001/2) == 500. Both halves get equal 500-wide
+        // rects, leaving a 1pt gutter the user won't notice — but the
+        // result must be deterministic.
+        let oddVisible = CGRect(x: 0, y: 0, width: 1001, height: 800)
+        let window = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let left = WindowLayoutGeometry.targetRect(
+            action: .leftHalf, windowFrame: window, visibleFrame: oddVisible
+        )
+        let right = WindowLayoutGeometry.targetRect(
+            action: .rightHalf, windowFrame: window, visibleFrame: oddVisible
+        )
+        XCTAssertEqual(left.width, 500)
+        XCTAssertEqual(right.width, 500)
+        XCTAssertEqual(left.minX, 0)
+        XCTAssertEqual(right.maxX, 1001)
+    }
+
+    func testFractionalVisibleFrameRoundsConsistently() {
+        // Notch displays expose visibleFrame heights with .5pt fractions.
+        // Result must be deterministic and the two halves must not overlap.
+        let frac = CGRect(x: 0.5, y: 24.5, width: 1440.5, height: 874.5)
+        let window = CGRect(x: 100, y: 100, width: 400, height: 300)
+        let left = WindowLayoutGeometry.targetRect(
+            action: .leftHalf, windowFrame: window, visibleFrame: frac
+        )
+        let right = WindowLayoutGeometry.targetRect(
+            action: .rightHalf, windowFrame: window, visibleFrame: frac
+        )
+        XCTAssertEqual(left.minX, frac.minX)
+        XCTAssertEqual(left.minY, frac.minY)
+        XCTAssertEqual(left.height, frac.height)
+        XCTAssertEqual(right.maxX, frac.maxX)
+        XCTAssertLessThanOrEqual(left.maxX, right.minX,
+                                 "halves must not overlap on fractional widths")
+    }
+
+    func testCenterWithExactlyVisibleSizedWindow() {
+        // Edge case: window already exactly matches visibleFrame. Center
+        // must be a no-op (or produce the same rect).
+        let window = visible
+        let target = WindowLayoutGeometry.targetRect(
+            action: .center, windowFrame: window, visibleFrame: visible
+        )
+        XCTAssertEqual(target, visible)
+    }
+}


### PR DESCRIPTION
## Summary

Adds four Rectangle-style window layout actions that operate on the
current frontmost window:

- Window Left Half
- Window Right Half
- Maximize Window
- Center Window

Each is a regular `.action` BuiltinItem, so it participates in the
existing panel (show / hide, reorder, individual hotkey binding) and
the existing hotkey snapshot pipeline — no changes to the CGEvent tap
or dispatch path.

## Architecture

- `WindowLayoutAction` enum + `WindowLayoutGeometry` pure functions
  in `Services/WindowLayoutService.swift`. Geometry is fully
  unit-tested without Accessibility / `NSScreen`.
- `WindowLayoutService` (`@MainActor`): locates the frontmost app's
  focused window via `kAXFocusedWindowAttribute`, reads/writes
  `kAXPositionAttribute` and `kAXSizeAttribute`, picks the screen
  with the largest AX-rect overlap, converts Cocoa `visibleFrame`
  into AX coordinates, and refuses to act on full-screen windows.
- `WindowLayoutProvider(item:action:)`: one ActionProvider per
  layout, sharing the service. Errors surface as localized toasts;
  the operation never crashes the app.

## Scope (first version)

In scope:
- Frontmost focused window only
- Single layout per action (no thirds / quarters / grids)
- Screen containing the window, fallback to primary

Intentionally out of scope:
- Drag-to-snap, window picker, multi-display matching beyond the
  containing screen, window memory, grid presets, thirds/quarters

## Permissions

No new permissions. Window manipulation uses the same Accessibility
permission that `HotkeyService` already prompts for at launch. If
the user later revokes it, `apply(_:)` throws and surfaces a
localized toast pointing at the system setting.

## Test plan

- [x] `swift test --filter WindowLayout` — 8/8 geometry tests
      (left/right/maximize/center + center clamp + odd width +
      fractional frame + exact-size edge)
- [x] `swift test --filter BuiltinItemLocalizationTests` — passes
- [x] `swift test --filter BuiltinPreferenceSeederTests` — passes
- [x] `swift test --filter LocalizationCoverageTests` — passes
- [x] `swift test --filter HotkeyConflictTests` — passes
- [x] `swift test --filter PanelStoreTests` — passes
- [x] `swift build` — succeeds
- [x] Manual: bind hotkeys for the four layouts, verify they apply
      to standard resizable windows (Safari, Finder, Terminal) and
      no-op gracefully on full-screen / desktop-frontmost / system
      windows