### PR TITLE
fix(command-palette): activate app before keying panel window

### DIFF
--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -72,8 +72,16 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
 
         installKeyMonitor()
         positionAtTopCenter()
-        window?.makeKeyAndOrderFront(nil)
+        // Activate the app BEFORE keying the window. Summoned from a global
+        // hotkey, this `.accessory` app is still in the background, so
+        // `makeKeyAndOrderFront` cannot make the panel the key window until the
+        // app is frontmost. With no key window, SwiftUI's @FocusState can't
+        // hold first responder on the search field, and the onAppear/onChange
+        // re-focus path oscillates every runloop tick (visible flicker, no
+        // typing) until the user clicks the field. Activating first lets the
+        // deferred focus assignment land on an already-key window.
         NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
     }
 
     /// Build the section groups shown in the palette. Sections with no


### PR DESCRIPTION
## Problem

The command palette search field flickers and refuses keystrokes on first open when summoned via the global hotkey. Clicking the field with the mouse makes it work.

## Root cause

`CommandPaletteWindowController.show()` called `makeKeyAndOrderFront` before `NSApp.activate`. Summoned from a global hotkey, this `.accessory` app is still in the background, so at the moment `makeKeyAndOrderFront` runs the panel cannot become the key window (the app is not frontmost yet).

With no key window, SwiftUI's `@FocusState` cannot hold first responder on the search field. The `onAppear` focus assignment is dropped, the `onChange` re-focus path detects `false` and re-asserts `true`, and the two oscillate every runloop tick — visible flicker, no typing. A mouse click makes the window key directly, which is why clicking fixes it.

`SpotlightAppPickerWindowController` shares the same code but is only summoned from the already-active Settings window, so it never hits this race. That confirms the cause is the activation ordering, not the re-focus logic.

## Fix

Activate the app before keying the window, so the deferred `searchFocused = true` lands on an already-key window and focus settles in one pass.

## Verification

- `swift build` passes.
- Manual: summon the palette via global hotkey from the background — the field accepts input immediately on first open with no flicker.

## Note

`SpotlightAppPickerWindowController.show()` has the same ordering as a latent issue, currently unreachable because it is only opened from the foreground. Worth aligning if it ever gets a global hotkey.