### PR TITLE
fix(brightness): replace unlicensed DDC.swift with vendored MonitorControl IntelDDC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ A macOS menu-bar toolbox. At its core it toggles (show/hide) a target applicatio
 - SwiftData persistence
 - CGEvent tap for global hotkey monitoring
 - Privileged XPC helper (`AnyDoorHostsHelper`) writes `/etc/hosts` (with an AppleScript fallback when the helper isn't enabled — see Architecture Notes)
-- Sparkle for auto-updates; DDC.swift for external display brightness; AskForPermission for permission onboarding
+- Sparkle for auto-updates; MonitorControl's MIT `IntelDDC` (vendored under `Services/Brightness/Vendor/`) for Intel external-display brightness; AskForPermission for permission onboarding. Bundled third-party license texts live in `THIRD-PARTY-LICENSES.md`.
 - SPM build, with an in-repo build-tool plugin that compiles the `.xcstrings` string catalog
 
 ## Build and Run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ versioning.
 - The menu-bar panel height cap is now a proportion of the usable screen height
   (80%) instead of a fixed 8pt margin, leaving more breathing room on tall
   displays. Overflow still scrolls inside the panel.
+- External-display brightness on Intel Macs now uses MonitorControl's
+  MIT-licensed `IntelDDC`, vendored into the app, instead of the upstream
+  `reitermarkus/DDC.swift` dependency, which ships with no license. The DDC/CI
+  behavior is unchanged; Apple Silicon continues to use the existing
+  `Arm64DDCBackend`. Bundled third-party license texts are now collected in
+  `THIRD-PARTY-LICENSES.md`.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ A macOS menu-bar toolbox. At its core it toggles (show/hide) a target applicatio
 - SwiftData persistence
 - CGEvent tap for global hotkey monitoring
 - Privileged XPC helper (`AnyDoorHostsHelper`) writes `/etc/hosts` (with an AppleScript fallback when the helper isn't enabled — see Architecture Notes)
-- Sparkle for auto-updates; DDC.swift for external display brightness; AskForPermission for permission onboarding
+- Sparkle for auto-updates; MonitorControl's MIT `IntelDDC` (vendored under `Services/Brightness/Vendor/`) for Intel external-display brightness; AskForPermission for permission onboarding. Bundled third-party license texts live in `THIRD-PARTY-LICENSES.md`.
 - SPM build, with an in-repo build-tool plugin that compiles the `.xcstrings` string catalog
 
 ## Build and Run

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90331f38bf394e04a4b608c9793301a6b16a6efab2a421468a6554c4444de4f3",
+  "originHash" : "e0a24088e9ff3379ec91d6957ad82556a1ad6a9f3792ac383588f537cf24c45f",
   "pins" : [
     {
       "identity" : "askforpermission",
@@ -7,15 +7,6 @@
       "location" : "https://github.com/riko2chen/AskForPermission.git",
       "state" : {
         "revision" : "91f4dde33f9f5dd58a89d72f3f05aa4b149a1f0e"
-      }
-    },
-    {
-      "identity" : "ddc.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/reitermarkus/DDC.swift",
-      "state" : {
-        "branch" : "master",
-        "revision" : "15b3ef8235a831e0d7812dbdf12d6a4bb16d3bd6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,6 @@ let package = Package(
             url: "https://github.com/sparkle-project/Sparkle",
             exact: "2.9.2"
         ),
-        .package(
-            url: "https://github.com/reitermarkus/DDC.swift",
-            branch: "master"
-        ),
     ],
     targets: [
         .plugin(
@@ -30,7 +26,6 @@ let package = Package(
             dependencies: [
                 .product(name: "AskForPermission", package: "AskForPermission"),
                 .product(name: "Sparkle", package: "Sparkle"),
-                .product(name: "DDC", package: "DDC.swift"),
                 "HostsHelperShared",
             ],
             resources: [

--- a/README.md
+++ b/README.md
@@ -290,9 +290,11 @@ publishes it.
 
 ## Acknowledgements
 
-- [DDC.swift](https://github.com/reitermarkus/DDC.swift) (MIT) — DDC/CI brightness control for external displays on Intel Macs.
-- [AskForPermission](https://github.com/riko2chen/AskForPermission) — macOS accessibility permission helper.
-- [Sparkle](https://sparkle-project.org/) — application auto-update.
+Bundled third-party code; full license texts in [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md).
+
+- [MonitorControl](https://github.com/MonitorControl/MonitorControl) (MIT) — its `IntelDDC` is vendored for DDC/CI brightness control of external displays on Intel Macs (itself adapted from [@reitermarkus](https://github.com/reitermarkus)'s work).
+- [Sparkle](https://sparkle-project.org/) (MIT) — application auto-update.
+- [AskForPermission](https://github.com/riko2chen/AskForPermission) (MIT) — macOS accessibility permission helper.
 
 ## License
 

--- a/Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift
+++ b/Sources/AnyDoor/Services/Brightness/IntelDDCBackend.swift
@@ -1,19 +1,19 @@
 #if !arch(arm64)
 import Foundation
 import CoreGraphics
-import DDC
 
-/// Wraps reitermarkus/DDC.swift for Intel Macs. Apple Silicon uses
-/// `Arm64DDCBackend` instead (DDC.swift's `IOFBGetI2CInterfaceCount`
-/// path does not work on arm64).
+/// DDC/CI transport for Intel Macs, built on the vendored MonitorControl
+/// `IntelDDC` (MIT) in `Vendor/MonitorControlIntelDDC.swift`. Apple Silicon
+/// uses `Arm64DDCBackend` instead (the IOFramebuffer I2C path used here does
+/// not work on arm64).
 struct IntelDDCBackend: DDCBackend {
     func transportReady(displayID: CGDirectDisplayID) -> Bool {
-        return DDC(for: displayID) != nil
+        return IntelDDC(for: displayID) != nil
     }
 
     func read(displayID: CGDirectDisplayID, vcp: UInt8) async -> UInt16? {
         await Task.detached(priority: .userInitiated) {
-            guard let ddc = DDC(for: displayID),
+            guard let ddc = IntelDDC(for: displayID),
                   let (current, _) = ddc.read(command: vcp) else { return UInt16?.none }
             return current
         }.value
@@ -21,7 +21,7 @@ struct IntelDDCBackend: DDCBackend {
 
     func write(displayID: CGDirectDisplayID, vcp: UInt8, value: UInt16) async throws {
         try await Task.detached(priority: .userInitiated) {
-            guard let ddc = DDC(for: displayID) else {
+            guard let ddc = IntelDDC(for: displayID) else {
                 throw NSError(domain: "IntelDDC", code: -1,
                               userInfo: [NSLocalizedDescriptionKey: "DDC unavailable"])
             }

--- a/Sources/AnyDoor/Services/Brightness/Vendor/MonitorControlIntelDDC.swift
+++ b/Sources/AnyDoor/Services/Brightness/Vendor/MonitorControlIntelDDC.swift
@@ -1,0 +1,288 @@
+//  Vendored from MonitorControl (https://github.com/MonitorControl/MonitorControl),
+//  file MonitorControl/Support/IntelDDC.swift, under the MIT License.
+//  See THIRD-PARTY-LICENSES.md for the full license text.
+//
+//  Original header:
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+//  Adapted from IntelDDC.swift, @reitermarkus
+//
+//  Local adaptations for building inside AnyDoor's SwiftPM target (no
+//  Objective-C bridging header is available, unlike MonitorControl's Xcode
+//  project):
+//    - Added explicit imports (CoreGraphics / IOKit / IOKit.i2c / IOKit.graphics)
+//      that MonitorControl pulled in via its bridging header / project settings.
+//    - Declared the private CoreGraphics symbol `CGSServiceForDisplayNumber`
+//      via @_silgen_name (it lived in MonitorControl's Bridging-Header.h).
+//    - `kIOMasterPortDefault` -> `kIOMainPortDefault` (the modern alias).
+//    - Wrapped in `#if !arch(arm64)`: AnyDoor only uses this Intel I2C path on
+//      Intel Macs (Apple Silicon uses `Arm64DDCBackend` / IOAVService), so the
+//      private symbol is never compiled into the arm64 slice.
+//  The DDC/CI logic below is otherwise unchanged.
+
+#if !arch(arm64)
+import Foundation
+import CoreGraphics
+import IOKit
+import IOKit.i2c
+import IOKit.graphics
+import os.log
+
+// Private CoreGraphics symbol, declared in MonitorControl's Bridging-Header.h as:
+//   extern void CGSServiceForDisplayNumber(CGDirectDisplayID display, io_service_t* service);
+@_silgen_name("CGSServiceForDisplayNumber")
+private func CGSServiceForDisplayNumber(_ display: CGDirectDisplayID, _ service: UnsafeMutablePointer<io_service_t>)
+
+public class IntelDDC {
+  let displayId: CGDirectDisplayID
+  let framebuffer: io_service_t
+  let replyTransactionType: IOOptionBits
+  var enabled: Bool = false
+
+  deinit {
+    assert(IOObjectRelease(self.framebuffer) == KERN_SUCCESS)
+  }
+
+  public init?(for displayId: CGDirectDisplayID, withReplyTransactionType replyTransactionType: IOOptionBits? = nil) {
+    self.displayId = displayId
+    guard let framebuffer = IntelDDC.ioFramebufferPortFromDisplayId(displayId: displayId) else {
+      return nil
+    }
+    self.framebuffer = framebuffer
+    if let replyTransactionType = replyTransactionType {
+      self.replyTransactionType = replyTransactionType
+    } else if let replyTransactionType = IntelDDC.supportedTransactionType() {
+      self.replyTransactionType = replyTransactionType
+    } else {
+      os_log("No supported reply transaction type found for display with ID %u.", type: .error, displayId)
+      return nil
+    }
+  }
+
+  public func write(command: UInt8, value: UInt16, errorRecoveryWaitTime: UInt32? = nil, writeSleepTime: UInt32 = 10000, numofWriteCycles: UInt8 = 2) -> Bool {
+    var success = false
+    var data: [UInt8] = Array(repeating: 0, count: 7)
+
+    data[0] = 0x51
+    data[1] = 0x84
+    data[2] = 0x03
+    data[3] = command
+    data[4] = UInt8(value >> 8)
+    data[5] = UInt8(value & 255)
+    data[6] = 0x6E ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5]
+
+    for _ in 1 ... numofWriteCycles {
+      usleep(writeSleepTime)
+      var request = IOI2CRequest()
+      request.commFlags = 0
+      request.sendAddress = 0x6E
+      request.sendTransactionType = IOOptionBits(kIOI2CSimpleTransactionType)
+      request.sendBuffer = withUnsafePointer(to: &data[0]) { vm_address_t(bitPattern: $0) }
+      request.sendBytes = UInt32(data.count)
+      request.replyTransactionType = IOOptionBits(kIOI2CNoTransactionType)
+      request.replyBytes = 0
+      if IntelDDC.send(request: &request, to: self.framebuffer, errorRecoveryWaitTime: errorRecoveryWaitTime) {
+        success = true
+      }
+    }
+    return success
+  }
+
+  public func read(command: UInt8, tries: UInt = 1, replyTransactionType _: IOOptionBits? = nil, minReplyDelay: UInt64? = nil, errorRecoveryWaitTime: UInt32? = nil, writeSleepTime: UInt32 = 10000) -> (UInt16, UInt16)? {
+    var data: [UInt8] = Array(repeating: 0, count: 5)
+    var replyData: [UInt8] = Array(repeating: 0, count: 11)
+
+    data[0] = 0x51
+    data[1] = 0x82
+    data[2] = 0x01
+    data[3] = command
+    data[4] = 0x6E ^ data[0] ^ data[1] ^ data[2] ^ data[3]
+
+    for i in 1 ... tries {
+      usleep(writeSleepTime)
+      usleep(errorRecoveryWaitTime ?? 0)
+      var request = IOI2CRequest()
+      request.commFlags = 0
+      request.sendAddress = 0x6E
+      request.sendTransactionType = IOOptionBits(kIOI2CSimpleTransactionType)
+      request.sendBuffer = withUnsafePointer(to: &data[0]) { vm_address_t(bitPattern: $0) }
+      request.sendBytes = UInt32(data.count)
+      request.minReplyDelay = minReplyDelay ?? 10
+      request.replyAddress = 0x6F
+      request.replySubAddress = 0x51
+      request.replyTransactionType = self.replyTransactionType
+      request.replyBytes = UInt32(replyData.count)
+      request.replyBuffer = withUnsafePointer(to: &replyData[0]) { vm_address_t(bitPattern: $0) }
+
+      if IntelDDC.send(request: &request, to: self.framebuffer, errorRecoveryWaitTime: errorRecoveryWaitTime) {
+        if replyData.count > 0 {
+          let checksum = replyData.last!
+          var calculated = UInt8(0x50)
+          for i in 0 ..< (replyData.count - 1) {
+            calculated ^= replyData[i]
+          }
+          guard checksum == calculated else {
+            os_log("Checksum of reply does not match. Expected %u, got %u.", type: .info, checksum, calculated)
+            os_log("Response was: %{public}@", type: .info, replyData.map { String(format: "%02X", $0) }.joined(separator: " "))
+            continue
+          }
+        }
+        guard replyData[2] == 0x02 else {
+          os_log("Got wrong response type for %{public}@. Expected %u, got %u.", type: .info, String(reflecting: command), 0x02, replyData[2])
+          os_log("Response was: %{public}@", type: .info, replyData.map { String(format: "%02X", $0) }.joined(separator: " "))
+          continue
+        }
+        guard replyData[3] == 0x00 else {
+          os_log("Reading %{public}@ is not supported.", type: .info, String(reflecting: command))
+          return nil
+        }
+        if i > 1 {
+          os_log("Reading %{public}@ took %u tries.", type: .info, String(reflecting: command), i)
+        }
+        let (mh, ml, sh, sl) = (replyData[6], replyData[7], replyData[8], replyData[9])
+        let maxValue = UInt16(mh << 8) + UInt16(ml)
+        let currentValue = UInt16(sh << 8) + UInt16(sl)
+        return (currentValue, maxValue)
+      }
+    }
+    return nil
+  }
+
+  private static func supportedTransactionType() -> IOOptionBits? {
+    var ioIterator = io_iterator_t()
+    guard IOServiceGetMatchingServices(kIOMainPortDefault, IOServiceNameMatching("IOFramebufferI2CInterface"), &ioIterator) == KERN_SUCCESS else {
+      return nil
+    }
+    defer {
+      assert(IOObjectRelease(ioIterator) == KERN_SUCCESS)
+    }
+    while case let ioService = IOIteratorNext(ioIterator), ioService != 0 {
+      var serviceProperties: Unmanaged<CFMutableDictionary>?
+      guard IORegistryEntryCreateCFProperties(ioService, &serviceProperties, kCFAllocatorDefault, IOOptionBits()) == KERN_SUCCESS, serviceProperties != nil else {
+        continue
+      }
+      let dict = serviceProperties!.takeRetainedValue() as NSDictionary
+      if let types = dict[kIOI2CTransactionTypesKey] as? UInt64 {
+        if (1 << kIOI2CDDCciReplyTransactionType) & types != 0 {
+          os_log("kIOI2CDDCciReplyTransactionType is supported.", type: .info)
+          return IOOptionBits(kIOI2CDDCciReplyTransactionType)
+        }
+        if (1 << kIOI2CSimpleTransactionType) & types != 0 {
+          os_log("kIOI2CSimpleTransactionType is supported.", type: .info)
+          return IOOptionBits(kIOI2CSimpleTransactionType)
+        }
+      }
+    }
+    return nil
+  }
+
+  static func send(request: inout IOI2CRequest, to framebuffer: io_service_t, errorRecoveryWaitTime: UInt32? = nil) -> Bool {
+    if let errorRecoveryWaitTime = errorRecoveryWaitTime {
+      usleep(errorRecoveryWaitTime)
+    }
+    var busCount: IOItemCount = 0
+    guard IOFBGetI2CInterfaceCount(framebuffer, &busCount) == KERN_SUCCESS else {
+      os_log("Failed to get interface count for framebuffer with ID %u.", type: .error, framebuffer)
+      return false
+    }
+    for bus: IOOptionBits in 0 ..< busCount {
+      var interface = io_service_t()
+      guard IOFBCopyI2CInterfaceForBus(framebuffer, bus, &interface) == KERN_SUCCESS else {
+        os_log("Failed to get interface %u for framebuffer with ID %u.", type: .error, bus, framebuffer)
+        continue
+      }
+      var connect: IOI2CConnectRef?
+      guard IOI2CInterfaceOpen(interface, IOOptionBits(), &connect) == KERN_SUCCESS else {
+        os_log("Failed to connect to interface %u for framebuffer with ID %u.", type: .error, bus, framebuffer)
+        continue
+      }
+      defer { IOI2CInterfaceClose(connect, IOOptionBits()) }
+      guard IOI2CSendRequest(connect, IOOptionBits(), &request) == KERN_SUCCESS else {
+        os_log("Failed to send request to interface %u for framebuffer with ID %u.", type: .error, bus, framebuffer)
+        continue
+      }
+      guard request.result == KERN_SUCCESS else {
+        os_log("Request to interface %u for framebuffer with ID %u failed.", type: .error, bus, framebuffer)
+        continue
+      }
+      return true
+    }
+    return false
+  }
+
+  static func servicePortUsingDisplayPropertiesMatching(from displayId: CGDirectDisplayID) -> io_object_t? {
+    var portIterator = io_iterator_t()
+    let status: kern_return_t = IOServiceGetMatchingServices(kIOMainPortDefault, IOServiceMatching(IOFRAMEBUFFER_CONFORMSTO), &portIterator)
+    guard status == KERN_SUCCESS else {
+      os_log("No matching services found for display with ID %u.", type: .error, displayId)
+      return nil
+    }
+    defer {
+      assert(IOObjectRelease(portIterator) == KERN_SUCCESS)
+    }
+    while case let port = IOIteratorNext(portIterator), port != 0 {
+      let dict = IODisplayCreateInfoDictionary(port, IOOptionBits(kIODisplayOnlyPreferredName)).takeRetainedValue() as NSDictionary
+      let valueForKey = { (k: String) in
+        (dict[k] as? CFIndex).flatMap { Int32(exactly: $0) }.flatMap { UInt32(bitPattern: $0) } ?? 0
+      }
+      let portVendorId = valueForKey(kDisplayVendorID)
+      let displayVendorId = CGDisplayVendorNumber(displayId)
+      guard portVendorId == displayVendorId else {
+        os_log("Service port vendor ID %u differs from display product ID %u.", type: .info,
+               portVendorId, displayVendorId)
+        continue
+      }
+      let portProductId = valueForKey(kDisplayProductID)
+      let displayProductId = CGDisplayModelNumber(displayId)
+      guard portProductId == displayProductId else {
+        os_log("Service port product ID %u differs from display product ID %u.", type: .info,
+               portProductId, displayProductId)
+        continue
+      }
+      let portSerialNumber = valueForKey(kDisplaySerialNumber)
+      let displaySerialNumber = CGDisplaySerialNumber(displayId)
+      guard portSerialNumber == displaySerialNumber else {
+        os_log("Service port serial number %u differs from display serial number %u.", type: .info, portSerialNumber, displaySerialNumber)
+        continue
+      }
+      if let displayLocation = dict[kIODisplayLocationKey] as? NSString {
+        // the unit number is the number right after the last "@" sign in the display location
+        // swiftlint:disable:next force_try
+        let regex = try! NSRegularExpression(pattern: "@([0-9]+)[^@]+$", options: [])
+        if let match = regex.firstMatch(in: displayLocation as String, options: [], range: NSRange(location: 0, length: displayLocation.length)) {
+          let unitNumber = UInt32(displayLocation.substring(with: match.range(at: 1)))
+          guard unitNumber == CGDisplayUnitNumber(displayId) else {
+            continue
+          }
+        }
+      }
+      os_log("Vendor ID: %u, Product ID: %u, Serial Number: %u", type: .info, portVendorId, portProductId, portSerialNumber)
+      os_log("Unit Number: %u", type: .info, CGDisplayUnitNumber(displayId))
+      os_log("Service Port: %u", type: .info, port)
+      return port
+    }
+    os_log("No service port found for display with ID %u.", type: .error, displayId)
+    return nil
+  }
+
+  static func ioFramebufferPortFromDisplayId(displayId: CGDirectDisplayID) -> io_service_t? {
+    if CGDisplayIsBuiltin(displayId) == boolean_t(truncating: true) {
+      return nil
+    }
+    var servicePortUsingCGSServiceForDisplayNumber: io_service_t = 0
+    CGSServiceForDisplayNumber(displayId, &servicePortUsingCGSServiceForDisplayNumber)
+    if servicePortUsingCGSServiceForDisplayNumber != 0 {
+      os_log("Using CGSServiceForDisplayNumber to acquire framebuffer port for %u.", type: .info, displayId)
+      return servicePortUsingCGSServiceForDisplayNumber
+    }
+    guard let servicePort = self.servicePortUsingDisplayPropertiesMatching(from: displayId) else {
+      return nil
+    }
+    var busCount: IOItemCount = 0
+    guard IOFBGetI2CInterfaceCount(servicePort, &busCount) == KERN_SUCCESS, busCount >= 1 else {
+      os_log("No framebuffer port found for display with ID %u.", type: .error, displayId)
+      return nil
+    }
+    return servicePort
+  }
+}
+#endif

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,217 @@
+# Third-Party Licenses
+
+AnyDoor incorporates the following third-party software. Their license texts are
+reproduced in full below, as required by their terms.
+
+---
+
+## MonitorControl
+
+`MonitorControl/Support/IntelDDC.swift` is vendored into AnyDoor at
+`Sources/AnyDoor/Services/Brightness/Vendor/MonitorControlIntelDDC.swift`
+(see that file's header for the local adaptations).
+
+- Project: https://github.com/MonitorControl/MonitorControl
+- Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+  (the vendored file is itself adapted from work by @reitermarkus).
+
+```
+MIT License
+
+Copyright © 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Sparkle
+
+Linked as a Swift Package dependency for application auto-updates.
+
+- Project: https://github.com/sparkle-project/Sparkle (pinned to 2.9.2)
+
+```
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions 
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## AskForPermission
+
+Linked as a Swift Package dependency for the accessibility permission onboarding flow.
+
+- Project: https://github.com/riko2chen/AskForPermission
+
+```
+MIT License
+
+Copyright (c) 2026 Riko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
## Summary

Removes an unlicensed dependency from the shipped binary. The Intel
external-display brightness path depended on
[`reitermarkus/DDC.swift`](https://github.com/reitermarkus/DDC.swift), which
carries **no license anywhere** (GitHub reports `license=null`, there is no
`LICENSE`/`COPYING` on any branch, no tags/releases, no podspec, and no
per-file headers). Under default copyright that is all-rights-reserved, so
AnyDoor had no grant to redistribute it inside its distributed universal
binary. The README's "DDC.swift (MIT)" credit was unsubstantiated.

This is a compliance fix independent of AnyDoor's own license choice — even
staying MIT, the app cannot legally ship someone else's unlicensed code.

## What changed

- **Vendor MonitorControl's MIT `IntelDDC`** into
  `Sources/AnyDoor/Services/Brightness/Vendor/MonitorControlIntelDDC.swift`
  (MonitorControl is MIT; its file is itself adapted from reitermarkus). The
  original copyright header is preserved and the local SwiftPM adaptations are
  documented in the file header:
  - explicit `CoreGraphics`/`IOKit`/`IOKit.i2c`/`IOKit.graphics` imports
    (MonitorControl pulled these in via its bridging header / project settings),
  - a `_silgen_name` shim for the private `CGSServiceForDisplayNumber`
    (it lived in MonitorControl's `Bridging-Header.h`),
  - `kIOMasterPortDefault` → `kIOMainPortDefault`,
  - wrapped in `#if !arch(arm64)` so the private symbol never enters the arm64 slice.
- **`IntelDDCBackend`** now builds on the vendored `IntelDDC`. Its
  `init?(for:)` / `read(command:)` / `write(command:value:)` surface matches the
  old dependency, so the change is minimal. **DDC/CI behavior is unchanged.**
  Apple Silicon still uses the existing IOAVService `Arm64DDCBackend`.
- **Drop** `reitermarkus/DDC.swift` from `Package.swift` / `Package.resolved`.
- **Attribution:** add `THIRD-PARTY-LICENSES.md` reproducing the full Sparkle
  (MIT + bundled BSD-2/zlib/MIT components), MonitorControl (MIT) and
  AskForPermission (MIT) license texts; update the README acknowledgements,
  `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md`.

## Test plan

- Native **arm64** `swift build` — passes.
- Cross-compiled **x86_64** `swift build --arch x86_64` (actually compiles the
  Intel backend + vendored file) — passes.
- Full test suite — **330 tests, 0 failures**.

> Note: this PR is **stacked on `chore/landing-refresh-and-fixes` (#37)** so its
> diff stays limited to the single brightness commit. GitHub will retarget the
> base to `main` automatically once #37 merges.
