### PR TITLE
perf(command-palette): cache row icons to stop first-scroll stutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Command Palette stuttered on the first scroll, then ran smoothly afterwards.
+  `CommandPaletteRow` resolved its Finder icon via `NSWorkspace.icon(forFile:)`
+  inside `body` — a synchronous disk read on every body pass with no caching —
+  so when `LazyVStack` materialized a fresh batch of rows on the first scroll,
+  each row hit disk in the same frame and dropped frames; reused rows never
+  re-ran, so later scrolling stayed smooth. The icon is now loaded once per row
+  in a `task` and cached in `@State`, leaving `body` a pure in-memory read. This
+  is the twin of the 1.8.2 `SpotlightRow` fix, which missed the command palette
+  row.
+
 ## [1.8.2] - 2026-06-02
 
 ### Fixed

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -298,6 +298,7 @@ private struct CommandPaletteRow: View {
     let onSelect: () -> Void
 
     @State private var isHovering = false
+    @State private var appIcon: NSImage?
 
     var body: some View {
         HStack(spacing: 12) {
@@ -327,6 +328,13 @@ private struct CommandPaletteRow: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture(perform: onSelect)
+        .task(id: entry.id) {
+            // Resolve the Finder icon once per row. NSWorkspace.icon(forFile:)
+            // touches disk, so doing it on every body pass stalls the first
+            // scroll as LazyVStack materializes a fresh batch of rows.
+            guard let path = iconPath else { return }
+            appIcon = NSWorkspace.shared.icon(forFile: path)
+        }
     }
 
     @ViewBuilder
@@ -348,33 +356,46 @@ private struct CommandPaletteRow: View {
 
     @ViewBuilder
     private var icon: some View {
+        if iconPath != nil {
+            // App-backed row: render the cached icon loaded in `.task`. Never
+            // resolve it inside `body` — see the .task comment above.
+            Group {
+                if let appIcon {
+                    Image(nsImage: appIcon)
+                        .resizable()
+                        .interpolation(.high)
+                } else {
+                    Color.clear
+                }
+            }
+        } else {
+            // SF Symbols carry no built-in transparent padding, so they need a
+            // smaller point size than the 22pt frame to read at the same visual
+            // weight as NSImage app icons. Built-in toggles read at full
+            // strength; port records match the dimmer fallback weight.
+            Image(systemName: entry.symbol)
+                .font(.system(size: 15))
+                .foregroundStyle(isBuiltin ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+        }
+    }
+
+    /// File path whose Finder icon backs this row, or nil when the row draws an
+    /// SF Symbol instead. App shortcuts and installed apps resolve a real icon;
+    /// built-ins and port records use a symbol.
+    private var iconPath: String? {
         switch entry.source {
         case .appShortcut:
-            if let path = PanelStore.shared.binding(id: bindingID).map(\.appPath) {
-                Image(nsImage: NSWorkspace.shared.icon(forFile: path))
-                    .resizable()
-                    .interpolation(.high)
-            } else {
-                // SF Symbols carry no built-in transparent padding, so they
-                // need a smaller point size than the 22pt frame to read at
-                // the same visual weight as NSImage app icons.
-                Image(systemName: entry.symbol)
-                    .font(.system(size: 15))
-                    .foregroundStyle(.secondary)
-            }
+            return PanelStore.shared.binding(id: bindingID).map(\.appPath)
         case .installedApp(_, let path):
-            Image(nsImage: NSWorkspace.shared.icon(forFile: path))
-                .resizable()
-                .interpolation(.high)
-        case .builtin:
-            Image(systemName: entry.symbol)
-                .font(.system(size: 15))
-                .foregroundStyle(.primary)
-        case .portRecord:
-            Image(systemName: entry.symbol)
-                .font(.system(size: 15))
-                .foregroundStyle(.secondary)
+            return path
+        case .builtin, .portRecord:
+            return nil
         }
+    }
+
+    private var isBuiltin: Bool {
+        if case .builtin = entry.source { return true }
+        return false
     }
 
     private var bindingID: UUID {


### PR DESCRIPTION
## Problem

The command palette stuttered on the first scroll, then ran smoothly afterwards — a classic "expensive first frame, cheap thereafter" signature.

`CommandPaletteRow.icon` resolved `NSWorkspace.shared.icon(forFile:)` directly inside `body`. That is a synchronous disk read (`.icns` / Finder icon), evaluated on every body pass with no caching. When `LazyVStack` materialized a fresh batch of rows on the first scroll, every row hit disk in the same frame and dropped frames. Already-rendered rows are reused (identifiers unchanged), so later scrolling stays smooth.

This is the twin of the `SpotlightRow` fix shipped in d43d2f5 — the command palette row was missed by that change.

## Fix

Mirror the proven `SpotlightRow` pattern:

- Cache the icon in `@State private var appIcon: NSImage?`.
- `body` only reads the cached state (placeholder `Color.clear` until loaded); it never calls `NSWorkspace` anymore.
- Load the icon once per row in `.task(id: entry.id)`.
- Extract `iconPath` / `isBuiltin` helpers so the app-icon vs SF Symbol branching and colors are preserved (built-ins keep `.primary`, port records keep `.secondary`).

## Scope note

Left `CommandPaletteState.filteredSections` recompute untouched on purpose: it depends on the mutable `portInventory.records` (live port refresh), so a query-only cache like `SpotlightPickerState`'s would show a stale port list. It is CPU-only and not the stutter root cause.

## Test

`swift build` passes.