### PR TITLE
fix(spotlight): break focus reclaim loop that pinned CPU to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Spotlight app picker pinned a CPU core to 100% when left open. The search
+  field re-focus handler reasserted focus on every runloop tick whenever the
+  system refused to return first-responder (a SwiftUI focus / AppKit
+  first-responder desync, e.g. the floating panel sitting on another Space):
+  each failed attempt fired the change handler again, never settling. The
+  handler now gives up after a few consecutive failed strikes and resets the
+  counter once focus is genuinely regained, so a stray hit-test still reclaims
+  focus once but a desync can no longer spin. The loop was amplified by two
+  per-frame costs, now removed: `filteredApps` re-scanned every installed app
+  on each of its several reads per render (now memoized behind an
+  observation-ignored cache over a precomputed pool), and each row resolved its
+  Finder icon via NSWorkspace on every body pass (now resolved once per row in
+  a task).
+
 ## [1.8.1] - 2026-06-02
 
 ### Added

--- a/Sources/AnyDoor/Views/SpotlightAppPicker.swift
+++ b/Sources/AnyDoor/Views/SpotlightAppPicker.swift
@@ -14,19 +14,35 @@ final class SpotlightPickerState {
     let allApps: [InstalledApp]
     let excludedBundleIDs: Set<String>
 
+    // Apps minus the excluded set, computed once. The picker never mutates its
+    // source list, so there is no need to re-filter the exclusions every read.
+    @ObservationIgnored private let pool: [InstalledApp]
+    // Memoize the last query result. A single render pass reads `filteredApps`
+    // several times; without this each read re-scans every installed app.
+    // Marked @ObservationIgnored so writing it from the getter does not feed
+    // back into SwiftUI's observation graph and retrigger invalidation.
+    @ObservationIgnored private var cache: (query: String, result: [InstalledApp])?
+
     init(apps: [InstalledApp], excluded: Set<String>) {
         self.allApps = apps
         self.excludedBundleIDs = excluded
+        self.pool = apps.filter { !excluded.contains($0.bundleID) }
     }
 
     var filteredApps: [InstalledApp] {
-        let pool = allApps.filter { !excludedBundleIDs.contains($0.bundleID) }
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return pool }
-        return pool.filter { app in
-            app.displayName.localizedCaseInsensitiveContains(trimmed)
-                || app.bundleID.localizedCaseInsensitiveContains(trimmed)
+        if let cache, cache.query == trimmed { return cache.result }
+        let result: [InstalledApp]
+        if trimmed.isEmpty {
+            result = pool
+        } else {
+            result = pool.filter { app in
+                app.displayName.localizedCaseInsensitiveContains(trimmed)
+                    || app.bundleID.localizedCaseInsensitiveContains(trimmed)
+            }
         }
+        cache = (query: trimmed, result: result)
+        return result
     }
 
     func moveDown() {
@@ -54,6 +70,9 @@ struct SpotlightAppPicker: View {
     let onCancel: () -> Void
 
     @FocusState private var searchFocused: Bool
+    // Counts consecutive failed attempts to reclaim focus. Reset whenever focus
+    // is actually regained; used to break the re-focus loop (see below).
+    @State private var refocusStrikes = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -82,11 +101,21 @@ struct SpotlightAppPicker: View {
             DispatchQueue.main.async { searchFocused = true }
         }
         .onChange(of: searchFocused) { _, focused in
-            // Search field must always be the keyboard target — re-focus if
-            // something (e.g. a stray hit-test in the panel chrome) steals it.
-            if !focused {
-                DispatchQueue.main.async { searchFocused = true }
+            // Keep the search field as the keyboard target — re-focus if a
+            // stray hit-test in the panel chrome steals it. But reasserting
+            // focus every runloop tick pins a CPU core when the system refuses
+            // to hand first-responder back (focus desync while the panel sits
+            // on another Space, etc.): each attempt fails, fires this handler
+            // again, and the loop never settles. Bail out after a few rapid
+            // strikes. Regaining focus resets the counter, and the window
+            // controller closes the panel on resignKey, so giving up is safe.
+            if focused {
+                refocusStrikes = 0
+                return
             }
+            guard refocusStrikes < 3 else { return }
+            refocusStrikes += 1
+            DispatchQueue.main.async { searchFocused = true }
         }
         .onChange(of: state.query) { _, _ in
             state.selectedIndex = 0
@@ -167,13 +196,20 @@ private struct SpotlightRow: View {
     let onSelect: () -> Void
 
     @State private var isHovering = false
+    @State private var icon: NSImage?
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(nsImage: NSWorkspace.shared.icon(forFile: app.path))
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 28, height: 28)
+            Group {
+                if let icon {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .interpolation(.high)
+                } else {
+                    Color.clear
+                }
+            }
+            .frame(width: 28, height: 28)
             VStack(alignment: .leading, spacing: 1) {
                 HStack(spacing: 6) {
                     Text(app.displayName)
@@ -207,6 +243,11 @@ private struct SpotlightRow: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture(perform: onSelect)
+        .task(id: app.bundleID) {
+            // Resolve the Finder icon once per row. NSWorkspace.icon(forFile:)
+            // touches disk, so doing it on every body pass is wasteful.
+            icon = NSWorkspace.shared.icon(forFile: app.path)
+        }
     }
 
     private var rowBackground: Color {


### PR DESCRIPTION
## Summary

The Spotlight-style app picker could pin a CPU core at 100% indefinitely when its window was left open. A live process was observed running for 4.5 hours at ~95% CPU; `sample` traced the main thread into `SpotlightAppPicker.body` -> `SpotlightPickerState.filteredApps` -> `SpotlightRow.body` with the system's `IATextInputActionsAnalytics` queue churning, i.e. the search field's focus state was oscillating every runloop tick.

## Root cause

The search field re-focus handler reasserted focus on every change:

```swift
.onChange(of: searchFocused) { _, focused in
    if !focused { DispatchQueue.main.async { searchFocused = true } }
}
```

When the system refuses to return first-responder to the field (a SwiftUI focus / AppKit first-responder desync — e.g. the floating panel sitting on another Space while still key), each `searchFocused = true` is rejected, reports `false` again, fires the handler again, and the loop never settles. `windowDidResignKey -> close()` does not save it because the window stays key; only the in-window first-responder desyncs.

## Fix

- **Break the loop (core):** count consecutive failed re-focus strikes and bail out after a few. Regaining focus resets the counter, so a stray hit-test in the panel chrome still reclaims focus once, but a desync can no longer spin the CPU.
- **Amplifier 1:** `filteredApps` re-scanned every installed app on each of its several reads per render. Now memoized behind an observation-ignored cache over a precomputed `pool` (apps minus the excluded set, built once).
- **Amplifier 2:** each row resolved its Finder icon via `NSWorkspace.icon(forFile:)` (disk-touching) on every body pass. Now resolved once per row in a `task(id:)`.

## Testing

- `swift build` passes; no new warnings in the changed file.
- The runtime trigger depends on a cross-Space focus desync that cannot be reproduced deterministically here. The fix guarantees statically that re-focus stops after a bounded number of strikes, removing the unbounded-spin path; the cache/icon changes also cut the per-frame cost of any future re-render.