### PR TITLE
fix: cap menu-bar panel height so it never runs off-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Settings window reopened on its own whenever AnyDoor auto-launched at
+  login. macOS state restoration was reopening the previous session's window,
+  but AnyDoor is a menu-bar utility where no window should appear unbidden. The
+  app now opts out of application state restoration
+  (`application(_:shouldRestoreApplicationState:)` and `shouldSaveApplicationState`
+  return `false`) and additionally marks the Settings window non-restorable as a
+  fallback for the per-window restoration path. Settings still opens on demand
+  from the menu-bar item.
+- The menu-bar panel could run off the bottom of the screen once enough items
+  were enabled, leaving the lower rows unreachable. The panel height is now
+  capped to the usable screen height; any overflow scrolls inside the panel
+  (`NSScrollView` wrapping the measured hosting view, with rounded-corner
+  clipping preserved). Hover sub-popovers (App Shortcuts, Port Manager,
+  brightness, clipboard history) re-anchor correctly as the list scrolls.
+
 ## [2.0.1] - 2026-06-04
 
 ### Fixed

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -10,6 +10,9 @@ import SwiftUI
 /// directly toggles the icon with no scene-graph involvement.
 @MainActor
 final class MenuBarController {
+    /// Slack left between the panel and the screen edges when capping height.
+    private static let panelScreenMargin: CGFloat = 8
+
     private let modelContainer: ModelContainer
 
     private var statusItem: NSStatusItem?
@@ -132,25 +135,65 @@ final class MenuBarController {
         // — that pegs the CPU and overflows the stack.
         hostingView.sizingOptions = .intrinsicContentSize
         hostingView.layoutSubtreeIfNeeded()
-        var size = hostingView.fittingSize
-        if size.width < 1 || size.height < 1 {
-            size = NSSize(width: 260, height: 320)
+        var contentSize = hostingView.fittingSize
+        if contentSize.width < 1 || contentSize.height < 1 {
+            contentSize = NSSize(width: 260, height: 320)
         }
         hostingView.sizingOptions = []
-        hostingView.frame = NSRect(origin: .zero, size: size)
-        hostingView.autoresizingMask = [.width, .height]
+
+        // Cap the panel height to the usable screen height so a long feature
+        // list never runs off-screen; the overflow scrolls inside the panel.
+        // With no resolvable screen, leave the height uncapped.
+        let maxHeight = (button.window?.screen?.visibleFrame.height)
+            .map { $0 - Self.panelScreenMargin } ?? .greatestFiniteMagnitude
+        let panelSize = NSSize(
+            width: contentSize.width,
+            height: min(contentSize.height, max(1, maxHeight))
+        )
+
+        let contentView: NSView
+        if contentSize.height > panelSize.height {
+            // Content taller than the screen: scroll it. The hosting view keeps
+            // its full natural height as the scroll document; the scroll view
+            // clips to the capped viewport. `sizingOptions = []` already detached
+            // window sizing, so nothing here can drive a window resize.
+            hostingView.frame = NSRect(origin: .zero, size: contentSize)
+            hostingView.autoresizingMask = [.width]
+            let scrollView = NSScrollView(frame: NSRect(origin: .zero, size: panelSize))
+            scrollView.documentView = hostingView
+            scrollView.hasVerticalScroller = true
+            scrollView.scrollerStyle = .overlay
+            scrollView.autohidesScrollers = true
+            scrollView.drawsBackground = false
+            scrollView.automaticallyAdjustsContentInsets = false
+            // Round the viewport so the panel keeps its corner radius even when
+            // the SwiftUI content's own rounded background has scrolled off.
+            scrollView.wantsLayer = true
+            scrollView.layer?.cornerRadius = 12
+            scrollView.layer?.cornerCurve = .continuous
+            scrollView.layer?.masksToBounds = true
+            // NSHostingView is flipped, so the document's top sits at the top;
+            // make sure the panel opens scrolled to the first row.
+            scrollView.contentView.scroll(to: .zero)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            contentView = scrollView
+        } else {
+            // A plain NSView container keeps the hosting view out of the window's
+            // constraint-based layout, so nothing can drive a window resize.
+            hostingView.frame = NSRect(origin: .zero, size: panelSize)
+            hostingView.autoresizingMask = [.width, .height]
+            let container = NSView(frame: NSRect(origin: .zero, size: panelSize))
+            container.addSubview(hostingView)
+            contentView = container
+        }
 
         let panel = NSPanel(
-            contentRect: NSRect(origin: .zero, size: size),
+            contentRect: NSRect(origin: .zero, size: panelSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        // A plain NSView container keeps the hosting view out of the window's
-        // constraint-based layout, so nothing can drive a window resize.
-        let container = NSView(frame: NSRect(origin: .zero, size: size))
-        container.addSubview(hostingView)
-        panel.contentView = container
+        panel.contentView = contentView
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -423,10 +423,35 @@ private struct ScreenFrameReader: NSViewRepresentable {
     final class FrameReportingView: NSView {
         var onChange: ((NSRect) -> Void)?
         private var lastFrame: NSRect = .zero
+        private var scrollObserver: NSObjectProtocol?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            // Fires on both attach and detach; on detach `enclosingScrollView`
+            // is nil, so this also tears the observer down (no deinit needed,
+            // which Swift 6 forbids for this non-Sendable token anyway).
+            observeEnclosingScroll()
             reportFrame()
+        }
+
+        /// When the panel content scrolls (tall feature lists), the row's
+        /// on-screen position changes without triggering a layout pass, so the
+        /// cached hover-popover anchor would go stale. Track the enclosing
+        /// scroll view's clip bounds and re-report on every scroll.
+        private func observeEnclosingScroll() {
+            if let scrollObserver {
+                NotificationCenter.default.removeObserver(scrollObserver)
+                self.scrollObserver = nil
+            }
+            guard let clipView = enclosingScrollView?.contentView else { return }
+            clipView.postsBoundsChangedNotifications = true
+            scrollObserver = NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: clipView,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.reportFrame() }
+            }
         }
 
         override func setFrameSize(_ newSize: NSSize) {


### PR DESCRIPTION
## Summary

The menu-bar panel sized itself to its full SwiftUI content height. Once enough items were enabled the panel ran off the bottom of the screen, leaving the lower rows unreachable.

The panel height is now capped to the usable screen height, and any overflow scrolls inside the panel.

## Changes

- **`MenuBarController.showPanel`** — after measuring the SwiftUI content's natural size, cap the panel height to `visibleFrame.height - margin`. When the content is taller, wrap the measured hosting view in an `NSScrollView` (overlay scroller, auto-hide, rounded-corner clipping to match the material) instead of the plain container. Pure AppKit wrapping, so the existing synchronous measurement and the "no window-resize recursion" guarantee are preserved. Height stays uncapped when no screen is resolvable.
- **`MenuBarView.FrameReportingView`** — hover sub-popovers (App Shortcuts, Port Manager, brightness, clipboard history) anchor to cached row frames. Scrolling moves rows without a layout pass, so the cache would go stale. The view now observes the enclosing scroll view's clip-bounds changes and re-reports its frame on every scroll. Lifecycle is managed via `viewDidMoveToWindow` (no Swift 6-forbidden non-isolated `deinit`).

## Verification

`swift build` passes. Manually previewed by temporarily padding the panel with mock rows to overflow the screen, then confirmed: the panel is capped to the screen, scrolls, keeps rounded corners, and hover sub-popovers re-anchor correctly after scrolling. The mock rows were removed before committing.