### PR TITLE
feat(command-palette): installed apps, sticky headers, Liquid Glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Command Palette: every installed app on the system is now searchable, not
+  just apps the user explicitly bound to a hotkey. `CommandPaletteWindowController`
+  scans via `InstalledAppsScanner` when the palette opens, filters out bundle
+  IDs already represented by an app-shortcut row, and appends the remaining
+  apps to the Applications section after the bound rows. Selecting one routes
+  through `AppSwitcher.toggle`, identical to the bound-shortcut path. A new
+  `PanelEntry.Source.installedApp(bundleID:path:)` variant carries the
+  necessary data; it is command-palette-only and never surfaces in the menu
+  bar panel or settings UI.
+- Command Palette: sticky section headers. The Applications / Window Layout /
+  Commands labels stay pinned to the top of the scroll viewport as their rows
+  scroll past, matching the Raycast feel. Rows share the pinned header's
+  material layering on macOS < 26 so the header/row boundary has no visible
+  double-material seam. Arrow-key navigation now compensates for the pinned
+  header: moving up scrolls to the row above the target so the target lands
+  one row below the sticky band instead of hidden behind it, and a 0-height
+  top sentinel anchors the `newIndex == 0` case so the first section header
+  lands naturally above row 0 instead of pinning over it.
+
+### Changed
+
+- Menu bar panel: dismiss on Escape. The panel is a non-activating `NSPanel`
+  so a SwiftUI `keyDown` handler would never fire; a global + local
+  `NSEvent` monitor is now installed while the panel is visible so Escape
+  closes it whether AnyDoor or another app is frontmost.
+- Menu bar panel header removed. The AnyDoor title was redundant with the
+  status item icon, and the `%lld enabled` count was low-value noise on
+  every open. Dropping the header HStack also removes its now-orphaned
+  localization entries.
+- Menu bar panel footer removed. The Settings gear and Quit power icons
+  sat 2pt apart and were easy to mis-tap; both actions are already exposed
+  via the status item's right-click menu with the standard ⌘, and ⌘Q
+  shortcuts.
+- Command Palette adopts Liquid Glass on macOS 26+. Two new helpers in
+  `LiquidGlassCompatibility` — `adaptivePanelSurface(cornerRadius:)` for
+  non-interactive panel backgrounds and `adaptiveStickyHeaderSurface()` for
+  full-width pinned headers — apply `.glassEffect(.regular, in:)` and
+  `.background(.thinMaterial)` respectively, with `.thickMaterial` fallbacks
+  on earlier systems. The outer palette becomes one Liquid Glass surface so
+  the search field, rows, and headers read as a single material; per-row
+  `.thickMaterial` is dropped on macOS 26 to avoid double-layer composites
+  that previously made the list area look noticeably darker than the search
+  field. The sticky header uses `.thinMaterial` — heavy materials or a
+  nested `glassEffect` rendered as a dark opaque strip that broke the
+  design language.
+- Command Palette row icons: SF Symbols dropped from 18pt to 15pt so they
+  read at the same visual weight as the NSImage app icons, which carry
+  built-in transparent padding the symbols lacked.
+
 ## [1.6.0] - 2026-05-27
 
 ### Added

--- a/Sources/AnyDoor/Models/PanelEntry.swift
+++ b/Sources/AnyDoor/Models/PanelEntry.swift
@@ -45,11 +45,12 @@ struct HotkeyDescriptor: Hashable, Sendable {
 /// A unified row visible to the SwiftUI views. Built from one of three sources.
 struct PanelEntry: Identifiable, Hashable {
     enum Source: Hashable {
-        case appShortcut(UUID)         // KeyBinding.id
+        case appShortcut(UUID)                         // KeyBinding.id
         case builtin(BuiltinItem)
+        case installedApp(bundleID: String, path: String) // Command-palette-only: installed but unbound
     }
 
-    let id: String                     // "app:<uuid>" or "builtin:<key>"
+    let id: String                     // "app:<uuid>" or "builtin:<key>" or "installedApp:<bundleID>"
     let source: Source
     let displayOrder: Double
     let isVisible: Bool
@@ -63,8 +64,9 @@ struct PanelEntry: Identifiable, Hashable {
 
     static func id(for source: Source) -> String {
         switch source {
-        case .appShortcut(let id): return "app:\(id.uuidString)"
-        case .builtin(let item):   return "builtin:\(item.rawValue)"
+        case .appShortcut(let id):                return "app:\(id.uuidString)"
+        case .builtin(let item):                  return "builtin:\(item.rawValue)"
+        case .installedApp(let bundleID, _):      return "installedApp:\(bundleID)"
         }
     }
 
@@ -76,6 +78,7 @@ struct PanelEntry: Identifiable, Hashable {
         switch source {
         case .appShortcut: return title
         case .builtin(let item): return L(item.titleKey)
+        case .installedApp: return title
         }
     }
 }

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -64,13 +64,6 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "设置" } }
       }
     },
-    "panel.header.enabledCount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%lld enabled" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "%lld 个已启用" } }
-      }
-    },
     "panel.row.needsPermission" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -17,6 +17,8 @@ final class MenuBarController {
     private var hostingView: NSHostingView<AnyView>?
     private var globalClickMonitor: Any?
     private var localClickMonitor: Any?
+    private var globalKeyMonitor: Any?
+    private var localKeyMonitor: Any?
 
     init(modelContainer: ModelContainer) {
         self.modelContainer = modelContainer
@@ -163,10 +165,12 @@ final class MenuBarController {
         panel.orderFrontRegardless()
         button.highlight(true)
         installClickMonitors()
+        installKeyMonitors()
     }
 
     private func hidePanel() {
         removeClickMonitors()
+        removeKeyMonitors()
         statusItem?.button?.highlight(false)
         panel?.orderOut(nil)
         panel?.contentView = nil
@@ -239,6 +243,36 @@ final class MenuBarController {
         if let localClickMonitor { NSEvent.removeMonitor(localClickMonitor) }
         globalClickMonitor = nil
         localClickMonitor = nil
+    }
+
+    // MARK: - Escape-to-dismiss
+
+    /// Hide the panel when the user presses Escape. The panel is a
+    /// `.nonactivatingPanel`, so it never becomes key — a plain `.keyDown`
+    /// handler in the SwiftUI view wouldn't fire. A global monitor catches
+    /// Escape when another app is frontmost; the local monitor covers the
+    /// rare case where our own app is active (e.g. Settings window open).
+    private func installKeyMonitors() {
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: .keyDown
+        ) { [weak self] event in
+            guard event.keyCode == 53 else { return }
+            MainActor.assumeIsolated { self?.hidePanel() }
+        }
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: .keyDown
+        ) { [weak self] event in
+            guard event.keyCode == 53 else { return event }
+            MainActor.assumeIsolated { self?.hidePanel() }
+            return nil
+        }
+    }
+
+    private func removeKeyMonitors() {
+        if let globalKeyMonitor { NSEvent.removeMonitor(globalKeyMonitor) }
+        if let localKeyMonitor { NSEvent.removeMonitor(localKeyMonitor) }
+        globalKeyMonitor = nil
+        localKeyMonitor = nil
     }
 
     // MARK: - Icon image

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -58,7 +58,6 @@ enum L10n {
         case panelAppShortcutToggleHelp = "panel.appShortcut.toggleHelp"
         case panelFooterQuit = "panel.footer.quit"
         case panelFooterSettings = "panel.footer.settings"
-        case panelHeaderEnabledCount = "panel.header.enabledCount"
         case panelRowNeedsPermission = "panel.row.needsPermission"
         case clipboardEmpty = "clipboard.empty"
         case clipboardHeaderCountSuffix = "clipboard.header.countSuffix"

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -288,6 +288,10 @@ private struct CommandPaletteRow: View {
                     .font(.system(size: 18))
                     .foregroundStyle(.secondary)
             }
+        case .installedApp(_, let path):
+            Image(nsImage: NSWorkspace.shared.icon(forFile: path))
+                .resizable()
+                .interpolation(.high)
         case .builtin:
             Image(systemName: entry.symbol)
                 .font(.system(size: 18))

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -83,7 +83,12 @@ struct CommandPalettePicker: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(.thickMaterial)
+        // Liquid Glass on macOS 26+; .thickMaterial on earlier systems.
+        // Driving the whole palette from one surface keeps the search field,
+        // rows, and section headers visually consistent — on macOS 26 the
+        // TextField picks up the system glass treatment automatically, which
+        // used to clash with the per-row .thickMaterial below.
+        .adaptivePanelSurface(cornerRadius: 16)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)
@@ -168,10 +173,12 @@ struct CommandPalettePicker: View {
                                     onSelect: { onSelect(entry) }
                                 )
                                 .id(entry.id)
-                                // Rows share the pinned header's material
-                                // layering so the header/row boundary has no
-                                // visible double-material seam.
-                                .background(.thickMaterial)
+                                // Pre-macOS-26 fallback: rows share the pinned
+                                // header's material layering so the header/row
+                                // boundary has no visible double-material
+                                // seam. On macOS 26+ rows stay transparent on
+                                // top of the panel's Liquid Glass surface.
+                                .legacyMaterialBackground()
                             }
                         } header: {
                             sectionHeader(titleKey: section.titleKey)
@@ -213,10 +220,11 @@ struct CommandPalettePicker: View {
             // when it stuck to the top.
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
-            // Opaque background so rows scrolling underneath the pinned
-            // header are masked instead of bleeding through the palette's
-            // material.
-            .background(.thickMaterial)
+            // On macOS 26+ the header uses Liquid Glass so it reads as a
+            // distinct band on top of the panel's glass while still masking
+            // rows that scroll underneath. Earlier systems fall back to
+            // .thickMaterial for the same masking job.
+            .adaptiveStickyHeaderSurface()
     }
 }
 

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -277,8 +277,11 @@ private struct CommandPaletteRow: View {
                     .resizable()
                     .interpolation(.high)
             } else {
+                // SF Symbols carry no built-in transparent padding, so they
+                // need a smaller point size than the 22pt frame to read at
+                // the same visual weight as NSImage app icons.
                 Image(systemName: entry.symbol)
-                    .font(.system(size: 18))
+                    .font(.system(size: 15))
                     .foregroundStyle(.secondary)
             }
         case .installedApp(_, let path):
@@ -287,7 +290,7 @@ private struct CommandPaletteRow: View {
                 .interpolation(.high)
         case .builtin:
             Image(systemName: entry.symbol)
-                .font(.system(size: 18))
+                .font(.system(size: 15))
                 .foregroundStyle(.primary)
         }
     }

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -142,96 +142,81 @@ struct CommandPalettePicker: View {
         .frame(maxWidth: .infinity, minHeight: 320, maxHeight: .infinity)
     }
 
-    /// Pre-flattens sections into one stream of rows so a single ForEach can
-    /// render headers + rows in order while assigning a globally unique flat
-    /// index to each row (matched against `state.selectedIndex`).
-    private struct RowItem: Identifiable {
-        let globalIndex: Int
-        let entry: PanelEntry
-        let headerTitleKey: L10n.Key?
-        let isFirstSection: Bool
-        var id: String { entry.id }
-    }
-
-    private var rowItems: [RowItem] {
-        var items: [RowItem] = []
-        var globalIndex = 0
-        for (sectionIdx, section) in state.filteredSections.enumerated() {
-            for (entryIdx, entry) in section.entries.enumerated() {
-                items.append(RowItem(
-                    globalIndex: globalIndex,
-                    entry: entry,
-                    headerTitleKey: entryIdx == 0 ? section.titleKey : nil,
-                    isFirstSection: sectionIdx == 0
-                ))
-                globalIndex += 1
-            }
-        }
-        return items
-    }
-
     private var entryList: some View {
         ScrollViewReader { proxy in
+            let entries = state.flatEntries
+            let selectedID: String? = entries.indices.contains(state.selectedIndex)
+                ? entries[state.selectedIndex].id
+                : nil
+
             ScrollView {
-                // Eager VStack (not Lazy) so ScrollViewReader.scrollTo always
-                // resolves to a fully-laid-out row, even when section headers
-                // appear above. With section grouping in play, Lazy layout
-                // caused selectedIndex changes to land the row past the
-                // visible bottom.
-                VStack(spacing: 0) {
-                    ForEach(rowItems) { item in
-                        // Wrap the optional header + row in one VStack so the
-                        // `.id` covers both. ScrollViewReader then treats the
-                        // header as part of the row's bounds — scrolling to
-                        // the first row of a section also brings its header
-                        // into view, instead of clipping it above the edge.
-                        VStack(spacing: 0) {
-                            if let key = item.headerTitleKey {
-                                sectionHeader(titleKey: key, isFirst: item.isFirstSection)
+                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    // Sentinel at the very top of the scroll content. Scrolling
+                    // here forces scroll offset back to 0 so the first section
+                    // header sits naturally above row 0 instead of pinning over
+                    // it (which would hide row 0 when newIndex reaches 0).
+                    Color.clear
+                        .frame(height: 0)
+                        .id("top-sentinel")
+                    ForEach(state.filteredSections) { section in
+                        Section {
+                            ForEach(section.entries) { entry in
+                                CommandPaletteRow(
+                                    entry: entry,
+                                    hyperFlags: state.hyperFlags,
+                                    isSelected: entry.id == selectedID,
+                                    onSelect: { onSelect(entry) }
+                                )
+                                .id(entry.id)
+                                // Rows share the pinned header's material
+                                // layering so the header/row boundary has no
+                                // visible double-material seam.
+                                .background(.thickMaterial)
                             }
-                            CommandPaletteRow(
-                                entry: item.entry,
-                                hyperFlags: state.hyperFlags,
-                                isSelected: item.globalIndex == state.selectedIndex,
-                                onSelect: { onSelect(item.entry) }
-                            )
+                        } header: {
+                            sectionHeader(titleKey: section.titleKey)
                         }
-                        .id(item.entry.id)
                     }
                 }
             }
-            // safeAreaInset reserves non-scrolling space at the top/bottom of
-            // the ScrollView. SwiftUI's scrollTo respects the safe area, so
-            // when a row reaches the end of the content, it stops 12pt above
-            // the panel edge instead of touching it.
-            .safeAreaInset(edge: .top, spacing: 0) { Color.clear.frame(height: 8) }
             .safeAreaInset(edge: .bottom, spacing: 0) { Color.clear.frame(height: 8) }
             .frame(minHeight: 320, maxHeight: .infinity)
-            .onChange(of: state.selectedIndex) { _, newIndex in
-                let entries = state.flatEntries
+            .onChange(of: state.selectedIndex) { oldIndex, newIndex in
                 guard entries.indices.contains(newIndex) else { return }
-                // No anchor → SwiftUI picks the minimum scroll required to
-                // bring the target into view. Matches Raycast: in-view rows
-                // don't trigger any scroll, and rows just off-screen scroll
-                // just enough to reveal them at the closest edge.
-                proxy.scrollTo(entries[newIndex].id)
+                if newIndex == 0 {
+                    // Top of list — scroll to the sentinel so the first
+                    // section header lands naturally at the top (not pinning
+                    // over row 0).
+                    proxy.scrollTo("top-sentinel")
+                } else if newIndex < oldIndex {
+                    // Nav up. ScrollTo the row above the target so the
+                    // target lands one row down — visible just below the
+                    // pinned section header instead of hidden behind it.
+                    proxy.scrollTo(entries[newIndex - 1].id)
+                } else {
+                    proxy.scrollTo(entries[newIndex].id)
+                }
             }
         }
     }
 
-    private func sectionHeader(titleKey: L10n.Key, isFirst: Bool) -> some View {
+    private func sectionHeader(titleKey: L10n.Key) -> some View {
         LocalizedText(titleKey)
             .font(.system(size: 11, weight: .semibold))
             .textCase(.uppercase)
             .foregroundStyle(.secondary)
             .tracking(0.6)
             .padding(.horizontal, 22)
-            // Uniform top spacing across sections so the first label has the
-            // same visual rhythm as later ones. The LazyVStack's outer 12pt
-            // padding still keeps the very top from clipping the first header.
-            .padding(.top, isFirst ? 4 : 14)
-            .padding(.bottom, 6)
+            // Uniform vertical padding regardless of section index so any
+            // section that becomes the pinned one has the same height. The
+            // `isFirst` differential collapsed the first section's band
+            // when it stuck to the top.
+            .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
+            // Opaque background so rows scrolling underneath the pinned
+            // header are masked instead of bleeding through the palette's
+            // material.
+            .background(.thickMaterial)
     }
 }
 

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -105,10 +105,41 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         }
 
         let appShortcuts = store.appShortcutChildren.filter(\.isVisible)
-        if !appShortcuts.isEmpty {
+        let boundBundleIDs: Set<String> = Set(appShortcuts.compactMap { entry in
+            guard case .appShortcut(let id) = entry.source,
+                  let binding = store.binding(id: id) else { return nil }
+            return binding.appBundleID
+        })
+
+        // Apps installed on the system but not bound to a hotkey are listed
+        // after the bound rows in the same section so they're searchable from
+        // the palette without polluting the menu-bar panel itself.
+        let scanned = InstalledAppsScanner.scan()
+        let unboundOrder = Double(appShortcuts.count) * 100 + 1_000_000
+        let installedExtras: [PanelEntry] = scanned
+            .filter { !boundBundleIDs.contains($0.bundleID) }
+            .enumerated()
+            .map { offset, app in
+                PanelEntry(
+                    id: PanelEntry.id(for: .installedApp(bundleID: app.bundleID, path: app.path)),
+                    source: .installedApp(bundleID: app.bundleID, path: app.path),
+                    displayOrder: unboundOrder + Double(offset),
+                    isVisible: true,
+                    hotkey: nil,
+                    title: app.displayName,
+                    subtitle: nil,
+                    symbol: "app.fill",
+                    kind: .submenu,
+                    toggleState: nil,
+                    permission: .notRequired
+                )
+            }
+
+        let combined = appShortcuts + installedExtras
+        if !combined.isEmpty {
             sections.append(CommandPaletteSection(
                 titleKey: .commandPaletteSectionApplications,
-                entries: appShortcuts
+                entries: combined
             ))
         }
 

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -173,6 +173,8 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         case .appShortcut(let id):
             guard let binding = PanelStore.shared.binding(id: id) else { return }
             AppSwitcher.toggle(bundleID: binding.appBundleID, appPath: binding.appPath)
+        case .installedApp(let bundleID, let path):
+            AppSwitcher.toggle(bundleID: bundleID, appPath: path)
         case .builtin(let item):
             switch item.kind {
             case .toggle:

--- a/Sources/AnyDoor/Views/LiquidGlassCompatibility.swift
+++ b/Sources/AnyDoor/Views/LiquidGlassCompatibility.swift
@@ -32,4 +32,58 @@ extension View {
             self.background(.regularMaterial, in: shape)
         }
     }
+
+    /// Non-interactive panel surface. Use for large container backgrounds
+    /// (palettes, popovers) where the surface itself isn't tappable.
+    @ViewBuilder
+    func adaptivePanelSurface(cornerRadius: CGFloat) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if #available(macOS 26.0, *) {
+            self.glassEffect(.regular, in: shape)
+        } else {
+            self.background(.thickMaterial, in: shape)
+        }
+    }
+}
+
+/// Applies a fallback `.thickMaterial` background on systems before macOS 26.
+/// On macOS 26+ the panel relies on its outer Liquid Glass surface to render
+/// rows/headers, so per-element materials are dropped to avoid double-layer
+/// composites that show up as visible seams against the glass.
+struct LegacyMaterialBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content
+        } else {
+            content.background(.thickMaterial)
+        }
+    }
+}
+
+extension View {
+    func legacyMaterialBackground() -> some View {
+        modifier(LegacyMaterialBackground())
+    }
+}
+
+/// Adaptive surface for full-width pinned section headers. macOS 26+ uses a
+/// thin material so the band stays subtle on top of the panel's Liquid Glass
+/// — heavy materials or a nested `.glassEffect()` would render as a dark
+/// opaque strip that breaks the design language. Earlier systems fall back
+/// to `.thickMaterial` to match the surrounding non-glass surface.
+struct AdaptiveStickyHeaderSurface: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.background(.thinMaterial)
+        } else {
+            content.background(.thickMaterial)
+        }
+    }
+}
+
+extension View {
+    func adaptiveStickyHeaderSurface() -> some View {
+        modifier(AdaptiveStickyHeaderSurface())
+    }
 }

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -14,11 +14,10 @@ private enum HoverPopoverTarget: Hashable {
 }
 
 struct MenuBarView: View {
-    /// Invoked by the footer's Settings button so the controller can dismiss
-    /// the panel before the Settings window opens.
+    /// Invoked when a row action needs the controller to dismiss the panel
+    /// (e.g. before opening another window or completing a clipboard copy).
     let onRequestClose: () -> Void
 
-    @Environment(\.openSettings) private var openSettings
     @State private var panel = PanelStore.shared
     @State private var updateService = UpdateService.shared
     @State private var popover: HoverPopover?
@@ -63,26 +62,6 @@ struct MenuBarView: View {
                 }
             }
             .padding(.horizontal, 4)
-
-            // Footer
-            VStack(spacing: 0) {
-                Divider()
-                    .padding(.horizontal, 8)
-                HStack(spacing: 2) {
-                    Spacer()
-                    footerIconButton(.panelFooterSettings, systemImage: "gearshape") {
-                        NSApp.activate()
-                        openSettings()
-                        onRequestClose()
-                    }
-                    footerIconButton(.panelFooterQuit, systemImage: "power") {
-                        NSApplication.shared.terminate(nil)
-                    }
-                }
-                .focusEffectDisabled()
-                .padding(.horizontal, 6)
-                .padding(.top, 4)
-            }
         }
         .padding(.vertical, 8).padding(.horizontal, 4)
         .frame(width: 260)
@@ -99,23 +78,6 @@ struct MenuBarView: View {
             // search field). Otherwise hide as before.
             if popover?.isHoldingFocus != true { popover?.hide() }
         }
-    }
-
-    private func footerIconButton(
-        _ titleKey: L10n.Key,
-        systemImage: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 13, weight: .regular))
-                .foregroundStyle(.secondary)
-                .frame(width: 24, height: 22)
-                .contentShape(Rectangle())
-                .adaptiveInteractiveSurface(cornerRadius: 6)
-        }
-        .buttonStyle(.plain)
-        .help(L(titleKey))
     }
 
     @ViewBuilder

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -31,15 +31,6 @@ struct MenuBarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            // Header
-            HStack {
-                Text("AnyDoor").font(.headline)
-                Spacer()
-                let count = panel.topLevelEntries.filter(\.isVisible).count
-                Text(L(.panelHeaderEnabledCount, count)).font(.caption).foregroundStyle(.tertiary)
-            }
-            .padding(.horizontal, 12).padding(.top, 4)
-
             if let version = updateService.availableVersion {
                 UpdateBannerView(
                     version: version,

--- a/Sources/AnyDoor/Views/PanelSettingsView.swift
+++ b/Sources/AnyDoor/Views/PanelSettingsView.swift
@@ -195,6 +195,9 @@ struct PanelSettingsView: View {
             panel.setBuiltinHotkey(item, hotkey: hotkey)
         case let .appShortcut(id):
             panel.updateAppShortcut(id: id, hotkey: hotkey)
+        case .installedApp:
+            // Command-palette-only source; never surfaces in the settings UI.
+            break
         }
     }
 
@@ -204,6 +207,9 @@ struct PanelSettingsView: View {
             panel.setBuiltinHotkey(item, hotkey: nil)
         case let .appShortcut(id):
             panel.updateAppShortcut(id: id, hotkey: nil)
+        case .installedApp:
+            // Command-palette-only source; never surfaces in the settings UI.
+            break
         }
     }
 


### PR DESCRIPTION
## Summary

Command Palette improvements plus a small set of menu-bar panel cleanups.

- Surface every installed app in the palette, not only the ones bound to a hotkey. `InstalledAppsScanner` runs on palette open and entries are filtered against existing app shortcuts, then appended in the Applications section. A new `PanelEntry.Source.installedApp(bundleID:path:)` variant keeps the data palette-only.
- Sticky section headers via `LazyVStack(pinnedViews:)`. Arrow-key navigation now scrolls to the row above the target so the target lands below the pinned header instead of behind it; a 0-height top sentinel handles `newIndex == 0`.
- Liquid Glass on macOS 26+ for the whole palette. New `adaptivePanelSurface(cornerRadius:)` and `adaptiveStickyHeaderSurface()` helpers in `LiquidGlassCompatibility`. The sticky header uses `.thinMaterial` on macOS 26 because a nested `.glassEffect()` rendered as a dark opaque strip that broke the design language.
- SF Symbol row icons dropped 18pt to 15pt to read at the same visual weight as the NSImage app icons.

Also included: menu bar panel header and footer were removed (info was redundant / mis-tap-prone) and the panel now dismisses on Escape via a global + local `NSEvent` monitor (the non-activating `NSPanel` never receives SwiftUI key handlers).

## Test plan

- [x] Open palette via hotkey; bound and unbound apps both appear in Applications, bound apps listed first.
- [x] Search filters across all three sections; selecting an unbound app launches it via `AppSwitcher.toggle`.
- [x] Scroll the palette: each section header pins to the viewport top as its rows scroll past, no double-material seam between header and rows on macOS < 26.
- [x] Arrow keys: moving up to any row leaves the selection visible (never hidden behind the sticky header), including the first row of a section and row 0 overall.
- [x] macOS 26 visual check: search field, rows, and headers read as one Liquid Glass surface; sticky header is a subtle band, not a dark opaque strip.
- [x] Row icons: SF Symbols and NSImage app icons look balanced at the same row size.
- [x] Menu bar panel: header/footer gone, Escape closes the panel whether AnyDoor or another app is frontmost.