### PR TITLE
feat: hosts file management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Hosts management: create, edit, delete, and activate named host profiles and
+  apply the merged result to `/etc/hosts`. A new `hostsManager` built-in opens
+  a hover popover for quick activation toggles plus a single button into a
+  master-detail editor window. Writes go through a privileged helper
+  (`SMAppService` LaunchDaemon over XPC) so the user authorizes once and writes
+  are password-free thereafter; ad-hoc/dev builds fall back to an
+  AppleScript admin-prompt writer. The helper validates every caller by audit
+  token (`SecCodeCopyGuestWithAttributes` + code-signing requirement, closing
+  the PID-recycling window), caps the payload, serializes writes, and replaces
+  `/etc/hosts` atomically (temp file in `/etc` → fsync → root:wheel 0644 →
+  rename). `HostsManager` is the single source of truth: it composes a marked
+  managed block between sentinel comments while preserving the system content
+  before and after it verbatim, applies first and persists only on success
+  (rolling back from the store on failure), debounces and serializes rapid
+  activation toggles into one consistent write, and skips the privileged write
+  entirely when the result would be unchanged (so toggling or deleting a blank
+  profile never prompts for authorization). System Hosts is editable in the
+  window — saving rewrites the system portion while preserving the managed
+  block — and the editor opens in read-only view mode by default, requiring an
+  explicit 编辑 to enter edit mode and resetting to view mode when switching
+  files, to prevent accidental writes. Profiles can be deleted from the detail
+  pane, a right-click menu, or the Delete key, and Return toggles activation
+  for the selected profile. A one-time backup of the original `/etc/hosts` is
+  captured before the first managed write and surfaced as a confirmed
+  "恢复首次备份" recovery; an in-app banner deep-links to System Settings when
+  the helper awaits approval.
+
 ### Fixed
 
 - Command Palette stuttered on the first scroll, then ran smoothly afterwards.

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ install: swift-release
 	@mkdir -p $(APP_DIR)/Contents/Resources
 	@mkdir -p $(APP_DIR)/Contents/Frameworks
 	@cp $(BINARY) $(APP_DIR)/Contents/MacOS/
+	@cp .build/release/AnyDoorHostsHelper $(APP_DIR)/Contents/MacOS/ 2>/dev/null || true
+	@mkdir -p $(APP_DIR)/Contents/Library/LaunchDaemons
+	@cp Resources/dev.bybee.AnyDoor.HostsHelper.plist $(APP_DIR)/Contents/Library/LaunchDaemons/
 	@cp Info.plist $(APP_DIR)/Contents/
 	@cp Resources/AppIcon.icns $(APP_DIR)/Contents/Resources/
 	@rm -rf $(APP_DIR)/Contents/Resources/$(APP_NAME)_$(APP_NAME).bundle

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                 .product(name: "AskForPermission", package: "AskForPermission"),
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "DDC", package: "DDC.swift"),
+                "HostsHelperShared",
             ],
             resources: [
                 .process("Resources"),
@@ -40,6 +41,19 @@ let package = Package(
             ],
             plugins: [
                 .plugin(name: "XCStringsCompilerPlugin")
+            ]
+        ),
+        .target(
+            name: "HostsHelperShared",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .executableTarget(
+            name: "AnyDoorHostsHelper",
+            dependencies: ["HostsHelperShared"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -49,9 +49,12 @@ let package = Package(
                 .swiftLanguageMode(.v6),
             ]
         ),
+        .target(
+            name: "XPCAuditToken"
+        ),
         .executableTarget(
             name: "AnyDoorHostsHelper",
-            dependencies: ["HostsHelperShared"],
+            dependencies: ["HostsHelperShared", "XPCAuditToken"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]

--- a/Resources/dev.bybee.AnyDoor.HostsHelper.plist
+++ b/Resources/dev.bybee.AnyDoor.HostsHelper.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.bybee.AnyDoor.HostsHelper</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/AnyDoorHostsHelper</string>
+    <key>MachServices</key>
+    <dict>
+        <key>dev.bybee.AnyDoor.HostsHelper</key>
+        <true/>
+    </dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>dev.bybee.AnyDoor</string>
+    </array>
+</dict>
+</plist>

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -107,6 +107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ClipboardWallProvider(),
         ]
         PanelStore.shared.bootstrap(modelContainer: modelContainer, providers: providers)
+        HostsManager.shared.bootstrap(modelContainer: modelContainer)
 
         // Brightness control (external DDC/CI displays). Arch-selected backend.
         #if arch(arm64)

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -25,7 +25,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let storeURL = storeDir.appendingPathComponent("AnyDoor.store")
             let config = ModelConfiguration(url: storeURL)
             modelContainer = try ModelContainer(
-                for: KeyBinding.self, BuiltinPreference.self, ClipboardHistoryItem.self,
+                for: KeyBinding.self, BuiltinPreference.self, ClipboardHistoryItem.self, HostProfile.self,
                 configurations: config
             )
 

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -47,6 +47,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case windowMoveNextDisplay
     case windowMovePreviousDisplay
     case windowLayout
+    case hostsManager
 
     enum Kind: Sendable {
         case toggle
@@ -58,7 +59,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
 
     var kind: Kind {
         switch self {
-        case .appShortcuts, .portManager, .windowLayout: return .submenu
+        case .appShortcuts, .portManager, .windowLayout, .hostsManager: return .submenu
         case .keepAwake, .muteAudio, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock: return .toggle
         case .lockScreen, .emptyTrash, .screenshot, .ocr, .qrcode, .pickColor, .displaySleep, .systemSleep,
@@ -121,6 +122,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMoveNextDisplay:    return .builtinWindowMoveNextDisplay
         case .windowMovePreviousDisplay: return .builtinWindowMovePreviousDisplay
         case .windowLayout:      return .builtinWindowLayout
+        case .hostsManager:      return .builtinHostsManager
         }
     }
 
@@ -170,6 +172,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMoveNextDisplay: return "rectangle.on.rectangle"
         case .windowMovePreviousDisplay: return "rectangle.on.rectangle"
         case .windowLayout: return "macwindow"
+        case .hostsManager: return "list.bullet.rectangle"
         }
     }
 
@@ -220,6 +223,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMoveNextDisplay:    return 2180
         case .windowMovePreviousDisplay: return 2190
         case .windowLayout:    return 2000
+        case .hostsManager:    return 1950
         }
     }
 

--- a/Sources/AnyDoor/Models/HostProfile.swift
+++ b/Sources/AnyDoor/Models/HostProfile.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftData
+
+/// A user-defined hosts profile. Active profiles are merged into the AnyDoor
+/// managed block in `/etc/hosts`. System hosts content is never stored here.
+@Model
+final class HostProfile {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var content: String
+    var isActive: Bool = false
+    var displayOrder: Double = 0
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(name: String, content: String = "", isActive: Bool = false, displayOrder: Double = 0) {
+        self.id = UUID()
+        self.name = name
+        self.content = content
+        self.isActive = isActive
+        self.displayOrder = displayOrder
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -253,6 +253,13 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "隐藏 Dock" } }
       }
     },
+    "builtin.hostsManager" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hosts" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Hosts 管理" } }
+      }
+    },
     "builtin.keepAwake" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/AnyDoor/Services/Hosts/HelperManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HelperManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import ServiceManagement
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts.helper")
+
+/// Manages the privileged LaunchDaemon lifecycle via SMAppService.
+@MainActor
+final class HelperManager {
+    static let shared = HelperManager()
+
+    static let plistName = "dev.bybee.AnyDoor.HostsHelper.plist"
+
+    enum Readiness {
+        case enabled
+        case requiresApproval
+        case unavailable   // ad-hoc/dev build, or registration failed
+    }
+
+    private var service: SMAppService { SMAppService.daemon(plistName: Self.plistName) }
+
+    /// True only when the daemon is registered and enabled. Used to pick the
+    /// production writer; false routes to the AppleScript fallback.
+    func ensureRegistered() -> Bool {
+        switch readiness() {
+        case .enabled:
+            return true
+        case .requiresApproval:
+            return false
+        case .unavailable:
+            do {
+                try service.register()
+                return service.status == .enabled
+            } catch {
+                logger.error("Helper register failed: \(error)")
+                return false
+            }
+        }
+    }
+
+    func readiness() -> Readiness {
+        switch service.status {
+        case .enabled: return .enabled
+        case .requiresApproval: return .requiresApproval
+        case .notRegistered: return .unavailable
+        case .notFound: return .unavailable
+        @unknown default: return .unavailable
+        }
+    }
+
+    func openApprovalSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One-time snapshot of the user's original `/etc/hosts`, plus restore.
+/// Snapshot is stored in App Support; restore writes back through a HostsWriter.
+struct HostsBackupStore {
+    private let backupURL: URL
+    private let readLiveHosts: () throws -> String
+
+    init(backupDirectory: URL, readLiveHosts: @escaping () throws -> String) {
+        self.backupURL = backupDirectory.appendingPathComponent("original.hosts")
+        self.readLiveHosts = readLiveHosts
+    }
+
+    /// Default production location: App Support/dev.bybee.AnyDoor/hosts-backup.
+    static func makeDefault() -> HostsBackupStore {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport
+            .appendingPathComponent("dev.bybee.AnyDoor", isDirectory: true)
+            .appendingPathComponent("hosts-backup", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return HostsBackupStore(backupDirectory: dir, readLiveHosts: {
+            try String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)
+        })
+    }
+
+    var hasBackup: Bool { FileManager.default.fileExists(atPath: backupURL.path) }
+
+    func originalContents() -> String? {
+        try? String(contentsOf: backupURL, encoding: .utf8)
+    }
+
+    /// Snapshot the current `/etc/hosts` exactly once. No-op if a backup exists.
+    func ensureOriginalBackup() throws {
+        guard !hasBackup else { return }
+        let live = try readLiveHosts()
+        try live.data(using: .utf8)?.write(to: backupURL)
+    }
+
+    /// Overwrite `/etc/hosts` with the first-run snapshot (destructive; the UI
+    /// must confirm before calling this).
+    func restoreFirstRunBackup(using writer: HostsWriter) async throws {
+        guard let original = originalContents() else {
+            throw HostsWriterError.writeFailed("no backup available")
+        }
+        try await writer.write(original)
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift
@@ -5,6 +5,8 @@ import Foundation
 struct HostsBackupStore {
     private let backupURL: URL
     private let readLiveHosts: () throws -> String
+    /// Test-only injection point: when non-nil, `ensureOriginalBackup()` throws this error instead.
+    var backupErrorOverride: Error?
 
     init(backupDirectory: URL, readLiveHosts: @escaping () throws -> String) {
         self.backupURL = backupDirectory.appendingPathComponent("original.hosts")
@@ -32,6 +34,7 @@ struct HostsBackupStore {
 
     /// Snapshot the current `/etc/hosts` exactly once. No-op if a backup exists.
     func ensureOriginalBackup() throws {
+        if let override = backupErrorOverride { throw override }
         guard !hasBackup else { return }
         let live = try readLiveHosts()
         try live.data(using: .utf8)?.write(to: backupURL)

--- a/Sources/AnyDoor/Services/Hosts/HostsFile.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsFile.swift
@@ -45,15 +45,16 @@ enum HostsFile {
         let prefix = trimTrailingNewlines(parsed.prefix)
         if !prefix.isEmpty { sections.append(prefix) }
 
-        if !activeProfiles.isEmpty {
-            var blockLines: [String] = [beginMarker]
-            for profile in activeProfiles {
-                blockLines.append("# --- \(sanitizeName(profile.name)) ---")
-                let body = trimTrailingNewlines(sanitizeContent(profile.content))
-                if !body.isEmpty { blockLines.append(body) }
-            }
-            blockLines.append(endMarker)
-            sections.append(blockLines.joined(separator: "\n"))
+        // Blank profiles (no meaningful content) contribute nothing — not even a
+        // header — so toggling or deleting them produces an unchanged file and
+        // never triggers a privileged write.
+        let entries: [String] = activeProfiles.compactMap { profile in
+            let body = trimTrailingNewlines(sanitizeContent(profile.content))
+            guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return "# --- \(sanitizeName(profile.name)) ---\n\(body)"
+        }
+        if !entries.isEmpty {
+            sections.append(([beginMarker] + entries + [endMarker]).joined(separator: "\n"))
         }
 
         let suffix = trimTrailingNewlines(parsed.suffix)

--- a/Sources/AnyDoor/Services/Hosts/HostsFile.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsFile.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Pure, side-effect-free parsing and composition of `/etc/hosts`.
+///
+/// `/etc/hosts` is treated as: prefix (system content) + an optional AnyDoor
+/// managed block + suffix (also system content). AnyDoor only ever rewrites
+/// the managed block; prefix and suffix are preserved verbatim.
+enum HostsFile {
+    static let beginMarker = "# >>> AnyDoor managed block - do not edit below this line >>>"
+    static let endMarker = "# <<< AnyDoor managed block end <<<"
+
+    struct Parsed: Equatable {
+        var prefix: String
+        var managed: String?
+        var suffix: String
+    }
+
+    /// Split raw hosts text. When the markers are absent or malformed (begin
+    /// without a following end), the whole file is treated as system prefix.
+    static func parse(_ raw: String) -> Parsed {
+        let lines = raw.components(separatedBy: "\n")
+        guard let beginIdx = lines.firstIndex(of: beginMarker) else {
+            return Parsed(prefix: raw, managed: nil, suffix: "")
+        }
+        let afterBegin = lines[(beginIdx + 1)...]
+        guard let endOffset = afterBegin.firstIndex(of: endMarker) else {
+            return Parsed(prefix: raw, managed: nil, suffix: "")
+        }
+        let prefix = lines[..<beginIdx].joined(separator: "\n")
+        let managed = lines[(beginIdx + 1)..<endOffset].joined(separator: "\n")
+        // Strip any leading blank lines that were the separator between the
+        // managed block and the following system content; this keeps round-trips
+        // stable when compose writes a "\n\n" join between sections.
+        let rawSuffix = lines[(endOffset + 1)...].joined(separator: "\n")
+        let suffix = trimLeadingNewlines(rawSuffix)
+        return Parsed(prefix: prefix, managed: managed, suffix: suffix)
+    }
+
+    /// Recompose hosts text: preserved prefix, a freshly built managed block
+    /// for the active profiles (omitted entirely when none), then preserved
+    /// suffix. Output always ends with a single trailing newline.
+    static func compose(parsed: Parsed, activeProfiles: [(name: String, content: String)]) -> String {
+        var sections: [String] = []
+
+        let prefix = trimTrailingNewlines(parsed.prefix)
+        if !prefix.isEmpty { sections.append(prefix) }
+
+        if !activeProfiles.isEmpty {
+            var blockLines: [String] = [beginMarker]
+            for profile in activeProfiles {
+                blockLines.append("# --- \(sanitizeName(profile.name)) ---")
+                let body = trimTrailingNewlines(sanitizeContent(profile.content))
+                if !body.isEmpty { blockLines.append(body) }
+            }
+            blockLines.append(endMarker)
+            sections.append(blockLines.joined(separator: "\n"))
+        }
+
+        let suffix = trimTrailingNewlines(parsed.suffix)
+        if !suffix.isEmpty { sections.append(suffix) }
+
+        return sections.joined(separator: "\n\n") + "\n"
+    }
+
+    /// Remove any lines from profile content that would forge our markers.
+    private static func sanitizeContent(_ content: String) -> String {
+        content
+            .components(separatedBy: "\n")
+            .filter { $0 != beginMarker && $0 != endMarker }
+            .joined(separator: "\n")
+    }
+
+    /// Keep profile names single-line so they cannot break the comment header.
+    private static func sanitizeName(_ name: String) -> String {
+        name.replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private static func trimTrailingNewlines(_ s: String) -> String {
+        var out = s
+        while out.hasSuffix("\n") { out.removeLast() }
+        return out
+    }
+
+    private static func trimLeadingNewlines(_ s: String) -> String {
+        var out = s
+        while out.hasPrefix("\n") { out.removeFirst() }
+        return out
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -119,12 +119,6 @@ final class HostsManager {
         await scheduleApply()
     }
 
-    /// DEFAULT safe restore: remove only AnyDoor's managed block.
-    func removeManagedBlock() async {
-        for p in profiles { p.isActive = false }
-        await scheduleApply()
-    }
-
     /// Edit the system portion of `/etc/hosts` in place. The edited content
     /// becomes the new prefix; AnyDoor's managed block (active profiles) is
     /// re-appended so user profiles survive a system-hosts edit.

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -1,0 +1,153 @@
+import Foundation
+import SwiftData
+import OSLog
+import Observation
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts")
+
+/// Single source of truth for host profiles. SwiftData-backed, @MainActor.
+/// Persisted state always equals what was successfully applied to the system.
+@Observable @MainActor
+final class HostsManager {
+    static let shared = HostsManager(
+        writer: HostsManager.makeDefaultWriter(),
+        backup: HostsBackupStore.makeDefault(),
+        readLiveHosts: { (try? String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)) ?? "" }
+    )
+
+    private(set) var profiles: [HostProfile] = []
+    /// System content (prefix + suffix) shown read-only in the UI.
+    private(set) var systemHosts: String = ""
+    private(set) var lastError: String?
+
+    private let writer: HostsWriter
+    private let backup: HostsBackupStore
+    private let readLiveHosts: () -> String
+    private var modelContainer: ModelContainer?
+
+    init(writer: HostsWriter, backup: HostsBackupStore, readLiveHosts: @escaping () -> String) {
+        self.writer = writer
+        self.backup = backup
+        self.readLiveHosts = readLiveHosts
+    }
+
+    /// TEMPORARY (Task 6): the privileged helper is not implemented yet.
+    private static func makeDefaultWriter() -> HostsWriter {
+        // TODO(Task 8): prefer PrivilegedHelperWriter when the helper is registered.
+        return AppleScriptWriter()
+    }
+
+    func bootstrap(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        reload()
+    }
+
+    func reload() {
+        guard let context = modelContainer?.mainContext else { return }
+        profiles = (try? context.fetch(
+            FetchDescriptor<HostProfile>(sortBy: [SortDescriptor(\.displayOrder)])
+        )) ?? []
+        let parsed = HostsFile.parse(readLiveHosts())
+        systemHosts = [parsed.prefix, parsed.suffix]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    func refresh() { reload() }
+
+    // MARK: - Mutations
+
+    func createProfile(name: String, content: String = "") {
+        guard let context = modelContainer?.mainContext else { return }
+        let nextOrder = (profiles.map(\.displayOrder).max() ?? 0) + 100
+        context.insert(HostProfile(name: name, content: content, displayOrder: nextOrder))
+        try? context.save()
+        reload()
+    }
+
+    func deleteProfile(_ profile: HostProfile) async {
+        guard let context = modelContainer?.mainContext else { return }
+        let wasActive = profile.isActive
+        context.delete(profile)
+        try? context.save()
+        reload()
+        if wasActive { await applyToSystem() }
+    }
+
+    /// Edit a profile. Persists immediately; re-applies only if active.
+    func updateProfile(_ profile: HostProfile, name: String, content: String) async {
+        profile.name = name
+        profile.content = content
+        profile.updatedAt = Date()
+        if profile.isActive {
+            await applyAndPersist()
+        } else {
+            try? modelContainer?.mainContext.save()
+            reload()
+        }
+    }
+
+    /// Toggle activation. Applies first; persists only on success.
+    func setActive(_ profile: HostProfile, _ active: Bool) async {
+        let previous = profile.isActive
+        profile.isActive = active
+        await applyAndPersist(onFailureRollback: { profile.isActive = previous })
+    }
+
+    /// DEFAULT safe restore: remove only AnyDoor's managed block.
+    func removeManagedBlock() async {
+        for p in profiles { p.isActive = false }
+        await applyAndPersist()
+    }
+
+    /// Destructive restore (UI must confirm): overwrite with first-run backup.
+    func restoreFirstRunBackup() async {
+        // Extract the backup content on the main actor before the async write,
+        // avoiding a Swift 6 data-race when sending self.backup to nonisolated code.
+        guard let original = backup.originalContents() else {
+            lastError = "No backup available"
+            return
+        }
+        do {
+            try await writer.write(original)
+            for p in profiles { p.isActive = false }
+            try? modelContainer?.mainContext.save()
+            reload()
+        } catch {
+            lastError = String(describing: error)
+        }
+    }
+
+    // MARK: - Apply
+
+    private func applyAndPersist(onFailureRollback rollback: (() -> Void)? = nil) async {
+        do {
+            try? backup.ensureOriginalBackup()
+            try await applyToSystemThrowing()
+            try? modelContainer?.mainContext.save()
+            lastError = nil
+            reload()
+        } catch {
+            rollback?()
+            lastError = String(describing: error)
+            logger.error("Apply failed: \(error)")
+            reload()
+        }
+    }
+
+    /// Non-throwing convenience used by delete (state already persisted).
+    private func applyToSystem() async {
+        try? backup.ensureOriginalBackup()
+        do { try await applyToSystemThrowing() } catch { lastError = String(describing: error) }
+    }
+
+    private func applyToSystemThrowing() async throws {
+        let parsed = HostsFile.parse(readLiveHosts())
+        let active = profiles
+            .filter(\.isActive)
+            .sorted { $0.displayOrder < $1.displayOrder }
+            .map { (name: $0.name, content: $0.content) }
+        let newContent = HostsFile.compose(parsed: parsed, activeProfiles: active)
+        try await writer.write(newContent)
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -10,7 +10,14 @@ private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts")
 @Observable @MainActor
 final class HostsManager {
     static let shared = HostsManager(
-        writer: HostsManager.makeDefaultWriter(),
+        makeWriter: {
+            // Re-evaluate on every write so the privileged helper is used as soon
+            // as the user approves it — without requiring an app relaunch.
+            if HelperManager.shared.readiness() == .enabled {
+                return PrivilegedHelperWriter()
+            }
+            return AppleScriptWriter()
+        },
         backup: HostsBackupStore.makeDefault(),
         readLiveHosts: { (try? String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)) ?? "" }
     )
@@ -20,26 +27,43 @@ final class HostsManager {
     private(set) var systemHosts: String = ""
     private(set) var lastError: String?
 
-    private let writer: HostsWriter
-    private let backup: HostsBackupStore
+    // MARK: - Writer factory (re-evaluated per write so helper approval takes effect immediately)
+    private let makeWriter: () -> HostsWriter
+    // `var` so tests can inject backupErrorOverride on the value-type HostsBackupStore.
+    var backup: HostsBackupStore
     private let readLiveHosts: () -> String
     private var modelContainer: ModelContainer?
 
-    init(writer: HostsWriter, backup: HostsBackupStore, readLiveHosts: @escaping () -> String) {
-        self.writer = writer
+    // MARK: - Debounce / serialization state
+    private let debounceInterval: Duration
+    private var applyPending = false
+    private var applyTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    /// Designated initialiser. Accepts a factory so the writer can be re-resolved per write.
+    init(makeWriter: @escaping () -> HostsWriter,
+         backup: HostsBackupStore,
+         readLiveHosts: @escaping () -> String,
+         debounceInterval: Duration = .milliseconds(150)) {
+        self.makeWriter = makeWriter
         self.backup = backup
         self.readLiveHosts = readLiveHosts
+        self.debounceInterval = debounceInterval
     }
 
-    @MainActor
-    private static func makeDefaultWriter() -> HostsWriter {
-        if HelperManager.shared.ensureRegistered() {
-            return PrivilegedHelperWriter()
-        }
-        return AppleScriptWriter()
+    /// Convenience initialiser for tests that supply a fixed writer.
+    convenience init(writer: HostsWriter,
+                     backup: HostsBackupStore,
+                     readLiveHosts: @escaping () -> String,
+                     debounceInterval: Duration = .milliseconds(150)) {
+        self.init(makeWriter: { writer }, backup: backup, readLiveHosts: readLiveHosts,
+                  debounceInterval: debounceInterval)
     }
 
     func bootstrap(modelContainer: ModelContainer) {
+        // Attempt helper registration once at startup (cheap; falls through if already registered).
+        _ = HelperManager.shared.ensureRegistered()
         self.modelContainer = modelContainer
         reload()
     }
@@ -73,7 +97,7 @@ final class HostsManager {
         context.delete(profile)
         try? context.save()
         reload()
-        if wasActive { await applyToSystem() }
+        if wasActive { await scheduleApply() }
     }
 
     /// Edit a profile. Persists immediately; re-applies only if active.
@@ -82,7 +106,7 @@ final class HostsManager {
         profile.content = content
         profile.updatedAt = Date()
         if profile.isActive {
-            await applyAndPersist()
+            await scheduleApply()
         } else {
             try? modelContainer?.mainContext.save()
             reload()
@@ -91,26 +115,27 @@ final class HostsManager {
 
     /// Toggle activation. Applies first; persists only on success.
     func setActive(_ profile: HostProfile, _ active: Bool) async {
-        let previous = profile.isActive
         profile.isActive = active
-        await applyAndPersist(onFailureRollback: { profile.isActive = previous })
+        await scheduleApply()
     }
 
     /// DEFAULT safe restore: remove only AnyDoor's managed block.
     func removeManagedBlock() async {
         for p in profiles { p.isActive = false }
-        await applyAndPersist()
+        await scheduleApply()
     }
 
     /// Destructive restore (UI must confirm): overwrite with first-run backup.
     func restoreFirstRunBackup() async {
-        // Extract the backup content on the main actor before the async write,
-        // avoiding a Swift 6 data-race when sending self.backup to nonisolated code.
+        // Wait for any in-flight composed apply to finish before overwriting.
+        await applyTask?.value
+
         guard let original = backup.originalContents() else {
-            lastError = "No backup available"
+            lastError = "无可用备份"
             return
         }
         do {
+            let writer = makeWriter()
             try await writer.write(original)
             for p in profiles { p.isActive = false }
             try? modelContainer?.mainContext.save()
@@ -120,30 +145,59 @@ final class HostsManager {
         }
     }
 
+    // MARK: - Debounce / serialize
+
+    /// Coalescing debounced entry-point for composed applies. All callers that
+    /// go through the compose path use this instead of `applyAndPersist` directly.
+    private func scheduleApply() async {
+        applyPending = true
+        if applyTask == nil {
+            applyTask = Task { @MainActor in
+                try? await Task.sleep(for: self.debounceInterval)
+                // Serial retry loop: pick up any toggle that arrived during the write.
+                while self.applyPending {
+                    self.applyPending = false
+                    await self.applyAndPersist()
+                }
+                self.applyTask = nil
+            }
+        }
+        await applyTask?.value
+    }
+
     // MARK: - Apply
 
-    private func applyAndPersist(onFailureRollback rollback: (() -> Void)? = nil) async {
+    private func applyAndPersist() async {
+        // Capture backup error; a failed backup must not abort the write.
+        var backupError: Error?
         do {
-            try? backup.ensureOriginalBackup()
+            try backup.ensureOriginalBackup()
+        } catch {
+            backupError = error
+            logger.warning("Backup creation failed: \(error)")
+        }
+
+        do {
             try await applyToSystemThrowing()
             try? modelContainer?.mainContext.save()
-            lastError = nil
+            // Surface backup warning instead of clearing error on success.
+            if let _ = backupError {
+                lastError = "备份创建失败，可能无法完整恢复"
+            } else {
+                lastError = nil
+            }
             reload()
         } catch {
-            rollback?()
+            // Discard unsaved in-memory mutations so reload() sees the persisted state.
+            modelContainer?.mainContext.rollback()
             lastError = String(describing: error)
             logger.error("Apply failed: \(error)")
             reload()
         }
     }
 
-    /// Non-throwing convenience used by delete (state already persisted).
-    private func applyToSystem() async {
-        try? backup.ensureOriginalBackup()
-        do { try await applyToSystemThrowing() } catch { lastError = String(describing: error) }
-    }
-
     private func applyToSystemThrowing() async throws {
+        let writer = makeWriter()
         let parsed = HostsFile.parse(readLiveHosts())
         let active = profiles
             .filter(\.isActive)

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -125,6 +125,31 @@ final class HostsManager {
         await scheduleApply()
     }
 
+    /// Edit the system portion of `/etc/hosts` in place. The edited content
+    /// becomes the new prefix; AnyDoor's managed block (active profiles) is
+    /// re-appended so user profiles survive a system-hosts edit.
+    func updateSystemHosts(_ newContent: String) async {
+        // Serialize against any in-flight composed apply.
+        await applyTask?.value
+
+        var backupError: Error?
+        do {
+            try backup.ensureOriginalBackup()
+        } catch {
+            backupError = error
+            logger.warning("Backup creation failed: \(error)")
+        }
+        do {
+            try await applyContent(composedContent(systemPrefix: newContent))
+            lastError = backupError != nil ? "备份创建失败，可能无法完整恢复" : nil
+            reload()
+        } catch {
+            lastError = String(describing: error)
+            logger.error("System hosts edit failed: \(error)")
+            reload()
+        }
+    }
+
     /// Destructive restore (UI must confirm): overwrite with first-run backup.
     func restoreFirstRunBackup() async {
         // Wait for any in-flight composed apply to finish before overwriting.
@@ -178,7 +203,7 @@ final class HostsManager {
         }
 
         do {
-            try await applyToSystemThrowing()
+            try await applyContent(composedContent(systemPrefix: nil))
             try? modelContainer?.mainContext.save()
             // Surface backup warning instead of clearing error on success.
             if let _ = backupError {
@@ -196,14 +221,30 @@ final class HostsManager {
         }
     }
 
-    private func applyToSystemThrowing() async throws {
-        let writer = makeWriter()
-        let parsed = HostsFile.parse(readLiveHosts())
+    /// Build the full `/etc/hosts` text. When `systemPrefix` is nil the existing
+    /// system content is preserved from the live file; otherwise it is replaced
+    /// (used by `updateSystemHosts`). The managed block is always rebuilt from
+    /// the currently active profiles.
+    private func composedContent(systemPrefix: String?) -> String {
+        let parsed: HostsFile.Parsed
+        if let systemPrefix {
+            parsed = HostsFile.Parsed(prefix: systemPrefix, managed: nil, suffix: "")
+        } else {
+            parsed = HostsFile.parse(readLiveHosts())
+        }
         let active = profiles
             .filter(\.isActive)
             .sorted { $0.displayOrder < $1.displayOrder }
             .map { (name: $0.name, content: $0.content) }
-        let newContent = HostsFile.compose(parsed: parsed, activeProfiles: active)
-        try await writer.write(newContent)
+        return HostsFile.compose(parsed: parsed, activeProfiles: active)
+    }
+
+    /// Write `content` through the current writer, skipping the privileged write
+    /// entirely when it would not change the file (e.g. toggling or deleting a
+    /// blank profile) so the user is never prompted for a no-op.
+    private func applyContent(_ content: String) async throws {
+        guard content != readLiveHosts() else { return }
+        let writer = makeWriter()
+        try await writer.write(content)
     }
 }

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -31,9 +31,11 @@ final class HostsManager {
         self.readLiveHosts = readLiveHosts
     }
 
-    /// TEMPORARY (Task 6): the privileged helper is not implemented yet.
+    @MainActor
     private static func makeDefaultWriter() -> HostsWriter {
-        // TODO(Task 8): prefer PrivilegedHelperWriter when the helper is registered.
+        if HelperManager.shared.ensureRegistered() {
+            return PrivilegedHelperWriter()
+        }
         return AppleScriptWriter()
     }
 

--- a/Sources/AnyDoor/Services/Hosts/HostsWriter.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsWriter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum HostsWriterError: Error, Equatable {
+    case writeFailed(String)
+    case authorizationCancelled
+}
+
+/// Abstraction over the privileged write to `/etc/hosts`. Implementations:
+/// `PrivilegedHelperWriter` (production, XPC), `AppleScriptWriter` (dev fallback).
+protocol HostsWriter: Sendable {
+    func write(_ content: String) async throws
+}
+
+/// Dev / ad-hoc fallback. Writes to an unpredictable temp file then copies it
+/// over `/etc/hosts` with an administrator-authorized shell command. Never
+/// changes the permissions of `/etc/hosts`.
+struct AppleScriptWriter: HostsWriter {
+    func write(_ content: String) async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anydoor-hosts-\(UUID().uuidString)")
+        try content.data(using: .utf8)?.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        // Quote both paths; embed via AppleScript "quoted form of".
+        let script = """
+        do shell script "/bin/cp " & quoted form of "\(tmp.path)" & " /etc/hosts" with administrator privileges
+        """
+        do {
+            _ = try await AppleScriptRunner.run(script)
+        } catch {
+            throw HostsWriterError.writeFailed(String(describing: error))
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/MockHostsWriter.swift
+++ b/Sources/AnyDoor/Services/Hosts/MockHostsWriter.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// In-memory `HostsWriter` for unit tests. Records the last payload and can be
+/// configured to throw.
+final class MockHostsWriter: HostsWriter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lastWritten: String?
+    private var _writeCount = 0
+    var errorToThrow: Error?
+
+    var lastWritten: String? { lock.withLock { _lastWritten } }
+    var writeCount: Int { lock.withLock { _writeCount } }
+
+    func write(_ content: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        lock.withLock {
+            _lastWritten = content
+            _writeCount += 1
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Hosts/PrivilegedHelperWriter.swift
+++ b/Sources/AnyDoor/Services/Hosts/PrivilegedHelperWriter.swift
@@ -1,0 +1,30 @@
+import Foundation
+import HostsHelperShared
+
+/// Production writer: sends the composed hosts content to the root helper over XPC.
+struct PrivilegedHelperWriter: HostsWriter {
+    func write(_ content: String) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let conn = NSXPCConnection(machServiceName: HostsHelperConstants.machServiceName,
+                                       options: .privileged)
+            conn.remoteObjectInterface = NSXPCInterface(with: HostsHelperProtocol.self)
+            conn.resume()
+            let proxy = conn.remoteObjectProxyWithErrorHandler { error in
+                cont.resume(throwing: HostsWriterError.writeFailed(String(describing: error)))
+            } as? HostsHelperProtocol
+            guard let proxy else {
+                conn.invalidate()
+                cont.resume(throwing: HostsWriterError.writeFailed("no proxy"))
+                return
+            }
+            proxy.writeHosts(content) { errorMessage in
+                conn.invalidate()
+                if let errorMessage {
+                    cont.resume(throwing: HostsWriterError.writeFailed(errorMessage))
+                } else {
+                    cont.resume(returning: ())
+                }
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/RegularWindowCoordinator.swift
+++ b/Sources/AnyDoor/Services/RegularWindowCoordinator.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+/// Keeps the app in `.regular` activation policy while any "real" window
+/// (Settings, the Hosts editor) is open.
+///
+/// AnyDoor normally runs as `.accessory` (menu-bar only, no Dock icon). Under
+/// that policy a standard window has no Dock / Cmd-Tab presence, so once the
+/// user clicks another app it slips behind and cannot be resurfaced — it looks
+/// like it vanished. While a tracked window is open we switch to `.regular` so
+/// those windows behave like ordinary app windows (Dock icon, Cmd-Tab, stay
+/// reachable); when the last one closes we revert to `.accessory`.
+@MainActor
+final class RegularWindowCoordinator {
+    static let shared = RegularWindowCoordinator()
+
+    private var tracked: Set<ObjectIdentifier> = []
+    private var observers: [ObjectIdentifier: NSObjectProtocol] = [:]
+
+    /// Begin tracking a window. Idempotent — safe to call again when a reused
+    /// window is shown a second time.
+    func track(_ window: NSWindow) {
+        let id = ObjectIdentifier(window)
+        guard tracked.insert(id).inserted else { return }
+        observers[id] = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: window, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.untrack(id) }
+        }
+        apply()
+    }
+
+    private func untrack(_ id: ObjectIdentifier) {
+        if let observer = observers.removeValue(forKey: id) {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        tracked.remove(id)
+        apply()
+    }
+
+    private func apply() {
+        NSApp.setActivationPolicy(tracked.isEmpty ? .accessory : .regular)
+    }
+}
+
+/// Registers the hosting SwiftUI window with `RegularWindowCoordinator`. Attach
+/// via `.background(RegularWindowRegistrar())` on a window's root view (e.g. the
+/// Settings scene) so the app adopts `.regular` policy while that window lives.
+struct RegularWindowRegistrar: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        // The view isn't attached to its window yet during makeNSView; defer the
+        // lookup to the next runloop tick.
+        DispatchQueue.main.async {
+            if let window = view.window {
+                RegularWindowCoordinator.shared.track(window)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -17,6 +17,7 @@ enum L10n {
         case builtinFlushDNS = "builtin.flushDNS"
         case builtinHideDesktopIcons = "builtin.hideDesktopIcons"
         case builtinHideDock = "builtin.hideDock"
+        case builtinHostsManager = "builtin.hostsManager"
         case builtinKeepAwake = "builtin.keepAwake"
         case builtinKeyboardLock = "builtin.keyboardLock"
         case builtinLockScreen = "builtin.lockScreen"

--- a/Sources/AnyDoor/Views/Hosts/HelperApprovalBanner.swift
+++ b/Sources/AnyDoor/Views/Hosts/HelperApprovalBanner.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Shown in the Hosts popover and editor when the privileged helper is
+/// registered but still awaiting the user's approval in System Settings.
+/// Renders nothing when the helper is enabled or unavailable (dev/ad-hoc
+/// builds fall back to the AppleScript writer and need no nagging).
+struct HelperApprovalBanner: View {
+    var body: some View {
+        if HelperManager.shared.readiness() == .requiresApproval {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.shield")
+                    .foregroundStyle(.orange)
+                Text("需要在系统设置中授权后台帮助程序")
+                    .font(.caption2)
+                Spacer()
+                Button("授权") { HelperManager.shared.openApprovalSettings() }
+                    .buttonStyle(.borderless)
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 4)
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -23,7 +23,6 @@ struct HostsEditorView: View {
     @State private var draftContent: String = ""
     @State private var draftSystemContent: String = ""
     @State private var showRestoreConfirm = false
-    @State private var showRemoveConfirm = false
     @State private var showDeleteConfirm = false
 
     var body: some View {
@@ -119,17 +118,10 @@ struct HostsEditorView: View {
                     }
                     Spacer()
                     Button("用默认编辑器打开") { HostsFileOpener.open() }
-                    Button("移除托管块", role: .destructive) { showRemoveConfirm = true }
-                        .tint(.red)
                     Button("恢复首次备份") { showRestoreConfirm = true }
                 }
             }
             .padding()
-            .confirmationDialog("移除 AnyDoor 托管块？将停用所有配置并从 /etc/hosts 中删除托管内容（系统内容保留）。",
-                                isPresented: $showRemoveConfirm, titleVisibility: .visible) {
-                Button("移除", role: .destructive) { Task { await manager.removeManagedBlock() } }
-                Button("取消", role: .cancel) {}
-            }
             .confirmationDialog("覆盖 /etc/hosts 为首次备份？外部改动将丢失。",
                                 isPresented: $showRestoreConfirm, titleVisibility: .visible) {
                 Button("恢复", role: .destructive) { Task { await manager.restoreFirstRunBackup() } }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -87,7 +87,7 @@ struct HostsEditorView: View {
                     }
                     Spacer()
                     Button("用默认编辑器打开") {
-                        NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                        HostsFileOpener.open()
                     }
                 }
             }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -24,6 +24,7 @@ struct HostsEditorView: View {
     @State private var draftSystemContent: String = ""
     @State private var showRestoreConfirm = false
     @State private var showRemoveConfirm = false
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         NavigationSplitView {
@@ -97,7 +98,28 @@ struct HostsEditorView: View {
                         await manager.updateProfile(profile, name: draftName, content: draftContent)
                     }
                     Spacer()
-                    Button("移除", role: .destructive) { showRemoveConfirm = true }
+                    Button("删除", role: .destructive) { showDeleteConfirm = true }
+                        .tint(.red)
+                }
+            }
+            .padding()
+            .confirmationDialog("删除配置「\(draftName)」？此操作不可撤销。",
+                                isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+                Button("删除", role: .destructive) { delete(profile) }
+                Button("取消", role: .cancel) {}
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("系统 Hosts").font(.headline)
+                editorArea(text: $draftSystemContent)
+                HStack {
+                    modeButton {
+                        await manager.updateSystemHosts(draftSystemContent)
+                        draftSystemContent = manager.systemHosts
+                    }
+                    Spacer()
+                    Button("用默认编辑器打开") { HostsFileOpener.open() }
+                    Button("移除托管块", role: .destructive) { showRemoveConfirm = true }
                         .tint(.red)
                     Button("恢复首次备份") { showRestoreConfirm = true }
                 }
@@ -113,20 +135,6 @@ struct HostsEditorView: View {
                 Button("恢复", role: .destructive) { Task { await manager.restoreFirstRunBackup() } }
                 Button("取消", role: .cancel) {}
             }
-        } else {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("系统 Hosts").font(.headline)
-                editorArea(text: $draftSystemContent)
-                HStack {
-                    modeButton {
-                        await manager.updateSystemHosts(draftSystemContent)
-                        draftSystemContent = manager.systemHosts
-                    }
-                    Spacer()
-                    Button("用默认编辑器打开") { HostsFileOpener.open() }
-                }
-            }
-            .padding()
             .onAppear { draftSystemContent = manager.systemHosts }
         }
     }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -7,6 +7,7 @@ struct HostsEditorView: View {
     @State private var selection: UUID?
     @State private var draftName: String = ""
     @State private var draftContent: String = ""
+    @State private var draftSystemContent: String = ""
     @State private var showRestoreConfirm = false
 
     var body: some View {
@@ -71,15 +72,27 @@ struct HostsEditorView: View {
                 Button("取消", role: .cancel) {}
             }
         } else {
-            VStack(alignment: .leading) {
-                Text(manager.systemHosts)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("系统 Hosts")
+                    .font(.headline)
+                TextEditor(text: $draftSystemContent)
                     .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                Button("用默认编辑器打开") {
-                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                    .border(.quaternary)
+                HStack {
+                    Button("保存") {
+                        Task {
+                            await manager.updateSystemHosts(draftSystemContent)
+                            draftSystemContent = manager.systemHosts
+                        }
+                    }
+                    Spacer()
+                    Button("用默认编辑器打开") {
+                        NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                    }
                 }
             }
             .padding()
+            .onAppear { draftSystemContent = manager.systemHosts }
         }
     }
 
@@ -91,6 +104,7 @@ struct HostsEditorView: View {
     private func loadDraft() {
         draftName = selectedProfile?.name ?? ""
         draftContent = selectedProfile?.content ?? ""
+        if selection == nil { draftSystemContent = manager.systemHosts }
     }
 
     private func deleteSelected() {

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -13,7 +13,7 @@ struct HostsEditorView: View {
         NavigationSplitView {
             List(selection: $selection) {
                 Section {
-                    Label("System Hosts", systemImage: "cpu").tag(Optional<UUID>.none)
+                    Label("系统 Hosts", systemImage: "cpu").tag(Optional<UUID>.none)
                 }
                 Section {
                     ForEach(manager.profiles) { profile in
@@ -30,7 +30,7 @@ struct HostsEditorView: View {
             .frame(minWidth: 220)
             .toolbar {
                 ToolbarItem {
-                    Button { manager.createProfile(name: "New Profile") } label: {
+                    Button { manager.createProfile(name: "新配置") } label: {
                         Image(systemName: "plus")
                     }
                 }
@@ -42,6 +42,7 @@ struct HostsEditorView: View {
         } detail: {
             detail
         }
+        .safeAreaInset(edge: .top) { HelperApprovalBanner() }
         .onChange(of: selection) { _, _ in loadDraft() }
     }
 
@@ -49,7 +50,7 @@ struct HostsEditorView: View {
     private var detail: some View {
         if let profile = selectedProfile {
             VStack(alignment: .leading, spacing: 8) {
-                TextField("Name", text: $draftName)
+                TextField("名称", text: $draftName)
                     .textFieldStyle(.roundedBorder)
                 TextEditor(text: $draftContent)
                     .font(.system(.body, design: .monospaced))

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Master-detail editor: profile list on the left, content editor on the right.
+/// System Hosts is read-only with an "open file" action.
+struct HostsEditorView: View {
+    @Bindable var manager: HostsManager
+    @State private var selection: UUID?
+    @State private var draftName: String = ""
+    @State private var draftContent: String = ""
+    @State private var showRestoreConfirm = false
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                Section {
+                    Label("System Hosts", systemImage: "cpu").tag(Optional<UUID>.none)
+                }
+                Section {
+                    ForEach(manager.profiles) { profile in
+                        HStack {
+                            Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(profile.isActive ? .green : .secondary)
+                                .onTapGesture { Task { await manager.setActive(profile, !profile.isActive) } }
+                            Text(profile.name)
+                        }
+                        .tag(Optional(profile.id))
+                    }
+                }
+            }
+            .frame(minWidth: 220)
+            .toolbar {
+                ToolbarItem {
+                    Button { manager.createProfile(name: "New Profile") } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+                ToolbarItem {
+                    Button { deleteSelected() } label: { Image(systemName: "trash") }
+                        .disabled(selectedProfile == nil)
+                }
+            }
+        } detail: {
+            detail
+        }
+        .onChange(of: selection) { _, _ in loadDraft() }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let profile = selectedProfile {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Name", text: $draftName)
+                    .textFieldStyle(.roundedBorder)
+                TextEditor(text: $draftContent)
+                    .font(.system(.body, design: .monospaced))
+                    .border(.quaternary)
+                HStack {
+                    Button("保存") {
+                        Task { await manager.updateProfile(profile, name: draftName, content: draftContent) }
+                    }
+                    Spacer()
+                    Button("移除托管块") { Task { await manager.removeManagedBlock() } }
+                    Button("恢复首次备份") { showRestoreConfirm = true }
+                }
+            }
+            .padding()
+            .confirmationDialog("覆盖 /etc/hosts 为首次备份？外部改动将丢失。",
+                                isPresented: $showRestoreConfirm, titleVisibility: .visible) {
+                Button("恢复", role: .destructive) { Task { await manager.restoreFirstRunBackup() } }
+                Button("取消", role: .cancel) {}
+            }
+        } else {
+            VStack(alignment: .leading) {
+                Text(manager.systemHosts)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                Button("用默认编辑器打开") {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var selectedProfile: HostProfile? {
+        guard let selection else { return nil }
+        return manager.profiles.first { $0.id == selection }
+    }
+
+    private func loadDraft() {
+        draftName = selectedProfile?.name ?? ""
+        draftContent = selectedProfile?.content ?? ""
+    }
+
+    private func deleteSelected() {
+        guard let profile = selectedProfile else { return }
+        Task { await manager.deleteProfile(profile) }
+        selection = nil
+    }
+}

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -37,6 +37,14 @@ struct HostsEditorView: View {
                 }
             }
             .frame(minWidth: 220)
+            // Return toggles activation for the selected profile. Scoped to the
+            // list's focus, so Return inside the content editor still inserts a
+            // newline rather than toggling.
+            .onKeyPress(.return) {
+                guard let profile = selectedProfile else { return .ignored }
+                Task { await manager.setActive(profile, !profile.isActive) }
+                return .handled
+            }
             .toolbar {
                 ToolbarItem {
                     Button { manager.createProfile(name: "新配置") } label: {

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -147,31 +147,15 @@ struct HostsEditorView: View {
         }
     }
 
-    /// The content area: editable in edit mode, a read-only selectable view
-    /// otherwise. Rounded card styling.
+    /// The content area: the same text view in both modes (only `isEditable`
+    /// changes) so toggling edit never shifts the text. Rounded card styling.
     @ViewBuilder
     private func editorArea(text: Binding<String>) -> some View {
-        Group {
-            if mode == .edit {
-                TextEditor(text: text)
-                    .font(.system(.body, design: .monospaced))
-                    .scrollContentBackground(.hidden)
-                    .padding(6)
-            } else {
-                ScrollView {
-                    Text(text.wrappedValue.isEmpty ? "（空）" : text.wrappedValue)
-                        .foregroundStyle(text.wrappedValue.isEmpty ? .secondary : .primary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-                        .font(.system(.body, design: .monospaced))
-                        .padding(6)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
+        PlainTextEditor(text: text, isEditable: mode == .edit)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(nsColor: .textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
     }
 
     /// "编辑" in view mode (enters edit mode) or "保存" in edit mode (runs the

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 /// Master-detail editor: profile list on the left, content editor on the right.
 ///
-/// Opens in read-only **view** mode to prevent accidental writes; the user must
-/// click "编辑" to enter **edit** mode. Switching the selected host file resets
+/// Profile names are renamed inline in the list (a freshly created profile
+/// drops straight into rename). The right pane shows only the content body —
+/// opening in read-only **view** mode to prevent accidental writes; the user
+/// clicks "编辑" to enter **edit** mode. Switching the selected host file resets
 /// back to view mode. System Hosts editing rewrites the system portion while
 /// preserving the managed block.
 struct HostsEditorView: View {
@@ -19,9 +21,11 @@ struct HostsEditorView: View {
 
     @State private var selection: Selection? = .system
     @State private var mode: Mode = .view
-    @State private var draftName: String = ""
     @State private var draftContent: String = ""
     @State private var draftSystemContent: String = ""
+    @State private var renamingID: UUID?
+    @State private var renameText: String = ""
+    @FocusState private var renameFieldFocused: Bool
     @State private var showRestoreConfirm = false
     @State private var showDeleteConfirm = false
 
@@ -33,18 +37,16 @@ struct HostsEditorView: View {
                 }
                 Section {
                     ForEach(manager.profiles) { profile in
-                        HStack {
-                            Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
-                                .foregroundStyle(profile.isActive ? .green : .secondary)
-                                .onTapGesture { Task { await manager.setActive(profile, !profile.isActive) } }
-                            Text(profile.name)
-                        }
-                        .tag(Selection.profile(profile.id))
-                        .contextMenu {
-                            Button(role: .destructive) { delete(profile) } label: {
-                                Label("删除", systemImage: "trash")
+                        profileRow(profile)
+                            .tag(Selection.profile(profile.id))
+                            .contextMenu {
+                                Button { beginRename(profile) } label: {
+                                    Label("重命名", systemImage: "pencil")
+                                }
+                                Button(role: .destructive) { delete(profile) } label: {
+                                    Label("删除", systemImage: "trash")
+                                }
                             }
-                        }
                     }
                 }
             }
@@ -53,7 +55,7 @@ struct HostsEditorView: View {
             // list's focus, so Return inside the content editor still inserts a
             // newline rather than toggling.
             .onKeyPress(.return) {
-                guard let profile = selectedProfile else { return .ignored }
+                guard renamingID == nil, let profile = selectedProfile else { return .ignored }
                 Task { await manager.setActive(profile, !profile.isActive) }
                 return .handled
             }
@@ -61,9 +63,7 @@ struct HostsEditorView: View {
             .onDeleteCommand { deleteSelected() }
             .toolbar {
                 ToolbarItem {
-                    Button { manager.createProfile(name: "新配置") } label: {
-                        Image(systemName: "plus")
-                    }
+                    Button { addProfile() } label: { Image(systemName: "plus") }
                 }
                 ToolbarItem {
                     Button { deleteSelected() } label: { Image(systemName: "trash") }
@@ -79,22 +79,39 @@ struct HostsEditorView: View {
             mode = .view
             loadDraft()
         }
+        // Commit an in-progress rename when its field loses focus (Enter, click
+        // away, or selecting another row).
+        .onChange(of: renameFieldFocused) { _, focused in
+            if !focused { commitRename() }
+        }
+    }
+
+    @ViewBuilder
+    private func profileRow(_ profile: HostProfile) -> some View {
+        HStack {
+            Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(profile.isActive ? .green : .secondary)
+                .onTapGesture { Task { await manager.setActive(profile, !profile.isActive) } }
+            if renamingID == profile.id {
+                TextField("名称", text: $renameText)
+                    .textFieldStyle(.plain)
+                    .focused($renameFieldFocused)
+                    .onSubmit { commitRename() }
+            } else {
+                Text(profile.name)
+                    .onTapGesture(count: 2) { beginRename(profile) }
+            }
+        }
     }
 
     @ViewBuilder
     private var detail: some View {
         if let profile = selectedProfile {
             VStack(alignment: .leading, spacing: 8) {
-                if mode == .edit {
-                    TextField("名称", text: $draftName)
-                        .textFieldStyle(.roundedBorder)
-                } else {
-                    Text(draftName).font(.headline)
-                }
                 editorArea(text: $draftContent)
                 HStack {
                     modeButton {
-                        await manager.updateProfile(profile, name: draftName, content: draftContent)
+                        await manager.updateProfile(profile, name: profile.name, content: draftContent)
                     }
                     Spacer()
                     Button("删除", role: .destructive) { showDeleteConfirm = true }
@@ -102,14 +119,13 @@ struct HostsEditorView: View {
                 }
             }
             .padding()
-            .confirmationDialog("删除配置「\(draftName)」？此操作不可撤销。",
+            .confirmationDialog("删除配置「\(profile.name)」？此操作不可撤销。",
                                 isPresented: $showDeleteConfirm, titleVisibility: .visible) {
                 Button("删除", role: .destructive) { delete(profile) }
                 Button("取消", role: .cancel) {}
             }
         } else {
             VStack(alignment: .leading, spacing: 8) {
-                Text("系统 Hosts").font(.headline)
                 editorArea(text: $draftSystemContent)
                 HStack {
                     modeButton {
@@ -132,25 +148,30 @@ struct HostsEditorView: View {
     }
 
     /// The content area: editable in edit mode, a read-only selectable view
-    /// otherwise.
+    /// otherwise. Rounded card styling.
     @ViewBuilder
     private func editorArea(text: Binding<String>) -> some View {
-        if mode == .edit {
-            TextEditor(text: text)
-                .font(.system(.body, design: .monospaced))
-                .border(.quaternary)
-        } else {
-            ScrollView {
-                Text(text.wrappedValue.isEmpty ? "（空）" : text.wrappedValue)
-                    .foregroundStyle(text.wrappedValue.isEmpty ? .secondary : .primary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
+        Group {
+            if mode == .edit {
+                TextEditor(text: text)
                     .font(.system(.body, design: .monospaced))
-                    .padding(4)
+                    .scrollContentBackground(.hidden)
+                    .padding(6)
+            } else {
+                ScrollView {
+                    Text(text.wrappedValue.isEmpty ? "（空）" : text.wrappedValue)
+                        .foregroundStyle(text.wrappedValue.isEmpty ? .secondary : .primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .font(.system(.body, design: .monospaced))
+                        .padding(6)
+                }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .border(.quaternary)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
     }
 
     /// "编辑" in view mode (enters edit mode) or "保存" in edit mode (runs the
@@ -175,9 +196,33 @@ struct HostsEditorView: View {
     }
 
     private func loadDraft() {
-        draftName = selectedProfile?.name ?? ""
         draftContent = selectedProfile?.content ?? ""
         if case .system = selection { draftSystemContent = manager.systemHosts }
+    }
+
+    private func addProfile() {
+        manager.createProfile(name: "新配置")
+        // The new profile sorts last (highest displayOrder); select it and drop
+        // straight into inline rename so the user types the name in the list.
+        if let new = manager.profiles.last {
+            selection = .profile(new.id)
+            beginRename(new)
+        }
+    }
+
+    private func beginRename(_ profile: HostProfile) {
+        renamingID = profile.id
+        renameText = profile.name
+        DispatchQueue.main.async { renameFieldFocused = true }
+    }
+
+    private func commitRename() {
+        guard let id = renamingID,
+              let profile = manager.profiles.first(where: { $0.id == id }) else { return }
+        renamingID = nil
+        let name = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != profile.name else { return }
+        Task { await manager.updateProfile(profile, name: name, content: profile.content) }
     }
 
     private func deleteSelected() {

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -23,6 +23,7 @@ struct HostsEditorView: View {
     @State private var draftContent: String = ""
     @State private var draftSystemContent: String = ""
     @State private var showRestoreConfirm = false
+    @State private var showRemoveConfirm = false
 
     var body: some View {
         NavigationSplitView {
@@ -96,11 +97,17 @@ struct HostsEditorView: View {
                         await manager.updateProfile(profile, name: draftName, content: draftContent)
                     }
                     Spacer()
-                    Button("移除托管块") { Task { await manager.removeManagedBlock() } }
+                    Button("移除", role: .destructive) { showRemoveConfirm = true }
+                        .tint(.red)
                     Button("恢复首次备份") { showRestoreConfirm = true }
                 }
             }
             .padding()
+            .confirmationDialog("移除 AnyDoor 托管块？将停用所有配置并从 /etc/hosts 中删除托管内容（系统内容保留）。",
+                                isPresented: $showRemoveConfirm, titleVisibility: .visible) {
+                Button("移除", role: .destructive) { Task { await manager.removeManagedBlock() } }
+                Button("取消", role: .cancel) {}
+            }
             .confirmationDialog("覆盖 /etc/hosts 为首次备份？外部改动将丢失。",
                                 isPresented: $showRestoreConfirm, titleVisibility: .visible) {
                 Button("恢复", role: .destructive) { Task { await manager.restoreFirstRunBackup() } }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -39,6 +39,11 @@ struct HostsEditorView: View {
                             Text(profile.name)
                         }
                         .tag(Selection.profile(profile.id))
+                        .contextMenu {
+                            Button(role: .destructive) { delete(profile) } label: {
+                                Label("删除", systemImage: "trash")
+                            }
+                        }
                     }
                 }
             }
@@ -51,6 +56,8 @@ struct HostsEditorView: View {
                 Task { await manager.setActive(profile, !profile.isActive) }
                 return .handled
             }
+            // Delete / Backspace removes the selected profile.
+            .onDeleteCommand { deleteSelected() }
             .toolbar {
                 ToolbarItem {
                     Button { manager.createProfile(name: "新配置") } label: {
@@ -168,7 +175,11 @@ struct HostsEditorView: View {
 
     private func deleteSelected() {
         guard let profile = selectedProfile else { return }
+        delete(profile)
+    }
+
+    private func delete(_ profile: HostProfile) {
+        if selection == .profile(profile.id) { selection = .system }
         Task { await manager.deleteProfile(profile) }
-        selection = .system
     }
 }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -1,10 +1,18 @@
 import SwiftUI
 
 /// Master-detail editor: profile list on the left, content editor on the right.
-/// System Hosts is read-only with an "open file" action.
+/// System Hosts is editable and rewrites the system portion while preserving
+/// the managed block.
 struct HostsEditorView: View {
     @Bindable var manager: HostsManager
-    @State private var selection: UUID?
+    // A dedicated case for System Hosts instead of a nil UUID tag: List single
+    // selection treats a nil tag as "no selection", which made the System Hosts
+    // row impossible to select.
+    private enum Selection: Hashable {
+        case system
+        case profile(UUID)
+    }
+    @State private var selection: Selection? = .system
     @State private var draftName: String = ""
     @State private var draftContent: String = ""
     @State private var draftSystemContent: String = ""
@@ -14,7 +22,7 @@ struct HostsEditorView: View {
         NavigationSplitView {
             List(selection: $selection) {
                 Section {
-                    Label("系统 Hosts", systemImage: "cpu").tag(Optional<UUID>.none)
+                    Label("系统 Hosts", systemImage: "cpu").tag(Selection.system)
                 }
                 Section {
                     ForEach(manager.profiles) { profile in
@@ -24,7 +32,7 @@ struct HostsEditorView: View {
                                 .onTapGesture { Task { await manager.setActive(profile, !profile.isActive) } }
                             Text(profile.name)
                         }
-                        .tag(Optional(profile.id))
+                        .tag(Selection.profile(profile.id))
                     }
                 }
             }
@@ -97,19 +105,19 @@ struct HostsEditorView: View {
     }
 
     private var selectedProfile: HostProfile? {
-        guard let selection else { return nil }
-        return manager.profiles.first { $0.id == selection }
+        guard case let .profile(id) = selection else { return nil }
+        return manager.profiles.first { $0.id == id }
     }
 
     private func loadDraft() {
         draftName = selectedProfile?.name ?? ""
         draftContent = selectedProfile?.content ?? ""
-        if selection == nil { draftSystemContent = manager.systemHosts }
+        if case .system = selection { draftSystemContent = manager.systemHosts }
     }
 
     private func deleteSelected() {
         guard let profile = selectedProfile else { return }
         Task { await manager.deleteProfile(profile) }
-        selection = nil
+        selection = .system
     }
 }

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
 /// Master-detail editor: profile list on the left, content editor on the right.
-/// System Hosts is editable and rewrites the system portion while preserving
-/// the managed block.
+///
+/// Opens in read-only **view** mode to prevent accidental writes; the user must
+/// click "编辑" to enter **edit** mode. Switching the selected host file resets
+/// back to view mode. System Hosts editing rewrites the system portion while
+/// preserving the managed block.
 struct HostsEditorView: View {
     @Bindable var manager: HostsManager
     // A dedicated case for System Hosts instead of a nil UUID tag: List single
@@ -12,7 +15,10 @@ struct HostsEditorView: View {
         case system
         case profile(UUID)
     }
+    private enum Mode { case view, edit }
+
     @State private var selection: Selection? = .system
+    @State private var mode: Mode = .view
     @State private var draftName: String = ""
     @State private var draftContent: String = ""
     @State private var draftSystemContent: String = ""
@@ -60,21 +66,27 @@ struct HostsEditorView: View {
             detail
         }
         .safeAreaInset(edge: .top) { HelperApprovalBanner() }
-        .onChange(of: selection) { _, _ in loadDraft() }
+        // Switching files always returns to the safe read-only view mode.
+        .onChange(of: selection) { _, _ in
+            mode = .view
+            loadDraft()
+        }
     }
 
     @ViewBuilder
     private var detail: some View {
         if let profile = selectedProfile {
             VStack(alignment: .leading, spacing: 8) {
-                TextField("名称", text: $draftName)
-                    .textFieldStyle(.roundedBorder)
-                TextEditor(text: $draftContent)
-                    .font(.system(.body, design: .monospaced))
-                    .border(.quaternary)
+                if mode == .edit {
+                    TextField("名称", text: $draftName)
+                        .textFieldStyle(.roundedBorder)
+                } else {
+                    Text(draftName).font(.headline)
+                }
+                editorArea(text: $draftContent)
                 HStack {
-                    Button("保存") {
-                        Task { await manager.updateProfile(profile, name: draftName, content: draftContent) }
+                    modeButton {
+                        await manager.updateProfile(profile, name: draftName, content: draftContent)
                     }
                     Spacer()
                     Button("移除托管块") { Task { await manager.removeManagedBlock() } }
@@ -89,26 +101,57 @@ struct HostsEditorView: View {
             }
         } else {
             VStack(alignment: .leading, spacing: 8) {
-                Text("系统 Hosts")
-                    .font(.headline)
-                TextEditor(text: $draftSystemContent)
-                    .font(.system(.body, design: .monospaced))
-                    .border(.quaternary)
+                Text("系统 Hosts").font(.headline)
+                editorArea(text: $draftSystemContent)
                 HStack {
-                    Button("保存") {
-                        Task {
-                            await manager.updateSystemHosts(draftSystemContent)
-                            draftSystemContent = manager.systemHosts
-                        }
+                    modeButton {
+                        await manager.updateSystemHosts(draftSystemContent)
+                        draftSystemContent = manager.systemHosts
                     }
                     Spacer()
-                    Button("用默认编辑器打开") {
-                        HostsFileOpener.open()
-                    }
+                    Button("用默认编辑器打开") { HostsFileOpener.open() }
                 }
             }
             .padding()
             .onAppear { draftSystemContent = manager.systemHosts }
+        }
+    }
+
+    /// The content area: editable in edit mode, a read-only selectable view
+    /// otherwise.
+    @ViewBuilder
+    private func editorArea(text: Binding<String>) -> some View {
+        if mode == .edit {
+            TextEditor(text: text)
+                .font(.system(.body, design: .monospaced))
+                .border(.quaternary)
+        } else {
+            ScrollView {
+                Text(text.wrappedValue.isEmpty ? "（空）" : text.wrappedValue)
+                    .foregroundStyle(text.wrappedValue.isEmpty ? .secondary : .primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .font(.system(.body, design: .monospaced))
+                    .padding(4)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .border(.quaternary)
+        }
+    }
+
+    /// "编辑" in view mode (enters edit mode) or "保存" in edit mode (runs the
+    /// save action, then returns to view mode).
+    @ViewBuilder
+    private func modeButton(save: @escaping () async -> Void) -> some View {
+        if mode == .edit {
+            Button("保存") {
+                Task {
+                    await save()
+                    mode = .view
+                }
+            }
+        } else {
+            Button("编辑") { mode = .edit }
         }
     }
 

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift
@@ -14,7 +14,10 @@ final class HostsEditorWindowController: NSWindowController, NSWindowDelegate {
         )
         panel.title = "Hosts"
         panel.isReleasedWhenClosed = false
-        panel.level = .floating
+        // A normal-level window (not floating) that does not hide when the app
+        // deactivates; RegularWindowCoordinator keeps it reachable via Dock /
+        // Cmd-Tab while it is open.
+        panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         super.init(window: panel)
         panel.delegate = self
@@ -30,6 +33,7 @@ final class HostsEditorWindowController: NSWindowController, NSWindowDelegate {
         host.autoresizingMask = [.width, .height]
         window?.contentView = host
         HostsManager.shared.refresh()
+        if let window { RegularWindowCoordinator.shared.track(window) }
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
         window?.center()

--- a/Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class HostsEditorWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = HostsEditorWindowController()
+
+    private init() {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Hosts"
+        panel.isReleasedWhenClosed = false
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        super.init(window: panel)
+        panel.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    func show() {
+        let view = HostsEditorView(manager: HostsManager.shared)
+        let host = NSHostingView(rootView: view)
+        host.frame = window?.contentLayoutRect ?? .zero
+        host.autoresizingMask = [.width, .height]
+        window?.contentView = host
+        HostsManager.shared.refresh()
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+        window?.center()
+    }
+}

--- a/Sources/AnyDoor/Views/Hosts/HostsFileOpener.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsFileOpener.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+/// Opens `/etc/hosts` in an external editor.
+///
+/// The file has no extension, so the LaunchServices default can resolve to
+/// Terminal — which opens and immediately exits, looking like a crash. Force
+/// TextEdit (located by bundle identifier so it survives OS path changes), and
+/// fall back to revealing the file in Finder if TextEdit is unavailable.
+enum HostsFileOpener {
+    static func open() {
+        let url = URL(fileURLWithPath: "/etc/hosts")
+        if let textEdit = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.TextEdit") {
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            NSWorkspace.shared.open([url], withApplicationAt: textEdit, configuration: config)
+        } else {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -23,7 +23,7 @@ struct HostsManagerPopoverView: View {
                 Text("系统 Hosts")
                 Spacer()
                 Button {
-                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                    HostsFileOpener.open()
                 } label: { Image(systemName: "arrow.up.forward.app") }
                     .buttonStyle(.borderless)
             }

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -10,6 +10,7 @@ struct HostsManagerPopoverView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
+            HelperApprovalBanner()
             if let error = manager.lastError {
                 Text(error)
                     .font(.caption2)
@@ -19,7 +20,7 @@ struct HostsManagerPopoverView: View {
             // System Hosts (read-only)
             HStack {
                 Image(systemName: "cpu")
-                Text("System Hosts")
+                Text("系统 Hosts")
                 Spacer()
                 Button {
                     NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
@@ -62,7 +63,7 @@ struct HostsManagerPopoverView: View {
     }
 
     private func newProfileName() -> String {
-        let base = "New Profile"
+        let base = "新配置"
         let existing = Set(manager.profiles.map(\.name))
         if !existing.contains(base) { return base }
         var i = 2

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -59,6 +59,11 @@ struct HostsManagerPopoverView: View {
             .padding(.horizontal, 8).padding(.vertical, 6)
         }
         .frame(width: 240)
+        // fixedSize forces the full intrinsic height so the hover panel measures
+        // and shows every row instead of clipping the bottom buttons.
+        .fixedSize(horizontal: false, vertical: true)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .onHover { onHoverChange($0) }
     }
 

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -49,16 +49,11 @@ struct HostsManagerPopoverView: View {
             Image(systemName: "list.bullet.rectangle").foregroundStyle(.secondary)
             Text("Hosts 管理").font(.headline)
             Spacer()
-            Button { manager.createProfile(name: newProfileName()) } label: {
-                Image(systemName: "plus")
-            }
-            .buttonStyle(.plain)
-            .help("新建")
             Button { onEdit() } label: {
-                Image(systemName: "pencil")
+                Image(systemName: "macwindow")
             }
             .buttonStyle(.plain)
-            .help("编辑")
+            .help("打开 Hosts 管理窗口")
         }
         .padding(.horizontal, 12).padding(.vertical, 10)
     }
@@ -93,14 +88,5 @@ struct HostsManagerPopoverView: View {
         .onTapGesture {
             Task { await manager.setActive(profile, !profile.isActive) }
         }
-    }
-
-    private func newProfileName() -> String {
-        let base = "新配置"
-        let existing = Set(manager.profiles.map(\.name))
-        if !existing.contains(base) { return base }
-        var i = 2
-        while existing.contains("\(base) \(i)") { i += 1 }
-        return "\(base) \(i)"
     }
 }

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
-/// Hover popover for the Hosts submenu: quick activation toggles, a read-only
-/// System Hosts entry with an "open file" action, and buttons to create/edit.
+/// Hover popover for the Hosts submenu. Matches the shared popover styling
+/// (material card + glass rows): a header carrying the title and the
+/// create/edit actions, a read-only System Hosts entry with an "open file"
+/// action, and quick activation toggles for each profile.
 struct HostsManagerPopoverView: View {
     @Bindable var manager: HostsManager
     let onHoverChange: (Bool) -> Void
@@ -9,62 +11,88 @@ struct HostsManagerPopoverView: View {
     let onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
             HelperApprovalBanner()
             if let error = manager.lastError {
                 Text(error)
                     .font(.caption2)
                     .foregroundStyle(.red)
-                    .padding(.horizontal, 8).padding(.vertical, 4)
-            }
-            // System Hosts (read-only)
-            HStack {
-                Image(systemName: "cpu")
-                Text("系统 Hosts")
-                Spacer()
-                Button {
-                    HostsFileOpener.open()
-                } label: { Image(systemName: "arrow.up.forward.app") }
-                    .buttonStyle(.borderless)
-            }
-            .padding(.horizontal, 8).padding(.vertical, 6)
-
-            Divider()
-
-            ForEach(manager.profiles) { profile in
-                HStack {
-                    Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(profile.isActive ? .green : .secondary)
-                    Text(profile.name)
-                    Spacer()
-                }
-                .contentShape(Rectangle())
-                .padding(.horizontal, 8).padding(.vertical, 6)
-                .onTapGesture {
-                    Task { await manager.setActive(profile, !profile.isActive) }
-                }
+                    .padding(.horizontal, 12).padding(.vertical, 4)
             }
 
-            Divider()
-            HStack {
-                Button { manager.createProfile(name: newProfileName()) } label: {
-                    Label("新建", systemImage: "plus")
-                }
-                Spacer()
-                Button { onEdit() } label: {
-                    Label("编辑", systemImage: "pencil")
+            AdaptiveGlassEffectContainer(spacing: 2) {
+                VStack(spacing: 2) {
+                    systemHostsRow
+                    ForEach(manager.profiles) { profile in
+                        profileRow(profile)
+                    }
                 }
             }
-            .buttonStyle(.borderless)
-            .padding(.horizontal, 8).padding(.vertical, 6)
+            .padding(.horizontal, 6).padding(.vertical, 4)
         }
-        .frame(width: 240)
+        .frame(width: 260)
         // fixedSize forces the full intrinsic height so the hover panel measures
-        // and shows every row instead of clipping the bottom buttons.
+        // and shows every row instead of clipping the bottom rows.
         .fixedSize(horizontal: false, vertical: true)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .onHover { onHoverChange($0) }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "list.bullet.rectangle").foregroundStyle(.secondary)
+            Text("Hosts 管理").font(.headline)
+            Spacer()
+            Button { manager.createProfile(name: newProfileName()) } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.plain)
+            .help("新建")
+            Button { onEdit() } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.plain)
+            .help("编辑")
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+    }
+
+    // MARK: - Rows
+
+    private var systemHostsRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "cpu").foregroundStyle(.secondary)
+            Text("系统 Hosts")
+            Spacer()
+            Button { HostsFileOpener.open() } label: {
+                Image(systemName: "arrow.up.forward.app")
+            }
+            .buttonStyle(.plain)
+            .help("用默认编辑器打开")
+        }
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .adaptiveInteractiveSurface(cornerRadius: 6)
+    }
+
+    private func profileRow(_ profile: HostProfile) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(profile.isActive ? .green : .secondary)
+            Text(profile.name)
+            Spacer()
+        }
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .adaptiveInteractiveSurface(cornerRadius: 6)
+        .onTapGesture {
+            Task { await manager.setActive(profile, !profile.isActive) }
+        }
     }
 
     private func newProfileName() -> String {

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Hover popover for the Hosts submenu: quick activation toggles, a read-only
+/// System Hosts entry with an "open file" action, and buttons to create/edit.
+struct HostsManagerPopoverView: View {
+    @Bindable var manager: HostsManager
+    let onHoverChange: (Bool) -> Void
+    let onEdit: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let error = manager.lastError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+            }
+            // System Hosts (read-only)
+            HStack {
+                Image(systemName: "cpu")
+                Text("System Hosts")
+                Spacer()
+                Button {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                } label: { Image(systemName: "arrow.up.forward.app") }
+                    .buttonStyle(.borderless)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 6)
+
+            Divider()
+
+            ForEach(manager.profiles) { profile in
+                HStack {
+                    Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(profile.isActive ? .green : .secondary)
+                    Text(profile.name)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .padding(.horizontal, 8).padding(.vertical, 6)
+                .onTapGesture {
+                    Task { await manager.setActive(profile, !profile.isActive) }
+                }
+            }
+
+            Divider()
+            HStack {
+                Button { manager.createProfile(name: newProfileName()) } label: {
+                    Label("新建", systemImage: "plus")
+                }
+                Spacer()
+                Button { onEdit() } label: {
+                    Label("编辑", systemImage: "pencil")
+                }
+            }
+            .buttonStyle(.borderless)
+            .padding(.horizontal, 8).padding(.vertical, 6)
+        }
+        .frame(width: 240)
+        .onHover { onHoverChange($0) }
+    }
+
+    private func newProfileName() -> String {
+        let base = "New Profile"
+        let existing = Set(manager.profiles.map(\.name))
+        if !existing.contains(base) { return base }
+        var i = 2
+        while existing.contains("\(base) \(i)") { i += 1 }
+        return "\(base) \(i)"
+    }
+}

--- a/Sources/AnyDoor/Views/Hosts/PlainTextEditor.swift
+++ b/Sources/AnyDoor/Views/Hosts/PlainTextEditor.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import AppKit
+
+/// An `NSTextView`-backed plain-text editor whose layout is identical whether or
+/// not it is editable, so toggling edit mode never shifts the text (a plain
+/// SwiftUI `Text` and `TextEditor` use different insets and visibly jump).
+/// Monospaced, selectable, and scrollable; read-only when `isEditable` is false.
+struct PlainTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    var isEditable: Bool
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSTextView.scrollableTextView()
+        scroll.drawsBackground = false
+        guard let textView = scroll.documentView as? NSTextView else { return scroll }
+        textView.delegate = context.coordinator
+        context.coordinator.textView = textView
+        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.string = text
+        textView.isEditable = isEditable
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let textView = scroll.documentView as? NSTextView else { return }
+        if textView.string != text {
+            textView.string = text
+        }
+        textView.isEditable = isEditable
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(text: $text) }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        private let text: Binding<String>
+        weak var textView: NSTextView?
+        init(text: Binding<String>) { self.text = text }
+
+        // AppKit invokes delegate callbacks on the main thread; hop into the
+        // MainActor context and read from the retained text view (not the
+        // non-Sendable notification) to write back the SwiftUI binding.
+        nonisolated func textDidChange(_ notification: Notification) {
+            MainActor.assumeIsolated {
+                guard let textView else { return }
+                text.wrappedValue = textView.string
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -320,6 +320,10 @@ struct MenuBarView: View {
             popover.show(anchoredTo: convertedTriggerFrame(for: target))
         case .submenu(.hostsManager):
             popover.needsKeyFocus = false
+            // Refresh before measuring so the panel sizes to the current profile
+            // list; deferring this left the popover too short and clipped the
+            // bottom rows.
+            HostsManager.shared.refresh()
             popover.updateContent {
                 HostsManagerPopoverView(
                     manager: HostsManager.shared,
@@ -336,7 +340,6 @@ struct MenuBarView: View {
                     }
                 )
             }
-            Task { HostsManager.shared.refresh() }
             popover.show(anchoredTo: convertedTriggerFrame(for: target))
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -318,6 +318,26 @@ struct MenuBarView: View {
                 )
             }
             popover.show(anchoredTo: convertedTriggerFrame(for: target))
+        case .submenu(.hostsManager):
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                HostsManagerPopoverView(
+                    manager: HostsManager.shared,
+                    onHoverChange: { gate.popoverHover($0) },
+                    onEdit: {
+                        gate.reset()
+                        popover.hide()
+                        HostsEditorWindowController.shared.show()
+                        onRequestClose()
+                    },
+                    onClose: {
+                        gate.reset()
+                        popover.hide()
+                    }
+                )
+            }
+            Task { HostsManager.shared.refresh() }
+            popover.show(anchoredTo: convertedTriggerFrame(for: target))
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.
             break

--- a/Sources/AnyDoor/Views/SettingsView.swift
+++ b/Sources/AnyDoor/Views/SettingsView.swift
@@ -14,5 +14,9 @@ struct SettingsView: View {
                 }
         }
         .frame(width: 560, height: 480)
+        // Adopt .regular activation policy while Settings is open so the window
+        // stays reachable (Dock / Cmd-Tab) instead of vanishing when the user
+        // focuses another app.
+        .background(RegularWindowRegistrar())
     }
 }

--- a/Sources/AnyDoorHostsHelper/HostsHelperListener.swift
+++ b/Sources/AnyDoorHostsHelper/HostsHelperListener.swift
@@ -56,7 +56,8 @@ final class HostsHelperListener: NSObject, NSXPCListenerDelegate, HostsHelperPro
     }
 
     func helperVersion(withReply reply: @escaping (String) -> Void) {
-        reply(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown")
+        // The helper is a bare Mach-O without an Info.plist; read the shared constant instead.
+        reply(HostsHelperConstants.helperVersion)
     }
 
     /// Write to a temp file in /etc (same filesystem so rename is atomic), then

--- a/Sources/AnyDoorHostsHelper/HostsHelperListener.swift
+++ b/Sources/AnyDoorHostsHelper/HostsHelperListener.swift
@@ -1,0 +1,88 @@
+import Foundation
+import HostsHelperShared
+import Security
+import XPCAuditToken
+
+/// XPC listener delegate running as root. Validates each caller's code
+/// signature before exposing the interface, serializes writes, and replaces
+/// /etc/hosts atomically.
+final class HostsHelperListener: NSObject, NSXPCListenerDelegate, HostsHelperProtocol, @unchecked Sendable {
+    private let writeQueue = DispatchQueue(label: "dev.bybee.AnyDoor.HostsHelper.write")
+
+    // anchor apple generic + our Team ID + our app identifier.
+    // TODO(Task 14): verify this OU matches the Developer ID Application cert used for release; detected from the Apple Development cert on the dev machine.
+    private static let clientRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"4GH398M5WH\" and identifier \"dev.bybee.AnyDoor\""
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        guard isValidClient(conn) else { return false }
+        conn.exportedInterface = NSXPCInterface(with: HostsHelperProtocol.self)
+        conn.exportedObject = self
+        conn.resume()
+        return true
+    }
+
+    private func isValidClient(_ conn: NSXPCConnection) -> Bool {
+        // Audit-token guest lookup closes the PID-recycling TOCTOU window that a
+        // PID-based check would leave open.
+        var ok: ObjCBool = false
+        var token = AnyDoorXPCPeerAuditToken(conn, &ok)
+        guard ok.boolValue else { return false }
+        let tokenData = Data(bytes: &token, count: MemoryLayout.size(ofValue: token))
+        let attrs = [kSecGuestAttributeAudit: tokenData] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attrs, [], &code) == errSecSuccess,
+              let code else { return false }
+        var req: SecRequirement?
+        guard SecRequirementCreateWithString(Self.clientRequirement as CFString, [], &req) == errSecSuccess,
+              let req else { return false }
+        return SecCodeCheckValidity(code, [], req) == errSecSuccess
+    }
+
+    // MARK: HostsHelperProtocol
+
+    func writeHosts(_ content: String, withReply reply: @escaping (String?) -> Void) {
+        guard content.utf8.count <= HostsHelperConstants.maxPayloadBytes else {
+            reply("payload too large"); return
+        }
+        writeQueue.async {
+            do {
+                try Self.atomicWrite(content)
+                reply(nil)
+            } catch {
+                reply(String(describing: error))
+            }
+        }
+    }
+
+    func helperVersion(withReply reply: @escaping (String) -> Void) {
+        reply(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown")
+    }
+
+    /// Write to a temp file in /etc (same filesystem so rename is atomic), then
+    /// fsync, set root:wheel 0644, and rename over /etc/hosts.
+    private static func atomicWrite(_ content: String) throws {
+        let dir = "/etc"
+        let template = "\(dir)/.hosts.anydoor.XXXXXX"
+        var bytes = Array(template.utf8) + [0]
+        let fd = bytes.withUnsafeMutableBufferPointer { mkstemp($0.baseAddress!) }
+        guard fd >= 0 else { throw NSError(domain: "hosts", code: Int(errno)) }
+        let tmpPath = String(cString: bytes)
+        defer { unlink(tmpPath) }
+
+        let data = Array(content.utf8)
+        var written = 0
+        while written < data.count {
+            let n = data[written...].withUnsafeBytes { write(fd, $0.baseAddress, data.count - written) }
+            if n <= 0 { close(fd); throw NSError(domain: "hosts", code: Int(errno)) }
+            written += n
+        }
+        fsync(fd)
+        fchown(fd, 0, 0)            // root:wheel
+        fchmod(fd, 0o644)
+        close(fd)
+        guard rename(tmpPath, "\(dir)/hosts") == 0 else {
+            throw NSError(domain: "hosts", code: Int(errno))
+        }
+    }
+}

--- a/Sources/AnyDoorHostsHelper/main.swift
+++ b/Sources/AnyDoorHostsHelper/main.swift
@@ -1,1 +1,9 @@
-// Placeholder entry point; the real listener is added in Task 8.
+import Foundation
+import HostsHelperShared
+
+let delegate = HostsHelperListener()
+let listener = NSXPCListener(machServiceName: HostsHelperConstants.machServiceName)
+listener.delegate = delegate
+listener.resume()
+// On-demand: launchd starts us on connect; exit when idle.
+RunLoop.current.run()

--- a/Sources/AnyDoorHostsHelper/main.swift
+++ b/Sources/AnyDoorHostsHelper/main.swift
@@ -1,0 +1,1 @@
+// Placeholder entry point; the real listener is added in Task 8.

--- a/Sources/HostsHelperShared/HostsHelperProtocol.swift
+++ b/Sources/HostsHelperShared/HostsHelperProtocol.swift
@@ -7,6 +7,8 @@ public enum HostsHelperConstants {
     public static let machServiceName = "dev.bybee.AnyDoor.HostsHelper"
     /// Upper bound on a single write payload (bytes) to bound helper memory.
     public static let maxPayloadBytes = 1_048_576  // 1 MiB
+    /// Bump alongside protocol or behavior changes so the app can detect stale helpers.
+    public static let helperVersion = "1"
 }
 
 /// XPC interface implemented by the root helper.

--- a/Sources/HostsHelperShared/HostsHelperProtocol.swift
+++ b/Sources/HostsHelperShared/HostsHelperProtocol.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Shared identifiers and the XPC contract between the AnyDoor app and the
+/// privileged helper. Kept free of hosts-file parsing logic on purpose.
+public enum HostsHelperConstants {
+    /// Mach service name vended by the LaunchDaemon and connected to by the app.
+    public static let machServiceName = "dev.bybee.AnyDoor.HostsHelper"
+    /// Upper bound on a single write payload (bytes) to bound helper memory.
+    public static let maxPayloadBytes = 1_048_576  // 1 MiB
+}
+
+/// XPC interface implemented by the root helper.
+@objc public protocol HostsHelperProtocol {
+    /// Replace `/etc/hosts` with `content`. Replies with nil on success or an
+    /// error message describing the failure.
+    func writeHosts(_ content: String, withReply reply: @escaping (String?) -> Void)
+    /// Returns the helper's bundle/build version for diagnostics + upgrade checks.
+    func helperVersion(withReply reply: @escaping (String) -> Void)
+}

--- a/Sources/HostsHelperShared/Placeholder.swift
+++ b/Sources/HostsHelperShared/Placeholder.swift
@@ -1,1 +1,0 @@
-// Intentionally empty; real types are added in Task 1.

--- a/Sources/HostsHelperShared/Placeholder.swift
+++ b/Sources/HostsHelperShared/Placeholder.swift
@@ -1,0 +1,1 @@
+// Intentionally empty; real types are added in Task 1.

--- a/Sources/XPCAuditToken/XPCAuditToken.m
+++ b/Sources/XPCAuditToken/XPCAuditToken.m
@@ -1,0 +1,18 @@
+#import "XPCAuditToken.h"
+
+// NSXPCConnection exposes `auditToken` at runtime (stable since 10.8) but the
+// public SDK omits its declaration. Redeclare it so the compiler emits the call.
+@interface NSXPCConnection (AnyDoorAuditToken)
+@property (nonatomic, readonly) audit_token_t auditToken;
+@end
+
+audit_token_t AnyDoorXPCPeerAuditToken(NSXPCConnection *connection, BOOL *ok) {
+    if ([connection respondsToSelector:@selector(auditToken)]) {
+        if (ok) { *ok = YES; }
+        return connection.auditToken;
+    }
+    if (ok) { *ok = NO; }
+    audit_token_t empty;
+    memset(&empty, 0, sizeof(empty));
+    return empty;
+}

--- a/Sources/XPCAuditToken/include/XPCAuditToken.h
+++ b/Sources/XPCAuditToken/include/XPCAuditToken.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <bsm/libbsm.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Returns the peer audit token for an NSXPCConnection. Sets `ok` to false if
+/// the connection does not expose an audit token.
+audit_token_t AnyDoorXPCPeerAuditToken(NSXPCConnection *connection, BOOL *ok);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/AnyDoorTests/HostProfileTests.swift
+++ b/Tests/AnyDoorTests/HostProfileTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+final class HostProfileTests: XCTestCase {
+    func test_init_setsDefaultsAndTimestamps() throws {
+        let p = HostProfile(name: "Dev", content: "1.2.3.4 dev")
+        XCTAssertEqual(p.name, "Dev")
+        XCTAssertEqual(p.content, "1.2.3.4 dev")
+        XCTAssertFalse(p.isActive)
+        XCTAssertEqual(p.displayOrder, 0)
+        XCTAssertEqual(p.createdAt.timeIntervalSince1970,
+                       p.updatedAt.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    @MainActor
+    func test_persistsInInMemoryContainer() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let container = try ModelContainer(for: HostProfile.self, configurations: config)
+        let ctx = container.mainContext
+        ctx.insert(HostProfile(name: "A", content: "x", isActive: true, displayOrder: 100))
+        try ctx.save()
+        let rows = try ctx.fetch(FetchDescriptor<HostProfile>())
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertTrue(rows[0].isActive)
+    }
+}

--- a/Tests/AnyDoorTests/HostsBackupStoreTests.swift
+++ b/Tests/AnyDoorTests/HostsBackupStoreTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import AnyDoor
+
+final class HostsBackupStoreTests: XCTestCase {
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hosts-backup-test-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func test_ensureOriginalBackup_writesSnapshotOnce() throws {
+        let dir = tempDir()
+        var reads = 0
+        let store = HostsBackupStore(backupDirectory: dir, readLiveHosts: {
+            reads += 1
+            return "127.0.0.1 localhost\n"
+        })
+        try store.ensureOriginalBackup()
+        try store.ensureOriginalBackup()  // second call must be a no-op
+        XCTAssertEqual(reads, 1)
+        XCTAssertTrue(store.hasBackup)
+        XCTAssertEqual(store.originalContents(), "127.0.0.1 localhost\n")
+    }
+
+    func test_restoreFirstRunBackup_writesSnapshotThroughWriter() async throws {
+        let dir = tempDir()
+        let store = HostsBackupStore(backupDirectory: dir, readLiveHosts: { "ORIGINAL\n" })
+        try store.ensureOriginalBackup()
+        let mock = MockHostsWriter()
+        try await store.restoreFirstRunBackup(using: mock)
+        XCTAssertEqual(mock.lastWritten, "ORIGINAL\n")
+    }
+}

--- a/Tests/AnyDoorTests/HostsFileTests.swift
+++ b/Tests/AnyDoorTests/HostsFileTests.swift
@@ -79,6 +79,27 @@ final class HostsFileTests: XCTestCase {
         XCTAssertEqual(ends, 1)
     }
 
+    func test_compose_skipsBlankProfile_noBlock() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "")
+        let out = HostsFile.compose(parsed: parsed,
+                                    activeProfiles: [(name: "Empty", content: "")])
+        XCTAssertFalse(out.contains(HostsFile.beginMarker))
+        XCTAssertFalse(out.contains("# --- Empty ---"))
+        XCTAssertTrue(out.contains("127.0.0.1 localhost"))
+    }
+
+    func test_compose_skipsBlankAmongNonBlank() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "")
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Empty", content: "   \n  "),
+                             (name: "Real", content: "1.2.3.4 real")]
+        )
+        XCTAssertTrue(out.contains("# --- Real ---"))
+        XCTAssertTrue(out.contains("1.2.3.4 real"))
+        XCTAssertFalse(out.contains("# --- Empty ---"))
+    }
+
     func test_compose_isIdempotent() {
         let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "tail")
         let profiles = [(name: "A", content: "1.1.1.1 a"), (name: "B", content: "2.2.2.2 b")]

--- a/Tests/AnyDoorTests/HostsFileTests.swift
+++ b/Tests/AnyDoorTests/HostsFileTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import AnyDoor
+
+final class HostsFileTests: XCTestCase {
+    func test_parse_noMarkers_allPrefix() {
+        let raw = "127.0.0.1 localhost\n255.255.255.255 broadcasthost\n"
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, raw)
+        XCTAssertNil(p.managed)
+        XCTAssertEqual(p.suffix, "")
+    }
+
+    func test_parse_splitsPrefixManagedSuffix() {
+        let raw = [
+            "127.0.0.1 localhost",
+            HostsFile.beginMarker,
+            "1.2.3.4 dev.example.com",
+            HostsFile.endMarker,
+            "9.9.9.9 after.example.com",
+        ].joined(separator: "\n")
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, "127.0.0.1 localhost")
+        XCTAssertEqual(p.managed, "1.2.3.4 dev.example.com")
+        XCTAssertEqual(p.suffix, "9.9.9.9 after.example.com")
+    }
+
+    func test_parse_beginWithoutEnd_treatsAllAsPrefix() {
+        let raw = "127.0.0.1 localhost\n\(HostsFile.beginMarker)\n1.2.3.4 x"
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, raw)
+        XCTAssertNil(p.managed)
+    }
+
+    func test_compose_noActiveProfiles_removesBlock_keepsPrefix() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost",
+                                      managed: "old stuff",
+                                      suffix: "")
+        let out = HostsFile.compose(parsed: parsed, activeProfiles: [])
+        XCTAssertFalse(out.contains(HostsFile.beginMarker))
+        XCTAssertTrue(out.contains("127.0.0.1 localhost"))
+    }
+
+    func test_compose_writesBlockBetweenMarkers() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "")
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Dev", content: "1.2.3.4 dev.example.com")]
+        )
+        XCTAssertTrue(out.contains(HostsFile.beginMarker))
+        XCTAssertTrue(out.contains("# --- Dev ---"))
+        XCTAssertTrue(out.contains("1.2.3.4 dev.example.com"))
+        XCTAssertTrue(out.contains(HostsFile.endMarker))
+    }
+
+    func test_compose_preservesSuffix() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost",
+                                      managed: nil,
+                                      suffix: "9.9.9.9 after.example.com")
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Dev", content: "1.2.3.4 dev")]
+        )
+        XCTAssertTrue(out.contains("9.9.9.9 after.example.com"))
+        let endRange = try! XCTUnwrap(out.range(of: HostsFile.endMarker))
+        let suffixRange = try! XCTUnwrap(out.range(of: "9.9.9.9 after.example.com"))
+        XCTAssertTrue(suffixRange.lowerBound > endRange.upperBound)
+    }
+
+    func test_compose_stripsMarkerInjectionFromProfileContent() {
+        let parsed = HostsFile.Parsed(prefix: "", managed: nil, suffix: "")
+        let evil = "1.2.3.4 a\n\(HostsFile.beginMarker)\n\(HostsFile.endMarker)\n5.6.7.8 b"
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Evil", content: evil)]
+        )
+        let begins = out.components(separatedBy: HostsFile.beginMarker).count - 1
+        let ends = out.components(separatedBy: HostsFile.endMarker).count - 1
+        XCTAssertEqual(begins, 1)
+        XCTAssertEqual(ends, 1)
+    }
+
+    func test_compose_isIdempotent() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "tail")
+        let profiles = [(name: "A", content: "1.1.1.1 a"), (name: "B", content: "2.2.2.2 b")]
+        let once = HostsFile.compose(parsed: parsed, activeProfiles: profiles)
+        let twice = HostsFile.compose(parsed: HostsFile.parse(once), activeProfiles: profiles)
+        XCTAssertEqual(once, twice)
+    }
+}

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+@MainActor
+final class HostsManagerTests: XCTestCase {
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        return try ModelContainer(for: HostProfile.self, configurations: config)
+    }
+
+    private func makeManager(writer: HostsWriter,
+                             live: @escaping () -> String = { "127.0.0.1 localhost\n" }) throws
+        -> (HostsManager, ModelContainer) {
+        let container = try makeContainer()
+        let mgr = HostsManager(writer: writer,
+                               backup: HostsBackupStore(backupDirectory: FileManager.default.temporaryDirectory
+                                   .appendingPathComponent(UUID().uuidString), readLiveHosts: live),
+                               readLiveHosts: live)
+        mgr.bootstrap(modelContainer: container)
+        return (mgr, container)
+    }
+
+    func test_createProfile_persists_noSystemWrite() throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        XCTAssertEqual(mgr.profiles.count, 1)
+        XCTAssertEqual(mock.writeCount, 0)  // inactive => no write
+    }
+
+    func test_activateProfile_composesAndWritesActiveContent() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev.example.com")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        XCTAssertTrue(mgr.profiles[0].isActive)
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertTrue(written.contains("127.0.0.1 localhost"))      // prefix preserved
+        XCTAssertTrue(written.contains("1.2.3.4 dev.example.com"))  // active content
+        XCTAssertTrue(written.contains(HostsFile.beginMarker))
+    }
+
+    func test_writeFailure_rollsBack_persistsNothing() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, container) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        mock.errorToThrow = HostsWriterError.writeFailed("denied")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        XCTAssertFalse(mgr.profiles[0].isActive)
+        let rows = try container.mainContext.fetch(FetchDescriptor<HostProfile>())
+        XCTAssertFalse(rows[0].isActive)
+    }
+
+    func test_deactivate_removesManagedBlock() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        let p = mgr.profiles[0]
+        await mgr.setActive(p, true)
+        await mgr.setActive(mgr.profiles[0], false)
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertFalse(written.contains(HostsFile.beginMarker))
+        XCTAssertTrue(written.contains("127.0.0.1 localhost"))
+    }
+}

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -58,7 +58,10 @@ final class HostsManagerTests: XCTestCase {
 
     func test_deactivate_removesManagedBlock() async throws {
         let mock = MockHostsWriter()
-        let (mgr, _) = try makeManager(writer: mock)
+        // Stateful live: each write becomes the new file content, so the no-op
+        // skip behaves as it would against the real /etc/hosts.
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
         mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
         let p = mgr.profiles[0]
         await mgr.setActive(p, true)
@@ -66,6 +69,44 @@ final class HostsManagerTests: XCTestCase {
         let written = try XCTUnwrap(mock.lastWritten)
         XCTAssertFalse(written.contains(HostsFile.beginMarker))
         XCTAssertTrue(written.contains("127.0.0.1 localhost"))
+    }
+
+    // MARK: - Blank profiles never trigger a privileged write
+
+    func test_activateBlankProfile_skipsWrite() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
+        mgr.createProfile(name: "Blank", content: "")
+        await mgr.setActive(mgr.profiles[0], true)
+        XCTAssertEqual(mock.writeCount, 0, "A blank profile changes nothing; no privileged write")
+        XCTAssertTrue(mgr.profiles[0].isActive, "Activation is still recorded in the model")
+    }
+
+    func test_deleteBlankActiveProfile_skipsWrite() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
+        mgr.createProfile(name: "Blank", content: "")
+        await mgr.setActive(mgr.profiles[0], true)
+        await mgr.deleteProfile(mgr.profiles[0])
+        XCTAssertEqual(mock.writeCount, 0, "Deleting a blank profile requires no authorization")
+        XCTAssertEqual(mgr.profiles.count, 0)
+    }
+
+    // MARK: - System hosts editing
+
+    func test_updateSystemHosts_writesEditedPrefix_preservesManagedBlock() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev.example.com")
+        await mgr.setActive(mgr.profiles[0], true)
+        await mgr.updateSystemHosts("10.0.0.1 newsystem")
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertTrue(written.contains("10.0.0.1 newsystem"))       // edited system content
+        XCTAssertTrue(written.contains("1.2.3.4 dev.example.com"))  // managed block preserved
+        XCTAssertTrue(written.contains(HostsFile.beginMarker))
     }
 
     // MARK: - Fix 1: debounce / coalesce

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -10,13 +10,15 @@ final class HostsManagerTests: XCTestCase {
     }
 
     private func makeManager(writer: HostsWriter,
-                             live: @escaping () -> String = { "127.0.0.1 localhost\n" }) throws
+                             live: @escaping () -> String = { "127.0.0.1 localhost\n" },
+                             debounceInterval: Duration = .milliseconds(150)) throws
         -> (HostsManager, ModelContainer) {
         let container = try makeContainer()
         let mgr = HostsManager(writer: writer,
                                backup: HostsBackupStore(backupDirectory: FileManager.default.temporaryDirectory
                                    .appendingPathComponent(UUID().uuidString), readLiveHosts: live),
-                               readLiveHosts: live)
+                               readLiveHosts: live,
+                               debounceInterval: debounceInterval)
         mgr.bootstrap(modelContainer: container)
         return (mgr, container)
     }
@@ -64,5 +66,54 @@ final class HostsManagerTests: XCTestCase {
         let written = try XCTUnwrap(mock.lastWritten)
         XCTAssertFalse(written.contains(HostsFile.beginMarker))
         XCTAssertTrue(written.contains("127.0.0.1 localhost"))
+    }
+
+    // MARK: - Fix 1: debounce / coalesce
+
+    func test_rapidToggles_coalesceIntoSingleWrite() async throws {
+        let mock = MockHostsWriter()
+        // Use a small debounce so the test runs quickly but both calls still land in the window.
+        let (mgr, _) = try makeManager(writer: mock, debounceInterval: .milliseconds(30))
+        mgr.createProfile(name: "Alpha", content: "1.1.1.1 alpha")
+        mgr.createProfile(name: "Beta", content: "2.2.2.2 beta")
+        // Capture IDs to look up profiles after awaiting — avoids sending isolated objects off-actor.
+        let alphaID = mgr.profiles[0].id
+        let betaID = mgr.profiles[1].id
+        // Fire two concurrent activations within the debounce window using Task so they both
+        // enqueue before the debounce window expires, then await both.
+        let t1 = Task { @MainActor in
+            if let p = mgr.profiles.first(where: { $0.id == alphaID }) {
+                await mgr.setActive(p, true)
+            }
+        }
+        let t2 = Task { @MainActor in
+            if let p = mgr.profiles.first(where: { $0.id == betaID }) {
+                await mgr.setActive(p, true)
+            }
+        }
+        await t1.value
+        await t2.value
+        // Only one write should have reached the system.
+        XCTAssertEqual(mock.writeCount, 1, "Rapid concurrent toggles must coalesce into a single write")
+        // The single write must contain both profiles' content.
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertTrue(written.contains("1.1.1.1 alpha"))
+        XCTAssertTrue(written.contains("2.2.2.2 beta"))
+    }
+
+    // MARK: - Fix 3: backup failure surfaced but write proceeds
+
+    func test_backupFailure_surfacedButWriteProceeds() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock, debounceInterval: .milliseconds(1))
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        // Inject a backup failure.
+        mgr.backup.backupErrorOverride = HostsWriterError.writeFailed("backup dir unwritable")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        // Write should still have proceeded.
+        XCTAssertEqual(mock.writeCount, 1, "Write must proceed even when backup creation fails")
+        // lastError must surface the backup warning to the user.
+        XCTAssertNotNil(mgr.lastError, "lastError must be non-nil after backup failure")
     }
 }

--- a/Tests/AnyDoorTests/HostsWriterTests.swift
+++ b/Tests/AnyDoorTests/HostsWriterTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import AnyDoor
+
+final class HostsWriterTests: XCTestCase {
+    func test_mockRecordsLastWrite() async throws {
+        let mock = MockHostsWriter()
+        try await mock.write("hello")
+        XCTAssertEqual(mock.lastWritten, "hello")
+        XCTAssertEqual(mock.writeCount, 1)
+    }
+
+    func test_mockThrowsWhenConfigured() async {
+        let mock = MockHostsWriter()
+        mock.errorToThrow = HostsWriterError.writeFailed("boom")
+        do {
+            try await mock.write("x")
+            XCTFail("expected throw")
+        } catch {
+            XCTAssertEqual(mock.writeCount, 0)
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-03-hosts-editing.md
+++ b/docs/superpowers/plans/2026-06-03-hosts-editing.md
@@ -1,0 +1,1728 @@
+# Hosts Editing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users create/edit/delete named host profiles, activate any subset (merged), and apply them to `/etc/hosts` via a privileged helper, without ever modifying the system's own hosts content.
+
+**Architecture:** A pure-logic `HostsFile` parses `/etc/hosts` into prefix + managed-block + suffix and recomposes only the block. `HostsManager` (@MainActor @Observable, SwiftData-backed, single source of truth) owns profile CRUD and drives writes through a `HostsWriter` protocol — `PrivilegedHelperWriter` (XPC to a root LaunchDaemon registered via `SMAppService`) in production, `AppleScriptWriter` in ad-hoc/dev builds. UI is a menu-bar popover (quick activation) plus a separate editor window.
+
+**Tech Stack:** Swift 6.2 (strict concurrency, `.v6` mode), SwiftData, SwiftUI/AppKit, ServiceManagement (`SMAppService`), NSXPC, Security framework, SPM multi-target.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-hosts-editing-design.md`
+
+---
+
+## Conventions for every task
+
+- All code comments in English. UI-facing strings stay Chinese, added via `L10n` + `Localizable.xcstrings`.
+- Run tests with: `swift test --filter <TestClass>` (single class) or `swift test` (all).
+- Commit messages: Conventional Commits, no `Co-Authored-By`, no watermark, no `@` characters in commit/PR text.
+- Build check after non-test changes: `swift build`.
+
+## Implementation note that refines the spec
+
+The begin/end markers live as `HostsFile` static constants (NOT in `HostsHelperShared`). The helper never parses hosts content — it only writes the final bytes it is handed — so the shared XPC target stays free of hosts-format logic. Markers use plain ASCII (no em-dash) to avoid any encoding ambiguity when round-tripping `/etc/hosts`.
+
+---
+
+## Task 0: SPM scaffolding for shared + helper targets
+
+**Files:**
+- Modify: `Package.swift:22-53`
+- Create: `Sources/HostsHelperShared/Placeholder.swift`
+- Create: `Sources/AnyDoorHostsHelper/main.swift`
+
+- [ ] **Step 1: Add the two targets to Package.swift**
+
+Add a library target `HostsHelperShared`, make `AnyDoor` depend on it, and add an executable target `AnyDoorHostsHelper`. Insert into the `targets:` array (after the `AnyDoor` executable target, before the test target):
+
+```swift
+        .target(
+            name: "HostsHelperShared",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .executableTarget(
+            name: "AnyDoorHostsHelper",
+            dependencies: ["HostsHelperShared"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+```
+
+And add `"HostsHelperShared"` to the `AnyDoor` target's `dependencies` array (currently `Package.swift:30-34`):
+
+```swift
+            dependencies: [
+                .product(name: "AskForPermission", package: "AskForPermission"),
+                .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "DDC", package: "DDC.swift"),
+                "HostsHelperShared",
+            ],
+```
+
+- [ ] **Step 2: Create placeholder sources so the targets compile**
+
+`Sources/HostsHelperShared/Placeholder.swift`:
+
+```swift
+// Intentionally empty; real types are added in Task 1.
+```
+
+`Sources/AnyDoorHostsHelper/main.swift`:
+
+```swift
+// Placeholder entry point; the real listener is added in Task 8.
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `swift build`
+Expected: builds with no errors (placeholder targets compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Package.swift Sources/HostsHelperShared Sources/AnyDoorHostsHelper
+git commit -m "build(hosts): scaffold shared + privileged helper SPM targets"
+```
+
+---
+
+## Task 1: XPC protocol + shared constants
+
+**Files:**
+- Create: `Sources/HostsHelperShared/HostsHelperProtocol.swift`
+- Delete: `Sources/HostsHelperShared/Placeholder.swift`
+
+- [ ] **Step 1: Define the protocol and constants**
+
+`Sources/HostsHelperShared/HostsHelperProtocol.swift`:
+
+```swift
+import Foundation
+
+/// Shared identifiers and the XPC contract between the AnyDoor app and the
+/// privileged helper. Kept free of hosts-file parsing logic on purpose.
+public enum HostsHelperConstants {
+    /// Mach service name vended by the LaunchDaemon and connected to by the app.
+    public static let machServiceName = "dev.bybee.AnyDoor.HostsHelper"
+    /// Upper bound on a single write payload (bytes) to bound helper memory.
+    public static let maxPayloadBytes = 1_048_576  // 1 MiB
+}
+
+/// XPC interface implemented by the root helper.
+@objc public protocol HostsHelperProtocol {
+    /// Replace `/etc/hosts` with `content`. Replies with nil on success or an
+    /// error message describing the failure.
+    func writeHosts(_ content: String, withReply reply: @escaping (String?) -> Void)
+    /// Returns the helper's bundle/build version for diagnostics + upgrade checks.
+    func helperVersion(withReply reply: @escaping (String) -> Void)
+}
+```
+
+- [ ] **Step 2: Remove placeholder and build**
+
+```bash
+rm Sources/HostsHelperShared/Placeholder.swift
+swift build
+```
+Expected: builds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/HostsHelperShared
+git commit -m "feat(hosts): add XPC protocol and shared helper constants"
+```
+
+---
+
+## Task 2: HostsFile parse/compose (pure logic, TDD)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Hosts/HostsFile.swift`
+- Test: `Tests/AnyDoorTests/HostsFileTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+`Tests/AnyDoorTests/HostsFileTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class HostsFileTests: XCTestCase {
+    private func block(_ profiles: [(String, String)]) -> String {
+        HostsFile.compose(
+            parsed: HostsFile.parse(""),
+            activeProfiles: profiles.map { (name: $0.0, content: $0.1) }
+        )
+    }
+
+    func test_parse_noMarkers_allPrefix() {
+        let raw = "127.0.0.1 localhost\n255.255.255.255 broadcasthost\n"
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, raw)
+        XCTAssertNil(p.managed)
+        XCTAssertEqual(p.suffix, "")
+    }
+
+    func test_parse_splitsPrefixManagedSuffix() {
+        let raw = [
+            "127.0.0.1 localhost",
+            HostsFile.beginMarker,
+            "1.2.3.4 dev.example.com",
+            HostsFile.endMarker,
+            "9.9.9.9 after.example.com",
+        ].joined(separator: "\n")
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, "127.0.0.1 localhost")
+        XCTAssertEqual(p.managed, "1.2.3.4 dev.example.com")
+        XCTAssertEqual(p.suffix, "9.9.9.9 after.example.com")
+    }
+
+    func test_parse_beginWithoutEnd_treatsAllAsPrefix() {
+        let raw = "127.0.0.1 localhost\n\(HostsFile.beginMarker)\n1.2.3.4 x"
+        let p = HostsFile.parse(raw)
+        XCTAssertEqual(p.prefix, raw)
+        XCTAssertNil(p.managed)
+    }
+
+    func test_compose_noActiveProfiles_removesBlock_keepsPrefix() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost",
+                                      managed: "old stuff",
+                                      suffix: "")
+        let out = HostsFile.compose(parsed: parsed, activeProfiles: [])
+        XCTAssertFalse(out.contains(HostsFile.beginMarker))
+        XCTAssertTrue(out.contains("127.0.0.1 localhost"))
+    }
+
+    func test_compose_writesBlockBetweenMarkers() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "")
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Dev", content: "1.2.3.4 dev.example.com")]
+        )
+        XCTAssertTrue(out.contains(HostsFile.beginMarker))
+        XCTAssertTrue(out.contains("# --- Dev ---"))
+        XCTAssertTrue(out.contains("1.2.3.4 dev.example.com"))
+        XCTAssertTrue(out.contains(HostsFile.endMarker))
+    }
+
+    func test_compose_preservesSuffix() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost",
+                                      managed: nil,
+                                      suffix: "9.9.9.9 after.example.com")
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Dev", content: "1.2.3.4 dev")]
+        )
+        XCTAssertTrue(out.contains("9.9.9.9 after.example.com"))
+        // suffix must come after the end marker
+        let endRange = try! XCTUnwrap(out.range(of: HostsFile.endMarker))
+        let suffixRange = try! XCTUnwrap(out.range(of: "9.9.9.9 after.example.com"))
+        XCTAssertTrue(suffixRange.lowerBound > endRange.upperBound)
+    }
+
+    func test_compose_stripsMarkerInjectionFromProfileContent() {
+        let parsed = HostsFile.Parsed(prefix: "", managed: nil, suffix: "")
+        let evil = "1.2.3.4 a\n\(HostsFile.beginMarker)\n\(HostsFile.endMarker)\n5.6.7.8 b"
+        let out = HostsFile.compose(
+            parsed: parsed,
+            activeProfiles: [(name: "Evil", content: evil)]
+        )
+        // exactly one begin marker and one end marker survive
+        let begins = out.components(separatedBy: HostsFile.beginMarker).count - 1
+        let ends = out.components(separatedBy: HostsFile.endMarker).count - 1
+        XCTAssertEqual(begins, 1)
+        XCTAssertEqual(ends, 1)
+    }
+
+    func test_compose_isIdempotent() {
+        let parsed = HostsFile.Parsed(prefix: "127.0.0.1 localhost", managed: nil, suffix: "tail")
+        let profiles = [(name: "A", content: "1.1.1.1 a"), (name: "B", content: "2.2.2.2 b")]
+        let once = HostsFile.compose(parsed: parsed, activeProfiles: profiles)
+        let twice = HostsFile.compose(parsed: HostsFile.parse(once), activeProfiles: profiles)
+        XCTAssertEqual(once, twice)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter HostsFileTests`
+Expected: FAIL — `HostsFile` not defined.
+
+- [ ] **Step 3: Implement HostsFile**
+
+`Sources/AnyDoor/Services/Hosts/HostsFile.swift`:
+
+```swift
+import Foundation
+
+/// Pure, side-effect-free parsing and composition of `/etc/hosts`.
+///
+/// `/etc/hosts` is treated as: prefix (system content) + an optional AnyDoor
+/// managed block + suffix (also system content). AnyDoor only ever rewrites
+/// the managed block; prefix and suffix are preserved verbatim.
+enum HostsFile {
+    static let beginMarker = "# >>> AnyDoor managed block - do not edit below this line >>>"
+    static let endMarker = "# <<< AnyDoor managed block end <<<"
+
+    struct Parsed: Equatable {
+        var prefix: String
+        var managed: String?
+        var suffix: String
+    }
+
+    /// Split raw hosts text. When the markers are absent or malformed (begin
+    /// without a following end), the whole file is treated as system prefix.
+    static func parse(_ raw: String) -> Parsed {
+        let lines = raw.components(separatedBy: "\n")
+        guard let beginIdx = lines.firstIndex(of: beginMarker) else {
+            return Parsed(prefix: raw, managed: nil, suffix: "")
+        }
+        let afterBegin = lines[(beginIdx + 1)...]
+        guard let endOffset = afterBegin.firstIndex(of: endMarker) else {
+            return Parsed(prefix: raw, managed: nil, suffix: "")
+        }
+        let prefix = lines[..<beginIdx].joined(separator: "\n")
+        let managed = lines[(beginIdx + 1)..<endOffset].joined(separator: "\n")
+        let suffix = lines[(endOffset + 1)...].joined(separator: "\n")
+        return Parsed(prefix: prefix, managed: managed, suffix: suffix)
+    }
+
+    /// Recompose hosts text: preserved prefix, a freshly built managed block
+    /// for the active profiles (omitted entirely when none), then preserved
+    /// suffix. Output always ends with a single trailing newline.
+    static func compose(parsed: Parsed, activeProfiles: [(name: String, content: String)]) -> String {
+        var sections: [String] = []
+
+        let prefix = trimTrailingNewlines(parsed.prefix)
+        if !prefix.isEmpty { sections.append(prefix) }
+
+        if !activeProfiles.isEmpty {
+            var blockLines: [String] = [beginMarker]
+            for profile in activeProfiles {
+                blockLines.append("# --- \(sanitizeName(profile.name)) ---")
+                let body = trimTrailingNewlines(sanitizeContent(profile.content))
+                if !body.isEmpty { blockLines.append(body) }
+            }
+            blockLines.append(endMarker)
+            sections.append(blockLines.joined(separator: "\n"))
+        }
+
+        let suffix = trimTrailingNewlines(parsed.suffix)
+        if !suffix.isEmpty { sections.append(suffix) }
+
+        return sections.joined(separator: "\n\n") + "\n"
+    }
+
+    /// Remove any lines from profile content that would forge our markers.
+    private static func sanitizeContent(_ content: String) -> String {
+        content
+            .components(separatedBy: "\n")
+            .filter { $0 != beginMarker && $0 != endMarker }
+            .joined(separator: "\n")
+    }
+
+    /// Keep profile names single-line so they cannot break the comment header.
+    private static func sanitizeName(_ name: String) -> String {
+        name.replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private static func trimTrailingNewlines(_ s: String) -> String {
+        var out = s
+        while out.hasSuffix("\n") { out.removeLast() }
+        return out
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --filter HostsFileTests`
+Expected: PASS (all cases). If a whitespace assertion fails, the tests are the spec — adjust the implementation's spacing to satisfy them, not vice versa.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Hosts/HostsFile.swift Tests/AnyDoorTests/HostsFileTests.swift
+git commit -m "feat(hosts): add HostsFile parse/compose with managed-block preservation"
+```
+
+---
+
+## Task 3: HostProfile SwiftData model + schema registration
+
+**Files:**
+- Create: `Sources/AnyDoor/Models/HostProfile.swift`
+- Modify: `Sources/AnyDoor/AppDelegate.swift:27-30` (ModelContainer schema)
+- Test: `Tests/AnyDoorTests/HostProfileTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+`Tests/AnyDoorTests/HostProfileTests.swift`:
+
+```swift
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+final class HostProfileTests: XCTestCase {
+    func test_init_setsDefaultsAndTimestamps() throws {
+        let p = HostProfile(name: "Dev", content: "1.2.3.4 dev")
+        XCTAssertEqual(p.name, "Dev")
+        XCTAssertEqual(p.content, "1.2.3.4 dev")
+        XCTAssertFalse(p.isActive)
+        XCTAssertEqual(p.displayOrder, 0)
+        XCTAssertEqual(p.createdAt.timeIntervalSince1970,
+                       p.updatedAt.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    @MainActor
+    func test_persistsInInMemoryContainer() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let container = try ModelContainer(for: HostProfile.self, configurations: config)
+        let ctx = container.mainContext
+        ctx.insert(HostProfile(name: "A", content: "x", isActive: true, displayOrder: 100))
+        try ctx.save()
+        let rows = try ctx.fetch(FetchDescriptor<HostProfile>())
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertTrue(rows[0].isActive)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter HostProfileTests`
+Expected: FAIL — `HostProfile` not defined.
+
+- [ ] **Step 3: Implement the model**
+
+`Sources/AnyDoor/Models/HostProfile.swift`:
+
+```swift
+import Foundation
+import SwiftData
+
+/// A user-defined hosts profile. Active profiles are merged into the AnyDoor
+/// managed block in `/etc/hosts`. System hosts content is never stored here.
+@Model
+final class HostProfile {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var content: String
+    var isActive: Bool = false
+    var displayOrder: Double = 0
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(name: String, content: String = "", isActive: Bool = false, displayOrder: Double = 0) {
+        self.id = UUID()
+        self.name = name
+        self.content = content
+        self.isActive = isActive
+        self.displayOrder = displayOrder
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}
+```
+
+- [ ] **Step 4: Register in the app's ModelContainer**
+
+Modify `Sources/AnyDoor/AppDelegate.swift:27-30` to add `HostProfile.self`:
+
+```swift
+            modelContainer = try ModelContainer(
+                for: KeyBinding.self, BuiltinPreference.self, ClipboardHistoryItem.self, HostProfile.self,
+                configurations: config
+            )
+```
+
+- [ ] **Step 5: Run to verify pass + build**
+
+Run: `swift test --filter HostProfileTests` (Expected: PASS)
+Run: `swift build` (Expected: success)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/HostProfile.swift Sources/AnyDoor/AppDelegate.swift Tests/AnyDoorTests/HostProfileTests.swift
+git commit -m "feat(hosts): add HostProfile model and register in ModelContainer"
+```
+
+---
+
+## Task 4: HostsWriter protocol + AppleScriptWriter
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Hosts/HostsWriter.swift`
+- Test: `Tests/AnyDoorTests/HostsWriterTests.swift`
+
+The protocol is the seam the business layer depends on. `PrivilegedHelperWriter` is implemented in Task 8 (needs the helper). `AppleScriptWriter` is the dev/ad-hoc fallback. A `MockHostsWriter` is added for tests.
+
+- [ ] **Step 1: Write the failing test (MockHostsWriter behavior)**
+
+`Tests/AnyDoorTests/HostsWriterTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class HostsWriterTests: XCTestCase {
+    func test_mockRecordsLastWrite() async throws {
+        let mock = MockHostsWriter()
+        try await mock.write("hello")
+        XCTAssertEqual(mock.lastWritten, "hello")
+        XCTAssertEqual(mock.writeCount, 1)
+    }
+
+    func test_mockThrowsWhenConfigured() async {
+        let mock = MockHostsWriter()
+        mock.errorToThrow = HostsWriterError.writeFailed("boom")
+        do {
+            try await mock.write("x")
+            XCTFail("expected throw")
+        } catch {
+            XCTAssertEqual(mock.writeCount, 0)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter HostsWriterTests`
+Expected: FAIL — types not defined.
+
+- [ ] **Step 3: Implement protocol, error, AppleScriptWriter, and the test mock**
+
+`Sources/AnyDoor/Services/Hosts/HostsWriter.swift`:
+
+```swift
+import Foundation
+
+enum HostsWriterError: Error, Equatable {
+    case writeFailed(String)
+    case authorizationCancelled
+}
+
+/// Abstraction over the privileged write to `/etc/hosts`. Implementations:
+/// `PrivilegedHelperWriter` (production, XPC), `AppleScriptWriter` (dev fallback).
+protocol HostsWriter: Sendable {
+    func write(_ content: String) async throws
+}
+
+/// Dev / ad-hoc fallback. Writes to an unpredictable temp file then copies it
+/// over `/etc/hosts` with an administrator-authorized shell command. Never
+/// changes the permissions of `/etc/hosts`.
+struct AppleScriptWriter: HostsWriter {
+    func write(_ content: String) async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anydoor-hosts-\(UUID().uuidString)")
+        try content.data(using: .utf8)?.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        // Quote both paths; embed via AppleScript "quoted form of".
+        let script = """
+        do shell script "/bin/cp " & quoted form of "\(tmp.path)" & " /etc/hosts" with administrator privileges
+        """
+        do {
+            _ = try await AppleScriptRunner.run(script)
+        } catch {
+            throw HostsWriterError.writeFailed(String(describing: error))
+        }
+    }
+}
+```
+
+`Sources/AnyDoor/Services/Hosts/MockHostsWriter.swift` (test support, but kept in the app target so tests can `@testable import`):
+
+```swift
+import Foundation
+
+/// In-memory `HostsWriter` for unit tests. Records the last payload and can be
+/// configured to throw.
+final class MockHostsWriter: HostsWriter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lastWritten: String?
+    private var _writeCount = 0
+    var errorToThrow: Error?
+
+    var lastWritten: String? { lock.withLock { _lastWritten } }
+    var writeCount: Int { lock.withLock { _writeCount } }
+
+    func write(_ content: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        lock.withLock {
+            _lastWritten = content
+            _writeCount += 1
+        }
+    }
+}
+```
+
+> Note: confirm `AppleScriptRunner.run(_:)` signature at `Sources/AnyDoor/Services/AppleScriptRunner.swift` (it returns `String` and is `async throws`). Adjust the call if the signature differs.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --filter HostsWriterTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Hosts/HostsWriter.swift Sources/AnyDoor/Services/Hosts/MockHostsWriter.swift Tests/AnyDoorTests/HostsWriterTests.swift
+git commit -m "feat(hosts): add HostsWriter protocol, AppleScript fallback, test mock"
+```
+
+---
+
+## Task 5: HostsBackupStore (TDD)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift`
+- Test: `Tests/AnyDoorTests/HostsBackupStoreTests.swift`
+
+Backup snapshot is plain-file IO into App Support (no privilege). Restore goes through a `HostsWriter`. The store reads the live `/etc/hosts` via an injectable reader so tests don't touch the real file.
+
+- [ ] **Step 1: Write the failing tests**
+
+`Tests/AnyDoorTests/HostsBackupStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import AnyDoor
+
+final class HostsBackupStoreTests: XCTestCase {
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hosts-backup-test-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func test_ensureOriginalBackup_writesSnapshotOnce() throws {
+        let dir = tempDir()
+        var reads = 0
+        let store = HostsBackupStore(backupDirectory: dir, readLiveHosts: {
+            reads += 1
+            return "127.0.0.1 localhost\n"
+        })
+        try store.ensureOriginalBackup()
+        try store.ensureOriginalBackup()  // second call must be a no-op
+        XCTAssertEqual(reads, 1)
+        XCTAssertTrue(store.hasBackup)
+        XCTAssertEqual(store.originalContents(), "127.0.0.1 localhost\n")
+    }
+
+    func test_restoreFirstRunBackup_writesSnapshotThroughWriter() async throws {
+        let dir = tempDir()
+        let store = HostsBackupStore(backupDirectory: dir, readLiveHosts: { "ORIGINAL\n" })
+        try store.ensureOriginalBackup()
+        let mock = MockHostsWriter()
+        try await store.restoreFirstRunBackup(using: mock)
+        XCTAssertEqual(mock.lastWritten, "ORIGINAL\n")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter HostsBackupStoreTests`
+Expected: FAIL — `HostsBackupStore` not defined.
+
+- [ ] **Step 3: Implement HostsBackupStore**
+
+`Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift`:
+
+```swift
+import Foundation
+
+/// One-time snapshot of the user's original `/etc/hosts`, plus restore.
+/// Snapshot is stored in App Support; restore writes back through a HostsWriter.
+struct HostsBackupStore {
+    private let backupURL: URL
+    private let readLiveHosts: () throws -> String
+
+    init(backupDirectory: URL, readLiveHosts: @escaping () throws -> String) {
+        self.backupURL = backupDirectory.appendingPathComponent("original.hosts")
+        self.readLiveHosts = readLiveHosts
+    }
+
+    /// Default production location: App Support/dev.bybee.AnyDoor/hosts-backup.
+    static func makeDefault() -> HostsBackupStore {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport
+            .appendingPathComponent("dev.bybee.AnyDoor", isDirectory: true)
+            .appendingPathComponent("hosts-backup", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return HostsBackupStore(backupDirectory: dir, readLiveHosts: {
+            try String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)
+        })
+    }
+
+    var hasBackup: Bool { FileManager.default.fileExists(atPath: backupURL.path) }
+
+    func originalContents() -> String? {
+        try? String(contentsOf: backupURL, encoding: .utf8)
+    }
+
+    /// Snapshot the current `/etc/hosts` exactly once. No-op if a backup exists.
+    func ensureOriginalBackup() throws {
+        guard !hasBackup else { return }
+        let live = try readLiveHosts()
+        try live.data(using: .utf8)?.write(to: backupURL)
+    }
+
+    /// Overwrite `/etc/hosts` with the first-run snapshot (destructive; the UI
+    /// must confirm before calling this).
+    func restoreFirstRunBackup(using writer: HostsWriter) async throws {
+        guard let original = originalContents() else {
+            throw HostsWriterError.writeFailed("no backup available")
+        }
+        try await writer.write(original)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --filter HostsBackupStoreTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Hosts/HostsBackupStore.swift Tests/AnyDoorTests/HostsBackupStoreTests.swift
+git commit -m "feat(hosts): add one-time backup store with restore"
+```
+
+---
+
+## Task 6: HostsManager (single source of truth, TDD)
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Hosts/HostsManager.swift`
+- Test: `Tests/AnyDoorTests/HostsManagerTests.swift`
+
+`HostsManager` mirrors `PanelStore` (`@MainActor @Observable`, `bootstrap(modelContainer:)`, SwiftData-backed). For testability it takes an injectable `writer` and an injectable `readLiveHosts`. The shared singleton uses production defaults; tests construct an isolated instance.
+
+Persisted-state semantics (from the spec): editing a non-active profile saves immediately; toggling `isActive` or editing an active profile applies first and persists only on success.
+
+- [ ] **Step 1: Write the failing tests**
+
+`Tests/AnyDoorTests/HostsManagerTests.swift`:
+
+```swift
+import XCTest
+import SwiftData
+@testable import AnyDoor
+
+@MainActor
+final class HostsManagerTests: XCTestCase {
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        return try ModelContainer(for: HostProfile.self, configurations: config)
+    }
+
+    private func makeManager(writer: HostsWriter,
+                             live: @escaping () -> String = { "127.0.0.1 localhost\n" }) throws
+        -> (HostsManager, ModelContainer) {
+        let container = try makeContainer()
+        let mgr = HostsManager(writer: writer,
+                               backup: HostsBackupStore(backupDirectory: FileManager.default.temporaryDirectory
+                                   .appendingPathComponent(UUID().uuidString), readLiveHosts: live),
+                               readLiveHosts: live)
+        mgr.bootstrap(modelContainer: container)
+        return (mgr, container)
+    }
+
+    func test_createProfile_persists_noSystemWrite() throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        XCTAssertEqual(mgr.profiles.count, 1)
+        XCTAssertEqual(mock.writeCount, 0)  // inactive => no write
+    }
+
+    func test_activateProfile_composesAndWritesActiveContent() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev.example.com")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        XCTAssertTrue(mgr.profiles[0].isActive)
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertTrue(written.contains("127.0.0.1 localhost"))      // prefix preserved
+        XCTAssertTrue(written.contains("1.2.3.4 dev.example.com"))  // active content
+        XCTAssertTrue(written.contains(HostsFile.beginMarker))
+    }
+
+    func test_writeFailure_rollsBack_persistsNothing() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, container) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        mock.errorToThrow = HostsWriterError.writeFailed("denied")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        // in-memory rolled back
+        XCTAssertFalse(mgr.profiles[0].isActive)
+        // nothing persisted as active
+        let rows = try container.mainContext.fetch(FetchDescriptor<HostProfile>())
+        XCTAssertFalse(rows[0].isActive)
+    }
+
+    func test_deactivate_removesManagedBlock() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        let p = mgr.profiles[0]
+        await mgr.setActive(p, true)
+        await mgr.setActive(mgr.profiles[0], false)
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertFalse(written.contains(HostsFile.beginMarker))
+        XCTAssertTrue(written.contains("127.0.0.1 localhost"))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `swift test --filter HostsManagerTests`
+Expected: FAIL — `HostsManager` not defined.
+
+- [ ] **Step 3: Implement HostsManager**
+
+`Sources/AnyDoor/Services/Hosts/HostsManager.swift`:
+
+```swift
+import Foundation
+import SwiftData
+import OSLog
+import Observation
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts")
+
+/// Single source of truth for host profiles. SwiftData-backed, @MainActor.
+/// Persisted state always equals what was successfully applied to the system.
+@Observable @MainActor
+final class HostsManager {
+    static let shared = HostsManager(
+        writer: HostsManager.makeDefaultWriter(),
+        backup: HostsBackupStore.makeDefault(),
+        readLiveHosts: { (try? String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)) ?? "" }
+    )
+
+    private(set) var profiles: [HostProfile] = []
+    /// System content (prefix + suffix) shown read-only in the UI.
+    private(set) var systemHosts: String = ""
+    private(set) var lastError: String?
+
+    private let writer: HostsWriter
+    private let backup: HostsBackupStore
+    private let readLiveHosts: () -> String
+    private var modelContainer: ModelContainer?
+
+    init(writer: HostsWriter, backup: HostsBackupStore, readLiveHosts: @escaping () -> String) {
+        self.writer = writer
+        self.backup = backup
+        self.readLiveHosts = readLiveHosts
+    }
+
+    /// Production writer selection: privileged helper when registered, else
+    /// the AppleScript fallback (ad-hoc/dev builds).
+    private static func makeDefaultWriter() -> HostsWriter {
+        if HelperManager.shared.ensureRegistered() {
+            return PrivilegedHelperWriter()
+        }
+        return AppleScriptWriter()
+    }
+
+    func bootstrap(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        reload()
+    }
+
+    func reload() {
+        guard let context = modelContainer?.mainContext else { return }
+        profiles = (try? context.fetch(
+            FetchDescriptor<HostProfile>(sortBy: [SortDescriptor(\.displayOrder)])
+        )) ?? []
+        let parsed = HostsFile.parse(readLiveHosts())
+        systemHosts = [parsed.prefix, parsed.suffix]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    func refresh() { reload() }
+
+    // MARK: - Mutations
+
+    func createProfile(name: String, content: String = "") {
+        guard let context = modelContainer?.mainContext else { return }
+        let nextOrder = (profiles.map(\.displayOrder).max() ?? 0) + 100
+        context.insert(HostProfile(name: name, content: content, displayOrder: nextOrder))
+        try? context.save()
+        reload()
+    }
+
+    func deleteProfile(_ profile: HostProfile) async {
+        guard let context = modelContainer?.mainContext else { return }
+        let wasActive = profile.isActive
+        context.delete(profile)
+        try? context.save()
+        reload()
+        if wasActive { await applyToSystem() }  // deleting an active profile re-applies
+    }
+
+    /// Edit a profile. Persists immediately; re-applies only if active.
+    func updateProfile(_ profile: HostProfile, name: String, content: String) async {
+        profile.name = name
+        profile.content = content
+        profile.updatedAt = Date()
+        if profile.isActive {
+            await applyAndPersist()
+        } else {
+            try? modelContainer?.mainContext.save()
+            reload()
+        }
+    }
+
+    /// Toggle activation. Applies first; persists only on success.
+    func setActive(_ profile: HostProfile, _ active: Bool) async {
+        let previous = profile.isActive
+        profile.isActive = active
+        await applyAndPersist(onFailureRollback: { profile.isActive = previous })
+    }
+
+    /// DEFAULT safe restore: remove only AnyDoor's managed block.
+    func removeManagedBlock() async {
+        for p in profiles { p.isActive = false }
+        await applyAndPersist()
+    }
+
+    /// Destructive restore (UI must confirm): overwrite with first-run backup.
+    func restoreFirstRunBackup() async {
+        do {
+            try await backup.restoreFirstRunBackup(using: writer)
+            for p in profiles { p.isActive = false }
+            try? modelContainer?.mainContext.save()
+            reload()
+        } catch {
+            lastError = String(describing: error)
+        }
+    }
+
+    // MARK: - Apply
+
+    private func applyAndPersist(onFailureRollback rollback: (() -> Void)? = nil) async {
+        do {
+            try? backup.ensureOriginalBackup()
+            try await applyToSystemThrowing()
+            try? modelContainer?.mainContext.save()
+            lastError = nil
+            reload()
+        } catch {
+            rollback?()
+            lastError = String(describing: error)
+            logger.error("Apply failed: \(error)")
+            reload()
+        }
+    }
+
+    /// Non-throwing convenience used by delete (state already persisted).
+    private func applyToSystem() async {
+        try? backup.ensureOriginalBackup()
+        do { try await applyToSystemThrowing() } catch { lastError = String(describing: error) }
+    }
+
+    private func applyToSystemThrowing() async throws {
+        let parsed = HostsFile.parse(readLiveHosts())
+        let active = profiles
+            .filter(\.isActive)
+            .sorted { $0.displayOrder < $1.displayOrder }
+            .map { (name: $0.name, content: $0.content) }
+        let newContent = HostsFile.compose(parsed: parsed, activeProfiles: active)
+        try await writer.write(newContent)
+    }
+}
+```
+
+> Note: `PrivilegedHelperWriter` and `HelperManager` are defined in Tasks 7-8. To keep this task self-contained and green, temporarily implement `makeDefaultWriter()` to `return AppleScriptWriter()` and add a `// TODO(Task 7): prefer PrivilegedHelperWriter` line; switch it in Task 8 Step 5. The tests inject their own writer and never call `makeDefaultWriter()`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --filter HostsManagerTests`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Hosts/HostsManager.swift Tests/AnyDoorTests/HostsManagerTests.swift
+git commit -m "feat(hosts): add HostsManager with apply-then-persist semantics"
+```
+
+---
+
+## Task 7: HelperManager (SMAppService) — SPIKE FIRST
+
+**Files:**
+- Create: `Sources/AnyDoor/Services/Hosts/HelperManager.swift`
+
+> **SPIKE (do before writing final code):** On a signed/notarized build, verify with a throwaway minimal helper that `SMAppService.daemon(plistName:)` registers, surfaces `.requiresApproval`, and runs as root. Confirm the exact plist location in the bundle (`Contents/Library/LaunchDaemons/`), required plist keys, and the helper's embedded `Info.plist` requirements against current docs (use ctx7: query "SMAppService daemon register privileged helper"). Record findings as comments in `HelperManager.swift`. Do NOT assume legacy `SMJobBless` / `SMAuthorizedClients` semantics.
+
+- [ ] **Step 1: Implement HelperManager covering the full status space**
+
+`Sources/AnyDoor/Services/Hosts/HelperManager.swift`:
+
+```swift
+import Foundation
+import ServiceManagement
+import OSLog
+
+private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts.helper")
+
+/// Manages the privileged LaunchDaemon lifecycle via SMAppService.
+@MainActor
+final class HelperManager {
+    static let shared = HelperManager()
+
+    static let plistName = "dev.bybee.AnyDoor.HostsHelper.plist"
+
+    enum Readiness {
+        case enabled
+        case requiresApproval
+        case unavailable   // ad-hoc/dev build, or registration failed
+    }
+
+    private var service: SMAppService { SMAppService.daemon(plistName: Self.plistName) }
+
+    /// True only when the daemon is registered and enabled. Used to pick the
+    /// production writer; false routes to the AppleScript fallback.
+    func ensureRegistered() -> Bool {
+        switch readiness() {
+        case .enabled:
+            return true
+        case .requiresApproval:
+            return false
+        case .unavailable:
+            do {
+                try service.register()
+                return service.status == .enabled
+            } catch {
+                logger.error("Helper register failed: \(error)")
+                return false
+            }
+        }
+    }
+
+    func readiness() -> Readiness {
+        switch service.status {
+        case .enabled: return .enabled
+        case .requiresApproval: return .requiresApproval
+        case .notRegistered: return .unavailable
+        case .notFound: return .unavailable
+        @unknown default: return .unavailable
+        }
+    }
+
+    func openApprovalSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: success. (Behavioral verification happens in the Task 14 spike on a signed build; ad-hoc builds return `.unavailable` and fall back.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/Services/Hosts/HelperManager.swift
+git commit -m "feat(hosts): add SMAppService helper lifecycle manager"
+```
+
+---
+
+## Task 8: Privileged helper executable + PrivilegedHelperWriter
+
+**Files:**
+- Modify: `Sources/AnyDoorHostsHelper/main.swift`
+- Create: `Sources/AnyDoorHostsHelper/HostsHelperListener.swift`
+- Create: `Sources/AnyDoor/Services/Hosts/PrivilegedHelperWriter.swift`
+- Create: `Resources/dev.bybee.AnyDoor.HostsHelper.plist`
+- Modify: `Sources/AnyDoor/Services/Hosts/HostsManager.swift` (switch default writer)
+
+> Replace `<TEAM_ID>` below with the real Apple Developer Team ID (find via `security find-identity -v -p codesigning` — the 10-char OU in the "Developer ID Application" cert). Keep it out of commit messages.
+
+- [ ] **Step 1: Implement the listener with caller validation, serial writes, atomic replace**
+
+`Sources/AnyDoorHostsHelper/HostsHelperListener.swift`:
+
+```swift
+import Foundation
+import HostsHelperShared
+import Security
+
+/// XPC listener delegate running as root. Validates each caller's code
+/// signature before exposing the interface, serializes writes, and replaces
+/// /etc/hosts atomically.
+final class HostsHelperListener: NSObject, NSXPCListenerDelegate, HostsHelperProtocol, @unchecked Sendable {
+    private let writeQueue = DispatchQueue(label: "dev.bybee.AnyDoor.HostsHelper.write")
+
+    // anchor apple generic + our Team ID + our app identifier.
+    private static let clientRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\" and identifier \"dev.bybee.AnyDoor\""
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        guard isValidClient(conn) else { return false }
+        conn.exportedInterface = NSXPCInterface(with: HostsHelperProtocol.self)
+        conn.exportedObject = self
+        conn.resume()
+        return true
+    }
+
+    private func isValidClient(_ conn: NSXPCConnection) -> Bool {
+        var token = conn.auditToken
+        let tokenData = Data(bytes: &token, count: MemoryLayout.size(ofValue: token))
+        let attrs = [kSecGuestAttributeAudit: tokenData] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attrs, [], &code) == errSecSuccess,
+              let code else { return false }
+        var req: SecRequirement?
+        guard SecRequirementCreateWithString(Self.clientRequirement as CFString, [], &req) == errSecSuccess,
+              let req else { return false }
+        return SecCodeCheckValidity(code, [], req) == errSecSuccess
+    }
+
+    // MARK: HostsHelperProtocol
+
+    func writeHosts(_ content: String, withReply reply: @escaping (String?) -> Void) {
+        guard content.utf8.count <= HostsHelperConstants.maxPayloadBytes else {
+            reply("payload too large"); return
+        }
+        writeQueue.async {
+            do {
+                try Self.atomicWrite(content)
+                reply(nil)
+            } catch {
+                reply(String(describing: error))
+            }
+        }
+    }
+
+    func helperVersion(withReply reply: @escaping (String) -> Void) {
+        reply(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown")
+    }
+
+    /// Write to a temp file in /etc (same filesystem so rename is atomic), then
+    /// fsync, set root:wheel 0644, and rename over /etc/hosts.
+    private static func atomicWrite(_ content: String) throws {
+        let dir = "/etc"
+        let template = "\(dir)/.hosts.anydoor.XXXXXX"
+        var bytes = Array(template.utf8) + [0]
+        let fd = bytes.withUnsafeMutableBufferPointer { mkstemp($0.baseAddress!) }
+        guard fd >= 0 else { throw NSError(domain: "hosts", code: Int(errno)) }
+        let tmpPath = String(cString: bytes)
+        defer { unlink(tmpPath) }
+
+        let data = Array(content.utf8)
+        var written = 0
+        while written < data.count {
+            let n = data[written...].withUnsafeBytes { write(fd, $0.baseAddress, data.count - written) }
+            if n <= 0 { close(fd); throw NSError(domain: "hosts", code: Int(errno)) }
+            written += n
+        }
+        fsync(fd)
+        fchown(fd, 0, 0)            // root:wheel
+        fchmod(fd, 0o644)
+        close(fd)
+        guard rename(tmpPath, "\(dir)/hosts") == 0 else {
+            throw NSError(domain: "hosts", code: Int(errno))
+        }
+    }
+}
+```
+
+`Sources/AnyDoorHostsHelper/main.swift`:
+
+```swift
+import Foundation
+import HostsHelperShared
+
+let delegate = HostsHelperListener()
+let listener = NSXPCListener(machServiceName: HostsHelperConstants.machServiceName)
+listener.delegate = delegate
+listener.resume()
+// On-demand: launchd starts us on connect; exit when idle.
+RunLoop.current.run()
+```
+
+- [ ] **Step 2: Implement PrivilegedHelperWriter (app side)**
+
+`Sources/AnyDoor/Services/Hosts/PrivilegedHelperWriter.swift`:
+
+```swift
+import Foundation
+import HostsHelperShared
+
+/// Production writer: sends the composed hosts content to the root helper over XPC.
+struct PrivilegedHelperWriter: HostsWriter {
+    func write(_ content: String) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let conn = NSXPCConnection(machServiceName: HostsHelperConstants.machServiceName,
+                                       options: .privileged)
+            conn.remoteObjectInterface = NSXPCInterface(with: HostsHelperProtocol.self)
+            conn.resume()
+            let proxy = conn.remoteObjectProxyWithErrorHandler { error in
+                cont.resume(throwing: HostsWriterError.writeFailed(String(describing: error)))
+            } as? HostsHelperProtocol
+            guard let proxy else {
+                conn.invalidate()
+                cont.resume(throwing: HostsWriterError.writeFailed("no proxy"))
+                return
+            }
+            proxy.writeHosts(content) { errorMessage in
+                conn.invalidate()
+                if let errorMessage {
+                    cont.resume(throwing: HostsWriterError.writeFailed(errorMessage))
+                } else {
+                    cont.resume(returning: ())
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Create the LaunchDaemon plist**
+
+`Resources/dev.bybee.AnyDoor.HostsHelper.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.bybee.AnyDoor.HostsHelper</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/AnyDoorHostsHelper</string>
+    <key>MachServices</key>
+    <dict>
+        <key>dev.bybee.AnyDoor.HostsHelper</key>
+        <true/>
+    </dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>dev.bybee.AnyDoor</string>
+    </array>
+</dict>
+</plist>
+```
+
+> The plist must NOT live inside the SPM `.process("Resources")` bundle (that lands in `AnyDoor_AnyDoor.bundle`, not `Contents/Library/LaunchDaemons/`). Keep this file at the repo's top-level `Resources/` and copy it explicitly in Task 13. If `Resources/` is wholly consumed by SPM resource processing for the app target, place it under a new `HelperSupport/` directory instead and update Task 13's `cp` path. Confirm against the SPIKE finding.
+
+- [ ] **Step 4: Switch HostsManager default writer to prefer the helper**
+
+In `Sources/AnyDoor/Services/Hosts/HostsManager.swift`, restore the real `makeDefaultWriter()` (undo the Task 6 temporary):
+
+```swift
+    private static func makeDefaultWriter() -> HostsWriter {
+        if HelperManager.shared.ensureRegistered() {
+            return PrivilegedHelperWriter()
+        }
+        return AppleScriptWriter()
+    }
+```
+
+- [ ] **Step 5: Build both products**
+
+Run: `swift build`
+Run: `swift build --product AnyDoorHostsHelper`
+Expected: both succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnyDoorHostsHelper Sources/AnyDoor/Services/Hosts/PrivilegedHelperWriter.swift Resources/dev.bybee.AnyDoor.HostsHelper.plist Sources/AnyDoor/Services/Hosts/HostsManager.swift
+git commit -m "feat(hosts): add root helper, XPC writer, and LaunchDaemon plist"
+```
+
+---
+
+## Task 9: BuiltinItem.hostsManager + localization
+
+**Files:**
+- Modify: `Sources/AnyDoor/Models/BuiltinItem.swift` (5 switch sites)
+- Modify: `Sources/AnyDoor/Utilities/L10n.swift:226` (add case)
+- Modify: `Sources/AnyDoor/Resources/Localizable.xcstrings` (add entry)
+- Test: existing `BuiltinItemLocalizationTests`, `LocalizationCoverageTests`, `BuiltinPreferenceSeederTests` must pass.
+
+- [ ] **Step 1: Add the enum case + all five switch arms**
+
+In `Sources/AnyDoor/Models/BuiltinItem.swift`:
+- Add to the case list (after `.windowLayout`, line 49): `case hostsManager`
+- `kind` (line 61): add `.hostsManager` to the `.submenu` arm → `case .appShortcuts, .portManager, .windowLayout, .hostsManager: return .submenu`
+- `titleKey` (after line 123): `case .hostsManager:      return .builtinHostsManager`
+- `symbol` (after line 172): `case .hostsManager: return "list.bullet.rectangle"`
+- `defaultOrder` (after line 222): `case .hostsManager: return 1950`
+
+- [ ] **Step 2: Add the L10n key (alphabetical by raw value)**
+
+In `Sources/AnyDoor/Utilities/L10n.swift`, add near the other `builtin.*` cases (keep alphabetical; `builtin.hostsManager` sits between `builtinHideDock` line 19 and `builtinKeepAwake` line 20):
+
+```swift
+        case builtinHostsManager = "builtin.hostsManager"
+```
+
+- [ ] **Step 3: Add the translations to the string catalog**
+
+In `Sources/AnyDoor/Resources/Localizable.xcstrings`, add a `"builtin.hostsManager"` entry mirroring the structure of the existing `"builtin.portManager"` entry, with:
+- `en` value: `Hosts`
+- `zh-Hans` value: `Hosts 管理`
+
+Open the file, find the `"builtin.portManager"` block under the top-level `"strings"` object, copy its shape, and insert the new key with both `localizations`. (`LocalizationCoverageTests.test_everyL10nKeyHasZhHansAndEnTranslations` enforces both languages exist and are non-empty.)
+
+- [ ] **Step 4: Run the localization + seeder tests**
+
+Run: `swift test --filter BuiltinItemLocalizationTests`
+Run: `swift test --filter LocalizationCoverageTests`
+Run: `swift test --filter BuiltinPreferenceSeederTests`
+Expected: PASS. (`testSeedsAllItemsOnEmptyStore` now expects the new count automatically via `BuiltinItem.allCases.count`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnyDoor/Models/BuiltinItem.swift Sources/AnyDoor/Utilities/L10n.swift Sources/AnyDoor/Resources/Localizable.xcstrings
+git commit -m "feat(hosts): register hostsManager built-in submenu with localization"
+```
+
+---
+
+## Task 10: AppDelegate bootstrap
+
+**Files:**
+- Modify: `Sources/AnyDoor/AppDelegate.swift` (after PanelStore bootstrap, ~line 109)
+
+- [ ] **Step 1: Bootstrap HostsManager with the shared container**
+
+In `applicationDidFinishLaunching`, after `PanelStore.shared.bootstrap(...)` (line 109), add:
+
+```swift
+        HostsManager.shared.bootstrap(modelContainer: modelContainer)
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnyDoor/AppDelegate.swift
+git commit -m "feat(hosts): bootstrap HostsManager from AppDelegate"
+```
+
+---
+
+## Task 11: Popover quick-activation UI + MenuBar wiring
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift`
+- Modify: `Sources/AnyDoor/Views/MenuBarView.swift:259-323` (add `.submenu(.hostsManager)` branch)
+
+- [ ] **Step 1: Build the popover view**
+
+`Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift`:
+
+```swift
+import SwiftUI
+
+/// Hover popover for the Hosts submenu: quick activation toggles, a read-only
+/// System Hosts entry with an "open file" action, and buttons to create/edit.
+struct HostsManagerPopoverView: View {
+    @Bindable var manager: HostsManager
+    let onHoverChange: (Bool) -> Void
+    let onEdit: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let error = manager.lastError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+            }
+            // System Hosts (read-only)
+            HStack {
+                Image(systemName: "cpu")
+                Text("System Hosts")
+                Spacer()
+                Button {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                } label: { Image(systemName: "arrow.up.forward.app") }
+                    .buttonStyle(.borderless)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 6)
+
+            Divider()
+
+            ForEach(manager.profiles) { profile in
+                HStack {
+                    Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(profile.isActive ? .green : .secondary)
+                    Text(profile.name)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .padding(.horizontal, 8).padding(.vertical, 6)
+                .onTapGesture {
+                    Task { await manager.setActive(profile, !profile.isActive) }
+                }
+            }
+
+            Divider()
+            HStack {
+                Button { manager.createProfile(name: newProfileName()) } label: {
+                    Label("新建", systemImage: "plus")
+                }
+                Spacer()
+                Button { onEdit() } label: {
+                    Label("编辑", systemImage: "pencil")
+                }
+            }
+            .buttonStyle(.borderless)
+            .padding(.horizontal, 8).padding(.vertical, 6)
+        }
+        .frame(width: 240)
+        .onHover { onHoverChange($0) }
+    }
+
+    private func newProfileName() -> String {
+        let base = "New Profile"
+        let existing = Set(manager.profiles.map(\.name))
+        if !existing.contains(base) { return base }
+        var i = 2
+        while existing.contains("\(base) \(i)") { i += 1 }
+        return "\(base) \(i)"
+    }
+}
+```
+
+> UI strings here ("新建"/"编辑") should ideally be `L10n` keys for consistency. If the reviewer wants them localized, add `hostsNew` / `hostsEdit` keys following Task 9's pattern. Kept inline here to stay within the YAGNI line for v1; flag for review.
+
+- [ ] **Step 2: Wire the popover into MenuBarView**
+
+In `Sources/AnyDoor/Views/MenuBarView.swift`, add a new case in `mountPopoverContent(for:)` before the catch-all `case .submenu:` (currently line 321):
+
+```swift
+        case .submenu(.hostsManager):
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                HostsManagerPopoverView(
+                    manager: HostsManager.shared,
+                    onHoverChange: { gate.popoverHover($0) },
+                    onEdit: {
+                        gate.reset()
+                        popover.hide()
+                        HostsEditorWindowController.shared.show()
+                        onRequestClose()
+                    },
+                    onClose: {
+                        gate.reset()
+                        popover.hide()
+                    }
+                )
+            }
+            Task { HostsManager.shared.refresh() }
+            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+```
+
+> `HostsEditorWindowController.shared.show()` is defined in Task 12. If implementing strictly task-by-task, temporarily replace the `onEdit` body with `popover.hide()` and a `// TODO(Task 12)` until Task 12 lands, then wire it.
+
+- [ ] **Step 3: Build + run smoke check**
+
+Run: `swift build`
+Expected: success.
+Run: `swift run AnyDoor` — hover the Hosts row in the menu bar; the popover lists System Hosts + profiles; toggling a profile triggers a write (in dev this prompts for admin via AppleScript fallback).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift Sources/AnyDoor/Views/MenuBarView.swift
+git commit -m "feat(hosts): add quick-activation popover and menu bar wiring"
+```
+
+---
+
+## Task 12: Editor window (master-detail)
+
+**Files:**
+- Create: `Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift`
+- Create: `Sources/AnyDoor/Views/Hosts/HostsEditorView.swift`
+
+Follow the `CommandPaletteWindowController` pattern (`Sources/AnyDoor/Views/CommandPaletteWindowController.swift:4-85`): singleton, `NSPanel`, `NSHostingView`, activate-then-key.
+
+- [ ] **Step 1: Window controller**
+
+`Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift`:
+
+```swift
+import AppKit
+import SwiftUI
+
+@MainActor
+final class HostsEditorWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = HostsEditorWindowController()
+
+    private init() {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Hosts"
+        panel.isReleasedWhenClosed = false
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        super.init(window: panel)
+        panel.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    func show() {
+        let view = HostsEditorView(manager: HostsManager.shared)
+        let host = NSHostingView(rootView: view)
+        host.frame = window?.contentLayoutRect ?? .zero
+        host.autoresizingMask = [.width, .height]
+        window?.contentView = host
+        HostsManager.shared.refresh()
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+        window?.center()
+    }
+}
+```
+
+- [ ] **Step 2: Editor view (master-detail)**
+
+`Sources/AnyDoor/Views/Hosts/HostsEditorView.swift`:
+
+```swift
+import SwiftUI
+
+/// Master-detail editor: profile list on the left, content editor on the right.
+/// System Hosts is read-only with an "open file" action.
+struct HostsEditorView: View {
+    @Bindable var manager: HostsManager
+    @State private var selection: HostProfile.ID?
+    @State private var draftName: String = ""
+    @State private var draftContent: String = ""
+    @State private var showRestoreConfirm = false
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                Section {
+                    Label("System Hosts", systemImage: "cpu").tag(Optional<HostProfile.ID>.none)
+                }
+                Section {
+                    ForEach(manager.profiles) { profile in
+                        HStack {
+                            Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(profile.isActive ? .green : .secondary)
+                                .onTapGesture { Task { await manager.setActive(profile, !profile.isActive) } }
+                            Text(profile.name)
+                        }
+                        .tag(Optional(profile.id))
+                    }
+                }
+            }
+            .frame(minWidth: 220)
+            .toolbar {
+                ToolbarItem {
+                    Button { manager.createProfile(name: "New Profile") } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+                ToolbarItem {
+                    Button { deleteSelected() } label: { Image(systemName: "trash") }
+                        .disabled(selectedProfile == nil)
+                }
+            }
+        } detail: {
+            detail
+        }
+        .onChange(of: selection) { _, _ in loadDraft() }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let profile = selectedProfile {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Name", text: $draftName)
+                    .textFieldStyle(.roundedBorder)
+                TextEditor(text: $draftContent)
+                    .font(.system(.body, design: .monospaced))
+                    .border(.quaternary)
+                HStack {
+                    Button("保存") {
+                        Task { await manager.updateProfile(profile, name: draftName, content: draftContent) }
+                    }
+                    Spacer()
+                    Button("移除托管块") { Task { await manager.removeManagedBlock() } }
+                    Button("恢复首次备份") { showRestoreConfirm = true }
+                }
+            }
+            .padding()
+            .confirmationDialog("覆盖 /etc/hosts 为首次备份？外部改动将丢失。",
+                                isPresented: $showRestoreConfirm, titleVisibility: .visible) {
+                Button("恢复", role: .destructive) { Task { await manager.restoreFirstRunBackup() } }
+                Button("取消", role: .cancel) {}
+            }
+        } else {
+            VStack(alignment: .leading) {
+                Text(manager.systemHosts)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                Button("用默认编辑器打开") {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: "/etc/hosts"))
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var selectedProfile: HostProfile? {
+        guard let selection else { return nil }
+        return manager.profiles.first { $0.id == selection }
+    }
+
+    private func loadDraft() {
+        draftName = selectedProfile?.name ?? ""
+        draftContent = selectedProfile?.content ?? ""
+    }
+
+    private func deleteSelected() {
+        guard let profile = selectedProfile else { return }
+        Task { await manager.deleteProfile(profile) }
+        selection = nil
+    }
+}
+```
+
+> UI strings are inline Chinese for v1 (consistent with this file's scope). Flag for the reviewer if full `L10n` coverage is required; if so, add keys per Task 9.
+
+- [ ] **Step 3: Build + smoke check**
+
+Run: `swift build`
+Run: `swift run AnyDoor` — open the editor from the popover "编辑"; create a profile, type content, save, activate; confirm `/etc/hosts` updates (admin prompt in dev). Select System Hosts → read-only + open button.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnyDoor/Views/Hosts/HostsEditorWindowController.swift Sources/AnyDoor/Views/Hosts/HostsEditorView.swift
+git commit -m "feat(hosts): add master-detail editor window"
+```
+
+---
+
+## Task 13: Build/sign the helper in release.sh + Makefile
+
+**Files:**
+- Modify: `scripts/release.sh` (Task 4 build ~line 137, Task 5 assemble ~line 148, Task 6 codesign ~line 199)
+- Modify: `Makefile:19-42` (install target — copy helper for local signed-ish installs; ad-hoc still falls back)
+
+- [ ] **Step 1: Build the helper universal in release.sh**
+
+After `swift build -c release "${BUILD_FLAGS[@]}"` (line 137) the helper is already built as part of the package. In the assemble section (after copying the main binary, ~line 148), add:
+
+```bash
+cp "$BIN_PATH/AnyDoorHostsHelper" "$APP/Contents/MacOS/AnyDoorHostsHelper"
+mkdir -p "$APP/Contents/Library/LaunchDaemons"
+cp Resources/dev.bybee.AnyDoor.HostsHelper.plist "$APP/Contents/Library/LaunchDaemons/"
+```
+
+> If the plist had to move out of `Resources/` in Task 8 Step 3, update the `cp` source path accordingly.
+
+- [ ] **Step 2: Sign the helper depth-first (before the main binary)**
+
+In the codesign section, add this line BEFORE the `codesign ... "$APP/Contents/MacOS/AnyDoor"` line (line 199):
+
+```bash
+codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/MacOS/AnyDoorHostsHelper"
+```
+
+- [ ] **Step 3: Update Makefile install for local testing**
+
+In `Makefile` `install:` target, after copying the main binary (line 23), add:
+
+```makefile
+	@cp .build/release/AnyDoorHostsHelper $(APP_DIR)/Contents/MacOS/ 2>/dev/null || true
+	@mkdir -p $(APP_DIR)/Contents/Library/LaunchDaemons
+	@cp Resources/dev.bybee.AnyDoor.HostsHelper.plist $(APP_DIR)/Contents/Library/LaunchDaemons/
+```
+
+> `make install` uses ad-hoc signing, so SMAppService won't register; the app falls back to AppleScript. The helper files are staged so a later properly-signed build is one step away.
+
+- [ ] **Step 4: Dry-run the release packaging path (no publish)**
+
+Run: `DRYRUN=1 ./scripts/release.sh 0.0.0-helpertest` in a clean tree on a branch (or visually inspect the diff if a full signed build isn't available). Expected: assemble + codesign steps reference the helper without error. Revert any version/CHANGELOG churn the dry run caused.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release.sh Makefile
+git commit -m "build(hosts): bundle and codesign the privileged helper"
+```
+
+---
+
+## Task 14: End-to-end spike verification (signed build, manual)
+
+**Files:** none (verification + notes).
+
+- [ ] **Step 1: Produce a signed, notarized build** via the normal release path (or a signing-only variant) so `SMAppService` can register.
+
+- [ ] **Step 2: Verify registration + approval flow**
+  - Launch the app; trigger a hosts activation.
+  - Confirm the system prompts once (Login Items & Extensions) and `HelperManager.readiness()` resolves to `.enabled` after approval.
+
+- [ ] **Step 3: Verify privileged write**
+  - Activate a profile; confirm `/etc/hosts` gains the managed block, ownership stays `root:wheel`, mode `0644`, and the system prefix/suffix are untouched.
+  - Manually append a line after the managed block, toggle a profile, and confirm the appended suffix survives (suffix preservation in production).
+
+- [ ] **Step 4: Verify caller validation**
+  - Confirm an unsigned/other-team process cannot connect (the listener rejects it). Record the test method used.
+
+- [ ] **Step 5: Record findings** in `docs/superpowers/specs/2026-06-03-hosts-editing-design.md` under a new "Spike Results" section, and fix any code that diverged from the spike reality (especially plist keys / client-auth mechanism). Commit:
+
+```bash
+git add docs/superpowers/specs/2026-06-03-hosts-editing-design.md
+git commit -m "docs(hosts): record helper registration + signing spike results"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** profiles CRUD (Tasks 3, 6, 11, 12) · multi-active merge (Tasks 2, 6) · system content untouched incl. suffix (Task 2 + tests) · privileged helper SMAppService (Tasks 7, 8, 14) · dev fallback (Task 4, 6) · backup + two-mode restore (Tasks 5, 6, 12) · popover + editor (Tasks 11, 12) · panel integration + L10n (Tasks 9, 10) · helper security boundary (Task 8) · atomic write (Task 8) · apply-then-persist (Task 6) · universal build + depth-first sign (Task 13) · full SMAppService status space (Task 7) · tests incl. suffix/marker-injection/rollback/idempotency (Tasks 2, 6). All spec sections map to a task.
+
+**Placeholder scan:** The only deferred items are the cross-task forward references (Task 6→7/8 default-writer; Task 11→12 window controller), each given an explicit temporary-then-switch instruction. No "TBD"/"add error handling"-style gaps.
+
+**Type consistency:** `HostsWriter.write(_:)`, `HostsManager.setActive(_:_:)`/`createProfile`/`updateProfile`/`removeManagedBlock`/`restoreFirstRunBackup`, `HostsFile.parse`/`compose`/`beginMarker`/`endMarker`/`Parsed`, `HostsBackupStore.ensureOriginalBackup`/`restoreFirstRunBackup(using:)`, `HelperManager.ensureRegistered`/`readiness`, `HostsHelperConstants.machServiceName`/`maxPayloadBytes`, and `HostsHelperProtocol.writeHosts(_:withReply:)` are used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-03-hosts-editing-design.md
+++ b/docs/superpowers/specs/2026-06-03-hosts-editing-design.md
@@ -8,10 +8,17 @@
 
 Add a hosts-file management feature to AnyDoor. Users can create, edit, and
 delete named host profiles, activate any subset of them (multiple active at
-once, merged), and apply the result to `/etc/hosts`. The system's pre-existing
-hosts content is never modified by AnyDoor; it is shown read-only with an
-"open in external editor" entry point. Writes to `/etc/hosts` go through a
-privileged helper so the user authorizes once instead of on every change.
+once, merged), and apply the result to `/etc/hosts`. Writes to `/etc/hosts` go
+through a privileged helper so the user authorizes once instead of on every
+change.
+
+> **Revision (post-implementation):** Two requirements changed after the first
+> build. (1) The system's existing hosts content is now **editable** in-app, not
+> read-only: editing it rewrites the system portion (prefix) while preserving
+> AnyDoor's managed block. The "open in external editor" entry point remains.
+> (2) Operations on a **blank** profile (empty content) and any change that would
+> not alter the file are skipped — blank profiles contribute nothing to the
+> managed block and never trigger a privileged write / authorization prompt.
 
 The UX reference is the Raycast `ihosts` extension, adapted to AnyDoor's
 existing menu-bar-panel + hover-popover interaction model.
@@ -21,7 +28,8 @@ existing menu-bar-panel + hover-popover interaction model.
 - Create / edit / delete user-defined host profiles.
 - Activate profiles via checkboxes; multiple active profiles are merged into
   one managed block.
-- Never modify the system's existing hosts content. Show it read-only and
+- Show and let the user edit the system's existing hosts content; editing
+  rewrites the system portion while preserving AnyDoor's managed block. Also
   provide an "open `/etc/hosts` in default editor" action.
 - Password-free writes after a one-time approval (privileged helper).
 - One-time backup of the original `/etc/hosts`, plus two restore actions:

--- a/docs/superpowers/specs/2026-06-03-hosts-editing-design.md
+++ b/docs/superpowers/specs/2026-06-03-hosts-editing-design.md
@@ -1,0 +1,410 @@
+# Hosts Editing Feature — Design
+
+- Date: 2026-06-03
+- Status: Approved (revised per review 2026-06-03)
+- Component: AnyDoor menu bar app
+
+## Overview
+
+Add a hosts-file management feature to AnyDoor. Users can create, edit, and
+delete named host profiles, activate any subset of them (multiple active at
+once, merged), and apply the result to `/etc/hosts`. The system's pre-existing
+hosts content is never modified by AnyDoor; it is shown read-only with an
+"open in external editor" entry point. Writes to `/etc/hosts` go through a
+privileged helper so the user authorizes once instead of on every change.
+
+The UX reference is the Raycast `ihosts` extension, adapted to AnyDoor's
+existing menu-bar-panel + hover-popover interaction model.
+
+## Goals
+
+- Create / edit / delete user-defined host profiles.
+- Activate profiles via checkboxes; multiple active profiles are merged into
+  one managed block.
+- Never modify the system's existing hosts content. Show it read-only and
+  provide an "open `/etc/hosts` in default editor" action.
+- Password-free writes after a one-time approval (privileged helper).
+- One-time backup of the original `/etc/hosts`, plus two restore actions:
+  a safe "remove managed block" and a confirmed "restore first-run backup".
+
+## Non-Goals (YAGNI for v1)
+
+- The "All Hosts" dropdown filter from the reference screenshot.
+- Importing hosts from a remote URL.
+- Per-profile scheduling / automation.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Privilege model | Privileged helper via `SMAppService` (LaunchDaemon) | Project already ships Developer ID + hardened runtime + notarization (the only hard prerequisite). One-time approval, password-free thereafter, no security downgrade. AnyDoor is a long-lived resident app, so `chmod 777` is rejected. |
+| Helper lifecycle | On-demand (no `RunAtLoad` / `KeepAlive`, `MachServices` only) | Zero resident process; launchd spawns it on XPC connect and it exits when idle. |
+| UI surface | Popover for quick activation + separate window for editing | High-frequency activation stays lightweight (matches port-manager / window-layout pattern); low-frequency editing opens a dedicated window. |
+| File composition | Marked managed block; all content outside the block (prefix AND suffix) untouched | AnyDoor only rewrites its own delimited block. Satisfies "system hosts is not editable in-app". Safest option. |
+| Activation | Multiple profiles active, merged | Matches the reference screenshot (several checkmarks). |
+| Persisted state semantics | Persisted state always equals "successfully applied to the system" | A failed write never leaves a divergent persisted state (see Write Flow). |
+
+## Pre-Implementation Spikes (do these first)
+
+These must be validated on a signed/notarized build before the dependent
+implementation tasks start. They are the highest-risk unknowns.
+
+1. **`SMAppService.daemon` registration + signing.** Confirm the exact, current
+   requirements for registering a privileged LaunchDaemon with
+   `SMAppService.daemon(plistName:)` on the supported macOS range: the
+   LaunchDaemon plist keys, where it must live in the bundle, the helper's
+   embedded `Info.plist` / entitlements, and how the client is authorized.
+   Note: `SMAuthorizedClients` belongs to the legacy `SMJobBless` model and is
+   NOT assumed here — the client-authorization mechanism for `SMAppService` must
+   be verified against up-to-date docs (ctx7) and a working spike. Output: a
+   minimal helper that registers, accepts one XPC call, and runs as root.
+2. **Caller code-signature validation** (see Helper Security Boundary) — verify
+   the public API path works end-to-end against the real signed app.
+
+## Architecture
+
+```
+┌─ UI ───────────────────────────────────────────────────────┐
+│  HostsManagerPopoverView      (menu-bar hover popover)        │
+│  HostsEditorWindowController + HostsEditorView (editor window) │
+└───────────────┬─────────────────────────────────────────────┘
+                │ read/write profiles, trigger activation
+┌─ Business ─────▼─────────────────────────────────────────────┐
+│  HostsManager  (@MainActor @Observable, single source of truth)│
+│    - bootstrap(modelContainer:)  // reuses AppDelegate's container│
+│    - profile CRUD (SwiftData)                                  │
+│    - read /etc/hosts, compose, invoke writer                   │
+│  HostsFile     (pure logic: parse prefix/block/suffix, compose) │
+│  HostsWriter   (protocol)                                      │
+│    ├ PrivilegedHelperWriter  (XPC -> helper; production)       │
+│    └ AppleScriptWriter       (dev / ad-hoc fallback)           │
+│  HelperManager (SMAppService registration / status / guidance) │
+│  HostsBackupStore (one-time original snapshot + restore)       │
+└───────────────┬─────────────────────────────────────────────┘
+                │ XPC (NSXPCConnection)
+┌─ Privileged (root) ▼─────────────────────────────────────────┐
+│  AnyDoorHostsHelper  (LaunchDaemon, on-demand)                 │
+│    - NSXPCListener; validates caller code signature            │
+│    - serial write queue                                        │
+│    - atomic write to /etc/hosts (temp in /etc -> rename, 644)  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Files
+
+### New
+
+- `Models/HostProfile.swift` — SwiftData model.
+- `Services/Hosts/HostsManager.swift` — business single source of truth.
+- `Services/Hosts/HostsFile.swift` — pure parse/compose logic (unit-testable).
+- `Services/Hosts/HostsWriter.swift` — protocol + `PrivilegedHelperWriter` + `AppleScriptWriter`.
+- `Services/Hosts/HelperManager.swift` — `SMAppService` lifecycle.
+- `Services/Hosts/HostsBackupStore.swift` — original snapshot + restore.
+- `Sources/HostsHelperShared/HostsHelperProtocol.swift` — XPC protocol + shared constants (mach service name, markers); SPM library target depended on by both the app and the helper.
+- `Sources/AnyDoorHostsHelper/main.swift` — helper executable (`NSXPCListener`); SPM executable target.
+- `Resources/dev.bybee.AnyDoor.HostsHelper.plist` — LaunchDaemon plist (placed into the bundle at build time).
+- `Views/Hosts/HostsManagerPopoverView.swift`
+- `Views/Hosts/HostsEditorWindowController.swift`
+- `Views/Hosts/HostsEditorView.swift`
+
+### Changed
+
+- `Models/BuiltinItem.swift` — add `case hostsManager` (kind `.submenu`) + `titleKey` / `symbol` / `defaultOrder` / `defaultVisibility`.
+- `Utilities/L10n.swift` — add the `hostsManager` title key (and any UI keys).
+- `Resources/Localizable.xcstrings` — add zh-Hans + en translations (enforced by `LocalizationCoverageTests`).
+- `Views/MenuBarView.swift` — add `.submenu(.hostsManager)` popover branch.
+- `AppDelegate.swift` — register `HostProfile` in the ModelContainer schema; call `HostsManager.shared.bootstrap(modelContainer:)`.
+- `Package.swift` — add the helper executable target + shared protocol library target.
+- `scripts/release.sh` / `Makefile` — build (universal), place, and sign the helper.
+
+## Data Model
+
+```swift
+@Model final class HostProfile {
+    @Attribute(.unique) var id: UUID
+    var name: String                 // e.g. "Dev Host"
+    var content: String              // raw hosts text block for this profile
+    var isActive: Bool = false       // included in the managed block when true
+    var displayOrder: Double = 0     // Float ordering, lower = earlier
+    var createdAt: Date
+    var updatedAt: Date              // drives the date shown in the list
+
+    init(name: String, content: String = "", isActive: Bool = false, displayOrder: Double = 0) {
+        self.id = UUID()
+        self.name = name
+        self.content = content
+        self.isActive = isActive
+        self.displayOrder = displayOrder
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}
+```
+
+- "System Hosts" is not a database record; it is the content of `/etc/hosts`
+  outside the managed block (prefix + suffix), read at runtime, shown read-only.
+- Follows project conventions: `@Attribute(.unique) id`, `displayOrder: Double`,
+  inline defaults for lightweight migration, `createdAt` set in `init`.
+- `HostsManager` is a `@MainActor @Observable` singleton bootstrapped with the
+  app's single `ModelContainer` (never creates its own), mirroring `PanelStore`.
+
+## HostsFile — Parse and Compose (pure logic)
+
+Markers (shared constants in `HostsHelperShared`):
+
+```swift
+let begin = "# >>> AnyDoor managed block — do not edit below this line >>>"
+let end   = "# <<< AnyDoor managed block end <<<"
+```
+
+Parse into three parts so that content BOTH before and after the block is
+preserved:
+
+```swift
+struct ParsedHosts {
+    var prefix: String      // everything before `begin` (system content)
+    var managed: String?    // content strictly between begin/end, if present
+    var suffix: String      // everything after `end` (also system content)
+}
+
+func parse(_ raw: String) -> ParsedHosts
+func compose(parsed: ParsedHosts, activeProfiles: [(name: String, content: String)]) -> String
+```
+
+- `parse`: when no markers are present, the whole file is `prefix`, `managed`
+  is nil, `suffix` is empty. Malformed cases (begin without end, duplicate
+  markers) resolve to a single well-defined interpretation (first `begin` /
+  first matching `end`); leftover marker lines outside that pair are treated as
+  ordinary system content.
+- `compose`: emits `prefix` + managed block (active profiles concatenated in
+  `displayOrder`, each prefixed with `# --- <name> ---`) + `suffix`. When there
+  are no active profiles, NO managed block is emitted (block removed), but
+  `prefix` and `suffix` are preserved.
+- Idempotent: composing the output again yields identical output.
+- Safe: every write re-parses the live file, so AnyDoor only ever rewrites its
+  own block and preserves all system content before and after it, regardless of
+  external edits.
+- Marker-injection guard: a profile `content` line that matches the begin/end
+  markers is stripped/escaped during `compose` so the block structure cannot be
+  forged or broken.
+
+## End-to-End Write Flow
+
+The persisted state always equals what was successfully applied to the system.
+
+- **Editing a non-active profile** (name/content): persist immediately via
+  `save()`; no system write.
+- **Toggling `isActive`, or editing an already-active profile**: apply first,
+  persist only on success.
+
+```
+HostsManager.applyAndPersist(change):
+    apply the change to an in-memory copy (do NOT save() yet)
+    HostsBackupStore.ensureOriginalBackup()   // one-time, before first managed write
+    raw    = read("/etc/hosts")                // plain read, no privilege
+    parsed = HostsFile.parse(raw)
+    active = profiles(with change applied).filter(\.isActive).sorted(by: displayOrder)
+    newTxt = HostsFile.compose(parsed, active)
+    do {
+        try await writer.write(newTxt)         // the only privileged step
+        modelContext.save()                    // persist only after success
+        refresh read-only systemHosts view
+    } catch {
+        // roll back in-memory change; nothing persisted; surface error to UI
+    }
+```
+
+Concurrency: activation toggles are debounced and serialized in `HostsManager`
+so rapid clicks coalesce into a single, consistent write.
+
+## XPC Protocol and Helper
+
+Shared target `HostsHelperShared`, used by both the app and the helper:
+
+```swift
+@objc protocol HostsHelperProtocol {
+    // returns nil on success, or an error message
+    func writeHosts(_ content: String, withReply reply: @escaping (String?) -> Void)
+    func helperVersion(withReply reply: @escaping (String) -> Void)
+}
+```
+
+### Helper Security Boundary (`AnyDoorHostsHelper`, runs as root)
+
+- `NSXPCListener(machServiceName:)`.
+- **Caller validation** in `listener(_:shouldAcceptNewConnection:)`:
+  - Read `newConnection.auditToken`.
+  - `SecCodeCopyGuestWithAttributes(nil, [kSecGuestAttributeAudit: auditTokenData], [], &code)`.
+  - `SecCodeCheckValidity(code, [], requirement)` where the requirement string is
+    `anchor apple generic and certificate leaf[subject.OU] = "<TEAM_ID>" and identifier "dev.bybee.AnyDoor"`.
+  - On failure: do NOT set `exportedObject`; `invalidate()` the connection.
+- **Request size cap**: reject `content` larger than a fixed limit (e.g. 1 MiB)
+  to bound memory / prevent abuse.
+- **Serialization**: all writes run on a single serial queue so concurrent XPC
+  calls cannot interleave file operations.
+- **Atomic write**: create a temp file in `/etc` (same filesystem as the target,
+  so `rename` is atomic) via an `mkstemp`-style unpredictable name; write →
+  `fsync` → `fchown root:wheel` → `fchmod 0644` → `rename()` over `/etc/hosts`.
+- **On-demand lifecycle**: plist has no `RunAtLoad` / `KeepAlive`, only
+  `MachServices`; launchd spawns the helper on connect and it exits when idle
+  (zero resident footprint).
+
+## SMAppService Registration
+
+`HelperManager` wraps `SMAppService.daemon(plistName: "dev.bybee.AnyDoor.HostsHelper.plist")`
+and handles the full status space, not just register-or-approve:
+
+- `.enabled` — ready; proceed.
+- `.notRegistered` — call `register()`.
+- `.requiresApproval` — guide the user to System Settings → Login Items & Extensions.
+- `.notFound` — surface an error (bundle/plist mismatch); fall back in dev.
+- default/unknown — surface an error.
+
+The LaunchDaemon plist is installed at `Contents/Library/LaunchDaemons/`. Exact
+plist keys, helper embedded `Info.plist`, and client-authorization specifics are
+finalized by Spike #1 before this task is implemented (do not rely on
+`SMAuthorizedClients` without verification).
+
+## Dev / Ad-hoc Fallback
+
+`swift run` and `make install` use ad-hoc signing, where `register()` fails.
+Handle it transparently:
+
+```swift
+// HostsManager bootstrap
+if helperManager.ensureRegistered() {       // status resolves to .enabled
+    writer = PrivilegedHelperWriter()        // signed/notarized production build
+} else {
+    writer = AppleScriptWriter()             // dev / ad-hoc: prompt each write
+}
+```
+
+`AppleScriptWriter` does NOT chmod the target. It writes to an unpredictable
+temp path (not a predictable `/tmp/xxx`), then runs, with correct shell
+quoting of every path:
+
+```
+do shell script "/bin/cp <quoted-temp> /etc/hosts && /bin/rm -f <quoted-temp>" with administrator privileges
+```
+
+The business layer only knows the `HostsWriter` protocol, so it is agnostic to
+the implementation.
+
+## Backup / Restore
+
+- `HostsBackupStore.ensureOriginalBackup()` — before AnyDoor's first managed
+  write, snapshot the current `/etc/hosts` verbatim into App Support
+  (`~/Library/Application Support/dev.bybee.AnyDoor/hosts-backup/original.hosts`).
+  Runs exactly once (guarded by file existence).
+- **Restore is two distinct actions** (the destructive one must not be the
+  default):
+  - `removeManagedBlock()` — DEFAULT, safe: re-parse the live file and
+    `compose` with no active profiles, so only AnyDoor's block is removed and
+    all current system content (prefix + suffix) is preserved. Does not depend
+    on the backup.
+  - `restoreFirstRunBackup()` — confirmation-gated, destructive: overwrite
+    `/etc/hosts` with the first-run snapshot. The UI warns that any external
+    changes made after the first run will be lost.
+
+Both go through the `HostsWriter`.
+
+## UI
+
+### Popover (quick activation) — `HostsManagerPopoverView`
+
+Follows the `PortManagerPopoverView` pattern.
+
+```
+┌─────────────────────────────┐
+│ 🔧 System Hosts        [Open] │  read-only; [Open] opens /etc/hosts externally
+├─────────────────────────────┤
+│ ✅ Dev Host          2023    │  checkbox = active; clicking the row toggles
+│ ⭕️ social            Mar 6   │
+│ ✅ muse-dam          Mar 5   │
+├─────────────────────────────┤
+│ + New             ✎ Edit All │  opens the editor window
+└─────────────────────────────┘
+```
+
+- Toggle → `HostsManager.setActive(_:_:)` → `applyAndPersist`.
+- System Hosts row is not checkable; it offers only the "open file" action.
+- A status bar appears when the helper is not enabled, with an "authorize"
+  button that deep-links to System Settings.
+
+### Editor window — `HostsEditorWindowController` + `HostsEditorView`
+
+Follows the `CommandPaletteWindowController` pattern (singleton + `NSPanel` +
+`NSHostingView` + `.accessory` activation). Master-detail layout:
+
+- Left: profile list — add / delete / drag-reorder (`onMove` → `displayOrder`) /
+  activate checkbox / search; System Hosts pinned at top.
+- Right: selected user profile → `name` field + monospaced `TextEditor` for
+  `content`; selected System Hosts → read-only display + "open file" button,
+  editor disabled.
+- Save: debounce edits then persist per the Write Flow rules above.
+- Includes the two restore actions and the helper-authorization status.
+
+## Panel Integration
+
+- `BuiltinItem` adds `case hostsManager`: `kind = .submenu`, `titleKey`,
+  `symbol` (suggest `list.bullet.rectangle` or `network`), `defaultOrder`,
+  `defaultVisibility`.
+- `Utilities/L10n.swift` + `Resources/Localizable.xcstrings` must gain the new
+  key and zh-Hans/en translations — `BuiltinItemLocalizationTests` and
+  `LocalizationCoverageTests` fail otherwise.
+- `BuiltinPreferenceSeeder` already appends new cases (`maxOrder + 100`); no
+  special backfill needed.
+- `MenuBarView` adds a `HoverPopoverTarget.submenu(.hostsManager)` branch that
+  mounts `HostsManagerPopoverView` and runs `Task { await HostsManager.shared.refresh() }`.
+  Structurally identical to the port-manager integration.
+
+## Error Handling and Edge Cases
+
+- Helper not enabled / registration failed: status bar + "authorize" button
+  (deep-link to System Settings); checked before any write.
+- Write failure / user cancels authorization: surface a clear message and roll
+  back the in-memory change; nothing is persisted (see Write Flow).
+- External edits to the system section (prefix or suffix): re-parse before each
+  write; both are preserved by construction.
+- Profile content containing the marker text: stripped/escaped in `compose`.
+- Empty / duplicate names, deleting an active profile: validated in the editor;
+  after deletion re-run the write flow.
+
+## Build / Signing Changes (`release.sh`, depth-first before the app)
+
+Reuse the existing universal build flags; build and sign the helper with the
+same architectures, depth-first (before signing the app):
+
+```bash
+BUILD_FLAGS=(--build-system swiftbuild --arch arm64 --arch x86_64)
+swift build -c release "${BUILD_FLAGS[@]}" --product AnyDoorHostsHelper
+HELPER_BIN="$(swift build --show-bin-path -c release "${BUILD_FLAGS[@]}")/AnyDoorHostsHelper"
+cp "$HELPER_BIN" "$APP/Contents/MacOS/"
+mkdir -p "$APP/Contents/Library/LaunchDaemons"
+cp Resources/dev.bybee.AnyDoor.HostsHelper.plist "$APP/Contents/Library/LaunchDaemons/"
+# sign helper before the app (hardened runtime + timestamp); notarization covers it
+codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/MacOS/AnyDoorHostsHelper"
+```
+
+## Testing Strategy
+
+- `HostsFile` pure-logic unit tests (primary):
+  - extract / compose / idempotency,
+  - no-marker file,
+  - **suffix preservation** (content after the block survives a rewrite),
+  - duplicate / missing markers (begin without end, etc.),
+  - **marker injection** (profile content containing the markers),
+  - **managed block removed** when no active profiles,
+  - external edits to prefix and suffix preserved.
+- `HostsManager`: inject a mock `HostsWriter` + in-memory `ModelContainer`:
+  - composed write content is correct,
+  - **write failure rolls back and persists nothing**,
+  - **concurrent toggle / debounce** coalesces into one consistent write,
+  - non-active edits persist without a system write.
+- `HostsBackupStore`: one-time snapshot; `removeManagedBlock` vs
+  `restoreFirstRunBackup` produce the expected content.
+- L10n: existing `BuiltinItemLocalizationTests` / `LocalizationCoverageTests`
+  must pass with the new `hostsManager` key.
+- Helper signature validation / end-to-end: requires a signed build; manual,
+  covered by the spikes.
+```

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -146,6 +146,9 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Framewor
 
 BIN_PATH="$(swift build --show-bin-path -c release "${BUILD_FLAGS[@]}")"
 cp "$BIN_PATH/AnyDoor" "$APP/Contents/MacOS/AnyDoor"
+cp "$BIN_PATH/AnyDoorHostsHelper" "$APP/Contents/MacOS/AnyDoorHostsHelper"
+mkdir -p "$APP/Contents/Library/LaunchDaemons"
+cp Resources/dev.bybee.AnyDoor.HostsHelper.plist "$APP/Contents/Library/LaunchDaemons/"
 cp Resources/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 cp Info.plist "$APP/Contents/Info.plist"
 
@@ -196,6 +199,7 @@ done
 
 codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/Frameworks/Sparkle.framework"
 codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/Resources/AnyDoor_AnyDoor.bundle"
+codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/MacOS/AnyDoorHostsHelper"
 codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP/Contents/MacOS/AnyDoor"
 codesign --force --options=runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP"
 


### PR DESCRIPTION
## Summary

Add hosts-file management to AnyDoor: create, edit, delete, and activate named host profiles, and apply the merged result to `/etc/hosts`. A new `hostsManager` built-in opens a hover popover for quick activation toggles plus a single button into a master-detail editor window. Writes go through a privileged helper so the user authorizes once and writes are password-free thereafter.

## How it works

- **Privileged writes**: an `SMAppService` LaunchDaemon over XPC. The helper validates every caller by audit token (`SecCodeCopyGuestWithAttributes` + code-signing requirement, closing the PID-recycling window), caps the payload, serializes writes, and replaces `/etc/hosts` atomically (temp file in `/etc` -> fsync -> root:wheel 0644 -> rename). Ad-hoc/dev builds fall back to an AppleScript admin-prompt writer.
- **Single source of truth (`HostsManager`)**: composes a marked managed block between sentinel comments while preserving system content before and after it verbatim; applies first and persists only on success (rolling back from the store on failure); debounces and serializes rapid activation toggles into one consistent write; and skips the privileged write entirely when the result would be unchanged, so toggling or deleting a blank profile never prompts for authorization.
- **Editor window**: master-detail. Profile names are renamed inline in the sidebar (a new profile drops straight into an editable name field). The detail pane shows only the content body in a rounded card, backed by a single `NSTextView` in both view and edit modes so toggling never shifts the text. It opens read-only by default and requires an explicit edit action to write, resetting to view mode when switching files. System Hosts is editable too (saving rewrites the system portion while preserving the managed block). Profiles can be deleted from the detail pane, a context menu, or the Delete key; Return toggles activation for the selected profile.
- **Backup/restore**: a one-time backup of the original `/etc/hosts` is captured before the first managed write and surfaced as a confirmed "restore first-run backup" recovery. An in-app banner deep-links to System Settings while the helper awaits approval.
- **Window reachability**: the app adopts `.regular` activation policy while the editor or Settings window is open (reverting to `.accessory` when the last closes) so those windows stay reachable instead of vanishing when another app takes focus.

## Test Plan

- [x] `swift build` and `swift test` (301 tests, 0 failures), covering `HostsFile` parse/compose + managed-block preservation + blank-profile skipping, `HostsManager` apply-then-persist + rollback + debounce coalescing + backup-failure surfacing, and `HostsBackupStore`.
- [x] Manual, on a signed/notarized build (cannot run in dev): verify `SMAppService` registration/approval, a real privileged write, caller rejection from a foreign-signed process, and suffix preservation. **Confirm the helper's client-requirement Team OU against the real Developer ID Application certificate** before release.

## Docs

Design spec and implementation plan under `docs/superpowers/`; CHANGELOG updated under Unreleased.
