### PR TITLE
perf(command-palette): resolve app row icons off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Command Palette still stuttered on the first scroll into the Applications
+  section, despite the 1.9.0 fix. That fix moved `NSWorkspace.icon(forFile:)`
+  out of `body` into a `task`, which stopped the per-body-pass re-resolution
+  but not the stutter: a SwiftUI `task` closure inherits the view's `@MainActor`
+  isolation, so the synchronous disk read still ran on the main thread — and
+  when `LazyVStack` materialized a fresh batch of app rows on the first scroll,
+  several cold-cache icon reads landed in the same frame and dropped it. A new
+  shared `AppIconCache` (a `@MainActor` cache modeled on `ClipboardThumbnail`)
+  now offloads the disk read to a detached task and memoizes icons by path; the
+  non-Sendable `NSImage` crosses back to the main actor via a small
+  `@unchecked Sendable` box. Rows seed synchronously from the cache on a warm
+  path (no flash) and resolve off-main on a miss, and both window controllers
+  prewarm every app icon when the palette / picker opens so even the first
+  scroll finds icons already resolved. The same path-keyed cache backs both the
+  command palette and the Spotlight app picker.
+
 ## [2.0.0] - 2026-06-04
 
 ### Added

--- a/Sources/AnyDoor/Utilities/AppIconCache.swift
+++ b/Sources/AnyDoor/Utilities/AppIconCache.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+/// Path-keyed cache for Finder/app icons shown by the command palette and the
+/// app pickers. `NSWorkspace.icon(forFile:)` touches disk (extracting `.icns`
+/// or an asset catalog), so resolving it inline on the main thread stalls the
+/// first scroll into a long list of app rows: as `LazyVStack` materializes a
+/// fresh batch, each row does a cold-cache disk hit on the main thread and drops
+/// scroll frames. This cache moves the disk read onto a background task and
+/// memoizes the result by path, so recycled rows and both pickers reuse warm
+/// icons with no main-thread I/O.
+///
+/// Mirrors `ClipboardThumbnail`: a `@MainActor` cache whose dictionaries are
+/// only ever touched on the main actor (so they need no lock); only the disk
+/// read itself is offloaded.
+@MainActor
+enum AppIconCache {
+    private static var cache: [String: NSImage] = [:]
+    private static var inflight: [String: Task<SendableImage, Never>] = [:]
+
+    /// Carries the non-Sendable `NSImage` produced off-main back to the main
+    /// actor. `@unchecked` is sound because the image is freshly created by
+    /// NSWorkspace inside the detached task and never mutated afterwards — it is
+    /// only read while drawing, the same immutable-handoff contract the rest of
+    /// the app relies on for its `nonisolated(unsafe)` storage.
+    private struct SendableImage: @unchecked Sendable {
+        let image: NSImage
+    }
+
+    /// Synchronous, cache-only lookup. Returns nil on a miss without touching
+    /// disk, letting a row render an already-resolved icon with no async hop
+    /// (and therefore no placeholder flash) on a warm path.
+    static func cached(_ path: String) -> NSImage? {
+        cache[path]
+    }
+
+    /// Returns the icon for `path`, resolving it on a background task on a cache
+    /// miss. `NSWorkspace.icon(forFile:)` is not MainActor-isolated, so it runs
+    /// off the main thread and never blocks scrolling. Concurrent requests for
+    /// the same path share one resolution via the in-flight task map.
+    static func icon(for path: String) async -> NSImage {
+        if let hit = cache[path] { return hit }
+
+        let task: Task<SendableImage, Never>
+        if let existing = inflight[path] {
+            task = existing
+        } else {
+            task = Task.detached(priority: .userInitiated) {
+                SendableImage(image: NSWorkspace.shared.icon(forFile: path))
+            }
+            inflight[path] = task
+        }
+
+        let image = await task.value.image
+        cache[path] = image
+        inflight[path] = nil
+        return image
+    }
+
+    /// Resolves icons for known paths ahead of time so the first scroll into a
+    /// list of app rows finds warm cache entries instead of cold-cache disk
+    /// hits. Fire-and-forget; skips paths already cached or in flight.
+    static func prewarm(_ paths: [String]) {
+        for path in paths where cache[path] == nil && inflight[path] == nil {
+            Task { _ = await icon(for: path) }
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -353,11 +353,16 @@ private struct CommandPaletteRow: View {
         .onHover { isHovering = $0 }
         .onTapGesture(perform: onSelect)
         .task(id: entry.id) {
-            // Resolve the Finder icon once per row. NSWorkspace.icon(forFile:)
-            // touches disk, so doing it on every body pass stalls the first
-            // scroll as LazyVStack materializes a fresh batch of rows.
+            // Resolve the Finder icon via the shared cache. A warm path
+            // (prewarmed apps, recycled rows) seeds synchronously with no
+            // flash; a cold path resolves off the main thread, so the first
+            // scroll into the Applications section never blocks on disk I/O.
             guard let path = iconPath else { return }
-            appIcon = NSWorkspace.shared.icon(forFile: path)
+            if let cached = AppIconCache.cached(path) {
+                appIcon = cached
+            } else {
+                appIcon = await AppIconCache.icon(for: path)
+            }
         }
     }
 

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -51,6 +51,16 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
 
     private func show() {
         let sections = collectSections()
+        // Warm the icon cache for every app-backed row off the main thread, so
+        // the first scroll into the Applications section finds resolved icons
+        // instead of cold-cache disk hits. Mirrors CommandPaletteRow.iconPath.
+        AppIconCache.prewarm(sections.flatMap(\.entries).compactMap { entry in
+            switch entry.source {
+            case .installedApp(_, let path): return path
+            case .appShortcut(let id): return PanelStore.shared.binding(id: id)?.appPath
+            case .builtin, .portRecord, .calcResult: return nil
+            }
+        })
         let hyperFlags = HyperKeyService.shared.hyperModifierFlags
         let pickerState = CommandPaletteState(sections: sections, hyperFlags: hyperFlags)
         self.state = pickerState

--- a/Sources/AnyDoor/Views/SpotlightAppPicker.swift
+++ b/Sources/AnyDoor/Views/SpotlightAppPicker.swift
@@ -244,9 +244,14 @@ private struct SpotlightRow: View {
         .onHover { isHovering = $0 }
         .onTapGesture(perform: onSelect)
         .task(id: app.bundleID) {
-            // Resolve the Finder icon once per row. NSWorkspace.icon(forFile:)
-            // touches disk, so doing it on every body pass is wasteful.
-            icon = NSWorkspace.shared.icon(forFile: app.path)
+            // Resolve the Finder icon via the shared cache: a warm path seeds
+            // synchronously, a cold path resolves off the main thread so the
+            // first scroll never blocks on disk I/O. See AppIconCache.
+            if let cached = AppIconCache.cached(app.path) {
+                icon = cached
+            } else {
+                icon = await AppIconCache.icon(for: app.path)
+            }
         }
     }
 

--- a/Sources/AnyDoor/Views/SpotlightAppPickerWindowController.swift
+++ b/Sources/AnyDoor/Views/SpotlightAppPickerWindowController.swift
@@ -47,6 +47,9 @@ final class SpotlightAppPickerWindowController: NSWindowController, NSWindowDele
         onSelect: @escaping (InstalledApp) -> Void
     ) {
         self.onSelect = onSelect
+        // Warm the icon cache off the main thread so the first scroll does not
+        // block on cold-cache disk hits. See AppIconCache.
+        AppIconCache.prewarm(apps.map(\.path))
         let pickerState = SpotlightPickerState(apps: apps, excluded: excluded)
         self.state = pickerState
 

--- a/Tests/AnyDoorTests/AppIconCacheTests.swift
+++ b/Tests/AnyDoorTests/AppIconCacheTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import AppKit
+@testable import AnyDoor
+
+@MainActor
+final class AppIconCacheTests: XCTestCase {
+    private let finderPath = "/System/Library/CoreServices/Finder.app"
+
+    func testCachedReturnsNilForUnrequestedPath() {
+        // A path no other test resolves: the synchronous lookup must report a
+        // miss without touching disk.
+        XCTAssertNil(AppIconCache.cached("/private/var/anydoor-tests/never-requested.app"))
+    }
+
+    func testIconResolvesAndPopulatesCache() async {
+        let icon = await AppIconCache.icon(for: finderPath)
+        XCTAssertGreaterThan(icon.size.width, 0, "A resolved icon should have a real size")
+        XCTAssertTrue(
+            AppIconCache.cached(finderPath) === icon,
+            "After resolving, the synchronous cache must return the same instance"
+        )
+    }
+
+    func testRepeatResolutionReusesCachedInstance() async {
+        let first = await AppIconCache.icon(for: finderPath)
+        let second = await AppIconCache.icon(for: finderPath)
+        XCTAssertTrue(first === second, "Repeated resolution must reuse the cached NSImage")
+    }
+
+    func testPrewarmPopulatesCacheOffMain() async {
+        AppIconCache.prewarm([finderPath])
+        // prewarm is fire-and-forget; poll the cache for the background result.
+        let warmed = await waitForCachedIcon(finderPath)
+        XCTAssertNotNil(warmed, "prewarm should resolve the icon into the cache")
+    }
+
+    /// Polls the synchronous cache until the icon appears or the timeout lapses.
+    private func waitForCachedIcon(_ path: String, timeout: TimeInterval = 2) async -> NSImage? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let icon = AppIconCache.cached(path) { return icon }
+            try? await Task.sleep(nanoseconds: 20_000_000) // 20ms
+        }
+        return AppIconCache.cached(path)
+    }
+}


### PR DESCRIPTION
## Problem

The command palette still stuttered on the first scroll into the Applications section, then ran smoothly afterwards. PR #31 (1.9.0) tried to fix this by moving the icon load out of `body` into a `task`, but the stutter remained.

## Root cause

A SwiftUI `task` closure inherits the view's MainActor isolation (it assigns to MainActor view state and compiles under strict concurrency — which proves it runs on the main actor). So `NSWorkspace.icon(forFile:)` — a synchronous disk read — still ran on the main thread; PR #31 only stopped it from re-running on every `body` pass. The Applications section is built last and is the only section whose rows carry a real icon, so when `LazyVStack` materializes a fresh batch of app rows on the first scroll, several cold-cache disk reads land in the same frame and drop it. NSWorkspace warms its internal cache after the first pass, which is why later scrolls are smooth.

The root cause was verified adversarially against three competing hypotheses — Liquid Glass / material compositing, LazyVStack materialization + scroll proxy, and `InstalledAppsScanner.scan()` / per-row binding lookups — all ruled out because none produce a first-scroll-only cost.

## Fix

- New `AppIconCache` (a MainActor cache modeled on `ClipboardThumbnail`): a synchronous `cached(_:)` hit path, plus `icon(for:)` that offloads cache misses to a detached `userInitiated` task, memoizes by path, and dedups concurrent requests. The non-Sendable `NSImage` crosses back via a small unchecked-Sendable box — `NSWorkspace` is not MainActor-isolated, so the disk read is legal off-main.
- Both pickers (`CommandPaletteRow`, `SpotlightRow`) read the shared cache: a warm path seeds synchronously with no flash, a cold path resolves off the main thread.
- Both window controllers `prewarm` every app icon when the palette / picker opens, so even the first scroll finds icons already resolved.

## Testing

- `swift build` — clean (strict concurrency, no new warnings).
- `swift test` — 330/330 pass, including 4 new `AppIconCacheTests` (cache hit, memoization, prewarm) plus the command-palette and installed-apps regression suites.
