### PR TITLE
feat: add Bluetooth device battery readout and capture shutter sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ versioning.
 
 ## [Unreleased]
 
+### Added
+
+- A capture sound: a successful screenshot now plays the native macOS screenshot
+  shutter (`Screen Capture.aif`, falling back to the system `Shutter` / `Grab`
+  sounds) at the moment the capture commits. It covers every successful still
+  capture — region, window, fullscreen, and scrolling — through the shared output
+  path. A "play sound after capture" toggle in Settings › Capture (on by default)
+  controls it, and the preference rides settings backup. Screen recording is
+  unaffected (it keeps its own start/stop cues).
+
 ## [3.0.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ versioning.
   path. A "play sound after capture" toggle in Settings › Capture (on by default)
   controls it, and the preference rides settings backup. Screen recording is
   unaffected (it keeps its own start/stop cues).
+- Bluetooth device battery: a new menu-bar panel item whose hover popover lists
+  every connected Bluetooth accessory macOS reports a battery level for — AirPods
+  and true-wireless earbuds (left / right / case), Apple Magic keyboards, mice,
+  and trackpads, generic BLE keyboards and mice that expose the standard GATT
+  Battery Service, and Logitech HID++ mice (MX Master and similar). Levels are
+  read off the main actor via `ShellRunner` from two public, permission-free
+  sources — `system_profiler SPBluetoothDataType -json` (rich; gives the earbud
+  left/right/case triple and a device type) and `pmset -g accps` (covers the
+  HID++ mice that system_profiler silently omits) — merged by a pure, unit-tested
+  `BluetoothBatteryParser` that prefers the richer system_profiler readings and
+  folds pmset in for the gaps. Each reading is tinted by charge (red ≤ 20 %,
+  yellow ≤ 35 %, green otherwise). macOS exposes no battery-change notification,
+  so the list polls on demand when the popover opens and caches for 30 s to avoid
+  re-spawning the subprocesses; no new entitlement, TCC prompt, or private API is
+  involved.
 
 ## [3.0.0] - 2026-06-18
 

--- a/Sources/AnyDoor/Models/BluetoothBatteryDevice.swift
+++ b/Sources/AnyDoor/Models/BluetoothBatteryDevice.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A connected Bluetooth accessory together with whatever battery readings macOS
+/// exposes for it. True-wireless earbuds populate `left` / `right` / `caseLevel`;
+/// every other device reports a single `main` level. All percentages are 0–100,
+/// or `nil` when that slot is unknown.
+struct BluetoothBatteryDevice: Identifiable, Hashable, Sendable {
+    /// Stable identity: the normalized device address when known, otherwise the
+    /// lowercased name (pmset-only devices have no address).
+    let id: String
+    let name: String
+    /// Raw `device_minorType` from system_profiler (e.g. "Keyboard", "Mouse",
+    /// "Headphones"); `nil` for pmset-only devices whose type we never learned.
+    let minorType: String?
+    let main: Int?
+    let left: Int?
+    let right: Int?
+    let caseLevel: Int?
+
+    /// True when the device reports the left/right/case triple (earbuds).
+    var isEarbuds: Bool { left != nil || right != nil || caseLevel != nil }
+
+    /// All known readings, used for sorting and low-battery checks.
+    var levels: [Int] { [main, left, right, caseLevel].compactMap { $0 } }
+
+    /// The lowest reading across every populated slot, or `nil` if none.
+    var lowestLevel: Int? { levels.min() }
+
+    /// SF Symbol representing the device category. Falls back to a generic
+    /// Bluetooth glyph when the type is unknown or unrecognized.
+    var symbol: String {
+        switch minorType?.lowercased() {
+        case let t? where t.contains("keyboard"): return "keyboard"
+        case let t? where t.contains("trackpad"): return "rectangle.and.hand.point.up.left"
+        case let t? where t.contains("mouse"):     return "computermouse"
+        case let t? where t.contains("headphone"): return "airpods"
+        case let t? where t.contains("headset"):   return "headphones"
+        case let t? where t.contains("speaker"):   return "hifispeaker"
+        default: return "dot.radiowaves.left.and.right"
+        }
+    }
+}
+
+extension Int {
+    /// Maps a 0–100 battery percentage to the closest `battery.NN` SF Symbol.
+    var batterySymbolName: String {
+        switch self {
+        case 88...: return "battery.100"
+        case 63...: return "battery.75"
+        case 38...: return "battery.50"
+        case 13...: return "battery.25"
+        default:    return "battery.0"
+        }
+    }
+}

--- a/Sources/AnyDoor/Models/BuiltinItem.swift
+++ b/Sources/AnyDoor/Models/BuiltinItem.swift
@@ -58,6 +58,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
     case windowMovePreviousDisplay
     case windowLayout
     case hostsManager
+    case bluetoothBattery
 
     enum Kind: Sendable {
         case toggle
@@ -69,7 +70,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
 
     var kind: Kind {
         switch self {
-        case .appShortcuts, .portManager, .windowLayout, .hostsManager: return .submenu
+        case .appShortcuts, .portManager, .windowLayout, .hostsManager, .bluetoothBattery: return .submenu
         case .keepAwake, .muteAudio, .microphoneMute, .hideDesktopIcons, .showHiddenFiles, .darkMode,
              .hideDock, .autoHideMenuBar, .keyboardLock, .scheduledShutdown: return .toggle
         case .clipboardMonitoring: return .toggle
@@ -146,6 +147,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMovePreviousDisplay: return .builtinWindowMovePreviousDisplay
         case .windowLayout:      return .builtinWindowLayout
         case .hostsManager:      return .builtinHostsManager
+        case .bluetoothBattery:  return .builtinBluetoothBattery
         }
     }
 
@@ -206,6 +208,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMovePreviousDisplay: return "rectangle.on.rectangle"
         case .windowLayout: return "macwindow"
         case .hostsManager: return "list.bullet.rectangle"
+        case .bluetoothBattery: return "battery.100"
         }
     }
 
@@ -267,6 +270,7 @@ enum BuiltinItem: String, CaseIterable, Sendable {
         case .windowMovePreviousDisplay: return 2190
         case .windowLayout:    return 2000
         case .hostsManager:    return 1950
+        case .bluetoothBattery: return 1980
         }
     }
 

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -698,6 +698,23 @@
         }
       }
     },
+    "settings.capture.playSound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play sound after capture"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截图后播放音效"
+          }
+        }
+      }
+    },
     "settings.capture.behaviorSection": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -1,6 +1,108 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "bluetooth.battery.case": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Case"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "充电盒"
+          }
+        }
+      }
+    },
+    "bluetooth.battery.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Bluetooth devices report battery"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可读取电量的蓝牙设备"
+          }
+        }
+      }
+    },
+    "bluetooth.battery.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to read battery levels"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "读取电量失败"
+          }
+        }
+      }
+    },
+    "bluetooth.battery.reading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "读取中…"
+          }
+        }
+      }
+    },
+    "bluetooth.battery.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        }
+      }
+    },
+    "builtin.bluetoothBattery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth Battery"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蓝牙电量"
+          }
+        }
+      }
+    },
     "capture.overlay.saveAs": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AnyDoor/Services/BluetoothBatteryParser.swift
+++ b/Sources/AnyDoor/Services/BluetoothBatteryParser.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+/// Pure parsing + merging of the two public macOS battery sources:
+///
+/// 1. `system_profiler SPBluetoothDataType -json` — rich, gives the L/R/case
+///    triple for earbuds and a `device_minorType` for every connected device,
+///    but silently omits a battery field for some accessories (notably Logitech
+///    HID++ mice like the MX Master series).
+/// 2. `pmset -g accps` — a flat `name → percent` list that *does* cover those
+///    HID++ devices, but only a single percentage and no device type.
+///
+/// We treat system_profiler as the canonical device set (for names + types +
+/// earbud granularity) and fold pmset in as the fallback level for anything
+/// system_profiler left blank. Everything here is deterministic and side-effect
+/// free so it can run off the MainActor and be unit-tested with fixture strings.
+enum BluetoothBatteryParser {
+    /// A connected device as seen by system_profiler, before pmset is folded in.
+    struct SystemProfilerDevice: Equatable, Sendable {
+        var name: String
+        var address: String?
+        var minorType: String?
+        var main: Int?
+        var left: Int?
+        var right: Int?
+        var caseLevel: Int?
+
+        var hasAnyBattery: Bool {
+            main != nil || left != nil || right != nil || caseLevel != nil
+        }
+    }
+
+    // MARK: - Public entry point
+
+    /// Merge both sources into the final, display-ready device list. Only devices
+    /// that report at least one battery reading (from either source) are kept.
+    static func merge(systemProfilerJSON: Data?, pmsetOutput: String?) -> [BluetoothBatteryDevice] {
+        let spDevices = systemProfilerJSON.map(parseSystemProfiler) ?? []
+        let accessories = pmsetOutput.map(parsePmsetAccessories) ?? []
+
+        // Index pmset percentages by normalized name; consume as we match.
+        var remaining: [String: Int] = [:]
+        for acc in accessories {
+            remaining[normalize(acc.name)] = acc.percent
+        }
+
+        var result: [BluetoothBatteryDevice] = []
+        for device in spDevices {
+            var main = device.main
+            // Fold in pmset only when system_profiler gave us nothing for this
+            // device (richer L/R/case data, when present, always wins).
+            if !device.hasAnyBattery, let percent = remaining[normalize(device.name)] {
+                main = percent
+            }
+            // Whether or not we used it, this device's pmset entry is now spoken
+            // for so it isn't re-added as a standalone row below.
+            remaining[normalize(device.name)] = nil
+
+            let merged = BluetoothBatteryDevice(
+                id: device.address.map(normalize) ?? normalize(device.name),
+                name: device.name,
+                minorType: device.minorType,
+                main: main,
+                left: device.left,
+                right: device.right,
+                caseLevel: device.caseLevel
+            )
+            if !merged.levels.isEmpty {
+                result.append(merged)
+            }
+        }
+
+        // pmset rows with no matching system_profiler device — keep them as
+        // name-only entries so we never drop a device macOS clearly knows about.
+        for acc in accessories where remaining[normalize(acc.name)] != nil {
+            remaining[normalize(acc.name)] = nil
+            result.append(
+                BluetoothBatteryDevice(
+                    id: normalize(acc.name),
+                    name: acc.name,
+                    minorType: nil,
+                    main: acc.percent,
+                    left: nil,
+                    right: nil,
+                    caseLevel: nil
+                )
+            )
+        }
+
+        return result.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    // MARK: - system_profiler
+
+    /// Parse the `device_connected` array out of `SPBluetoothDataType -json`.
+    static func parseSystemProfiler(_ data: Data) -> [SystemProfilerDevice] {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data),
+            let top = (root as? [String: Any])?["SPBluetoothDataType"] as? [[String: Any]]
+        else { return [] }
+
+        var devices: [SystemProfilerDevice] = []
+        for section in top {
+            guard let connected = section["device_connected"] as? [[String: Any]] else { continue }
+            // Each entry is a single-key dict: { "<device name>": { <props> } }.
+            for entry in connected {
+                for (name, value) in entry {
+                    guard let props = value as? [String: Any] else { continue }
+                    devices.append(
+                        SystemProfilerDevice(
+                            name: name,
+                            address: props["device_address"] as? String,
+                            minorType: props["device_minorType"] as? String,
+                            main: percent(props["device_batteryLevelMain"]),
+                            left: percent(props["device_batteryLevelLeft"]),
+                            right: percent(props["device_batteryLevelRight"]),
+                            caseLevel: percent(props["device_batteryLevelCase"])
+                        )
+                    )
+                }
+            }
+        }
+        return devices
+    }
+
+    // MARK: - pmset
+
+    struct Accessory: Equatable, Sendable {
+        var name: String
+        var percent: Int
+    }
+
+    /// Parse `pmset -g accps` lines such as `-MX Master 3S (id=38802333)\t55%;`.
+    /// The internal battery row is skipped; only Bluetooth accessories remain.
+    static func parsePmsetAccessories(_ output: String) -> [Accessory] {
+        var accessories: [Accessory] = []
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("-") else { continue }
+            // Name lives between the leading "-" and the " (id=" marker.
+            let afterDash = line.dropFirst()
+            guard let idRange = afterDash.range(of: " (id=") else { continue }
+            let name = String(afterDash[..<idRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty, !name.hasPrefix("InternalBattery") else { continue }
+            guard let percent = firstPercent(in: afterDash[idRange.upperBound...]) else { continue }
+            accessories.append(Accessory(name: name, percent: percent))
+        }
+        return accessories
+    }
+
+    // MARK: - Helpers
+
+    /// Extract an integer percentage from a `"100%"`-style value of any JSON type.
+    private static func percent(_ value: Any?) -> Int? {
+        if let s = value as? String {
+            let digits = s.filter(\.isNumber)
+            return Int(digits)
+        }
+        if let n = value as? Int { return n }
+        if let d = value as? Double { return Int(d) }
+        return nil
+    }
+
+    /// Find the first `NN%` token in a substring and return NN.
+    private static func firstPercent(in text: Substring) -> Int? {
+        guard let pctIndex = text.firstIndex(of: "%") else { return nil }
+        var digits = ""
+        var i = pctIndex
+        while i > text.startIndex {
+            i = text.index(before: i)
+            if text[i].isNumber {
+                digits.insert(text[i], at: digits.startIndex)
+            } else {
+                break
+            }
+        }
+        return Int(digits)
+    }
+
+    /// Canonical form for matching the same device across the two sources:
+    /// lowercased, trimmed, with address separators normalized to ':'.
+    private static func normalize(_ s: String) -> String {
+        s.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: ":")
+    }
+}

--- a/Sources/AnyDoor/Services/BluetoothBatteryService.swift
+++ b/Sources/AnyDoor/Services/BluetoothBatteryService.swift
@@ -1,0 +1,102 @@
+import Foundation
+import os
+
+enum BluetoothBatteryError: Equatable, Sendable {
+    case readFailed
+}
+
+/// Observable store for connected Bluetooth accessory battery levels.
+///
+/// Reads two public, permission-free macOS sources off the MainActor via
+/// `ShellRunner` — `system_profiler SPBluetoothDataType -json` (rich, earbud
+/// L/R/case) and `pmset -g accps` (covers HID++ mice system_profiler misses) —
+/// then folds them together in `BluetoothBatteryParser`. There is no push
+/// notification for battery changes, so the UI polls on demand (popover hover)
+/// and results are cached for `cacheDuration` to avoid re-spawning subprocesses.
+@MainActor
+@Observable
+final class BluetoothBatteryService {
+    // MARK: - Public state
+
+    private(set) var devices: [BluetoothBatteryDevice] = []
+    private(set) var isRefreshing: Bool = false
+    private(set) var lastError: BluetoothBatteryError? = nil
+
+    // MARK: - Dependencies
+
+    private let cacheDuration: TimeInterval
+    private let now: () -> Date
+    private static let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "BluetoothBattery")
+
+    // MARK: - Internal refresh state
+
+    private var generation: UInt64 = 0
+    private var lastSuccessfulRefreshAt: Date?
+
+    // MARK: - Lifecycle
+
+    // First touched from main-actor UI code. Use MainThreadIsolation rather than
+    // MainActor.assumeIsolated so a first access after a ScreenCaptureKit capture
+    // (which can leave the main thread's executor tracking dangling) does not
+    // fault the swift_task_isCurrentExecutor check. See MainThreadIsolation.
+    static let shared: BluetoothBatteryService = MainThreadIsolation.run { BluetoothBatteryService() }
+
+    init(cacheDuration: TimeInterval = 30, now: @escaping () -> Date = Date.init) {
+        self.cacheDuration = cacheDuration
+        self.now = now
+    }
+
+    // MARK: - Refresh
+
+    func refresh(force: Bool = false) async {
+        if !force, isCacheFresh { return }
+
+        generation &+= 1
+        let myGen = generation
+        isRefreshing = true
+
+        // Spawn both probes concurrently; either may fail independently (a `nil`
+        // result), so we tolerate one source being unavailable.
+        async let spProbe = ShellRunner.run(
+            "/usr/sbin/system_profiler",
+            args: ["SPBluetoothDataType", "-json"],
+            timeout: 12
+        )
+        async let pmProbe = ShellRunner.run(
+            "/usr/bin/pmset",
+            args: ["-g", "accps"],
+            timeout: 6
+        )
+        let sp = try? await spProbe
+        let pm = try? await pmProbe
+
+        // A newer refresh superseded us while we awaited the subprocesses.
+        guard myGen == generation else { return }
+
+        guard sp != nil || pm != nil else {
+            lastError = .readFailed
+            isRefreshing = false
+            Self.logger.error("both battery probes failed")
+            return
+        }
+
+        // Parsing walks up to a few hundred KB of JSON; keep it off the MainActor.
+        let parsed = await Task.detached(priority: .userInitiated) {
+            BluetoothBatteryParser.merge(
+                systemProfilerJSON: sp?.data(using: .utf8),
+                pmsetOutput: pm
+            )
+        }.value
+
+        guard myGen == generation else { return }
+        devices = parsed
+        lastError = nil
+        lastSuccessfulRefreshAt = now()
+        isRefreshing = false
+    }
+
+    private var isCacheFresh: Bool {
+        guard lastError == nil, let lastSuccessfulRefreshAt else { return false }
+        return now().timeIntervalSince(lastSuccessfulRefreshAt) < cacheDuration
+    }
+}

--- a/Sources/AnyDoor/Services/Capture/CaptureCoordinator.swift
+++ b/Sources/AnyDoor/Services/Capture/CaptureCoordinator.swift
@@ -285,6 +285,10 @@ final class CaptureCoordinator {
     /// capture grab is already complete and synchronous, and this mirrors the
     /// existing off-main OCR / history paths below.
     private func present(image cg: CGImage) {
+        // Shutter feedback at the capture's commit moment, matching native
+        // screenshots. NSSound plays asynchronously, so this never blocks.
+        if settings.playSound { SystemSound.screenCapture.play() }
+
         let image = NSImage(cgImage: cg, size: .zero)
 
         // Cheap and latency-sensitive: copy to the pasteboard right away (AppKit

--- a/Sources/AnyDoor/Services/Capture/CaptureSettings.swift
+++ b/Sources/AnyDoor/Services/Capture/CaptureSettings.swift
@@ -13,6 +13,7 @@ final class CaptureSettings {
     static let namingTemplateKey = "capture.namingTemplate"
     static let autoCopyKey = "capture.autoCopy"
     static let autoSaveKey = "capture.autoSave"
+    static let playSoundKey = "capture.playSound"
     static let delaySecondsKey = "capture.delaySeconds"
     static let overlayTimeoutKey = "capture.overlayTimeout"
     static let lastRegionRectKey = "capture.lastRegionRect"
@@ -25,6 +26,7 @@ final class CaptureSettings {
     private(set) var namingTemplate: String
     private(set) var autoCopy: Bool
     private(set) var autoSave: Bool
+    private(set) var playSound: Bool
     private(set) var delaySeconds: Int
     private(set) var overlayTimeout: Int
     private(set) var lastRegionRect: CGRect?
@@ -47,6 +49,7 @@ final class CaptureSettings {
         self.namingTemplate = defaults.string(forKey: Self.namingTemplateKey) ?? Self.defaultNamingTemplate
         self.autoCopy = defaults.object(forKey: Self.autoCopyKey) as? Bool ?? true
         self.autoSave = defaults.object(forKey: Self.autoSaveKey) as? Bool ?? true
+        self.playSound = defaults.object(forKey: Self.playSoundKey) as? Bool ?? true
         self.delaySeconds = defaults.object(forKey: Self.delaySecondsKey) as? Int ?? 5
         self.overlayTimeout = defaults.object(forKey: Self.overlayTimeoutKey) as? Int ?? 8
         self.lastRegionRect = Self.readRect(defaults, Self.lastRegionRectKey)
@@ -70,6 +73,11 @@ final class CaptureSettings {
     func setAutoSave(_ value: Bool) {
         autoSave = value
         defaults.set(value, forKey: Self.autoSaveKey)
+    }
+
+    func setPlaySound(_ value: Bool) {
+        playSound = value
+        defaults.set(value, forKey: Self.playSoundKey)
     }
 
     func setDelaySeconds(_ value: Int) {
@@ -100,6 +108,7 @@ final class CaptureSettings {
         namingTemplate = defaults.string(forKey: Self.namingTemplateKey) ?? Self.defaultNamingTemplate
         autoCopy = defaults.object(forKey: Self.autoCopyKey) as? Bool ?? true
         autoSave = defaults.object(forKey: Self.autoSaveKey) as? Bool ?? true
+        playSound = defaults.object(forKey: Self.playSoundKey) as? Bool ?? true
         delaySeconds = defaults.object(forKey: Self.delaySecondsKey) as? Int ?? 5
         overlayTimeout = defaults.object(forKey: Self.overlayTimeoutKey) as? Int ?? 8
         lastRegionRect = Self.readRect(defaults, Self.lastRegionRectKey)

--- a/Sources/AnyDoor/Services/SyncSettingsRegistry.swift
+++ b/Sources/AnyDoor/Services/SyncSettingsRegistry.swift
@@ -33,6 +33,7 @@ enum SyncSettingsRegistry {
         Entry(key: "capture.namingTemplate", type: .string),
         Entry(key: "capture.autoCopy", type: .bool),
         Entry(key: "capture.autoSave", type: .bool),
+        Entry(key: "capture.playSound", type: .bool),
         Entry(key: "capture.delaySeconds", type: .int),
         Entry(key: "capture.overlayTimeout", type: .int),
     ]

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -244,6 +244,7 @@ enum L10n {
         case settingsCaptureNamingFooter = "settings.capture.namingFooter"
         case settingsCaptureNamingTemplate = "settings.capture.namingTemplate"
         case settingsCaptureOverlayTimeout = "settings.capture.overlayTimeout"
+        case settingsCapturePlaySound = "settings.capture.playSound"
         case settingsCaptureSaveDirectory = "settings.capture.saveDirectory"
         case settingsCaptureSaveSection = "settings.capture.saveSection"
         case settingsCaptureTimerDelay = "settings.capture.timerDelay"

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -5,8 +5,14 @@ import SwiftUI
 /// migration tasks; the catalog must contain a matching entry for each case.
 enum L10n {
     enum Key: String, CaseIterable, Sendable {
+        case bluetoothBatteryCase = "bluetooth.battery.case"
+        case bluetoothBatteryEmpty = "bluetooth.battery.empty"
+        case bluetoothBatteryError = "bluetooth.battery.error"
+        case bluetoothBatteryReading = "bluetooth.battery.reading"
+        case bluetoothBatteryRefresh = "bluetooth.battery.refresh"
         case builtinAppShortcuts = "builtin.appShortcuts"
         case builtinAutoHideMenuBar = "builtin.autoHideMenuBar"
+        case builtinBluetoothBattery = "builtin.bluetoothBattery"
         case builtinBrightness = "builtin.brightness"
         case builtinBrightnessDown = "builtin.brightnessDown"
         case builtinBrightnessUp = "builtin.brightnessUp"

--- a/Sources/AnyDoor/Utilities/SystemSound.swift
+++ b/Sources/AnyDoor/Utilities/SystemSound.swift
@@ -2,11 +2,13 @@ import AppKit
 
 /// Lightweight wrapper over NSSound for system feedback effects.
 ///
-/// Uses macOS's own Finder sound files where possible so the UX matches
-/// what users hear when interacting with Finder directly. Falls back to a
-/// named system sound if the bundled asset has moved.
+/// Uses macOS's own sound files where possible so the UX matches what users hear
+/// when the system performs the same action directly. Falls back through a chain
+/// of equivalent assets if a bundled file has moved.
 enum SystemSound {
     case emptyTrash
+    /// The shutter sound macOS plays for native screenshots (⌘⇧3/4/5).
+    case screenCapture
 
     /// Plays asynchronously. Safe to call from any actor; NSSound dispatches internally.
     func play() {
@@ -17,12 +19,32 @@ enum SystemSound {
     private func makeSound() -> NSSound? {
         switch self {
         case .emptyTrash:
-            let path = "/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/finder/empty trash.aif"
-            if FileManager.default.fileExists(atPath: path),
-               let sound = NSSound(contentsOfFile: path, byReference: true) {
+            return Self.firstExistingSound(
+                paths: ["\(Self.finderDir)/empty trash.aif"]
+            ) ?? NSSound(named: NSSound.Name("Bottle"))
+        case .screenCapture:
+            // Prefer the exact native screenshot sound; fall back to the classic
+            // Grab / generic camera shutter shipped alongside it.
+            return Self.firstExistingSound(paths: [
+                "\(Self.systemDir)/Screen Capture.aif",
+                "\(Self.systemDir)/Shutter.aif",
+                "\(Self.systemDir)/Grab.aif",
+            ])
+        }
+    }
+
+    private static let soundsRoot =
+        "/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds"
+    private static let systemDir = "\(soundsRoot)/system"
+    private static let finderDir = "\(soundsRoot)/finder"
+
+    /// Returns the first readable sound from `paths`, or nil if none exist.
+    private static func firstExistingSound(paths: [String]) -> NSSound? {
+        for path in paths where FileManager.default.fileExists(atPath: path) {
+            if let sound = NSSound(contentsOfFile: path, byReference: true) {
                 return sound
             }
-            return NSSound(named: NSSound.Name("Bottle"))
         }
+        return nil
     }
 }

--- a/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
+++ b/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+/// Root SwiftUI view shown inside the Bluetooth Battery `HoverPopover`.
+///
+/// Lists every connected accessory macOS reports a battery level for. Earbuds
+/// render their left / right / case triple; everything else shows a single
+/// level badge. Data comes from `BluetoothBatteryService.shared`, refreshed on
+/// hover (see `MenuBarView.mountPopoverContent`).
+struct BluetoothBatteryPopoverView: View {
+    private static let popoverWidth: CGFloat = 300
+
+    @Bindable var service: BluetoothBatteryService
+    var onHoverChange: @MainActor (Bool) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .frame(width: Self.popoverWidth)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .onHoverSafe(perform: onHoverChange)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "battery.100")
+                .foregroundStyle(.secondary)
+            LocalizedText(.builtinBluetoothBattery)
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+            if service.isRefreshing {
+                ProgressView().controlSize(.small)
+            } else {
+                Button {
+                    Task { await service.refresh(force: true) }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(L(.bluetoothBatteryRefresh))
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if service.isRefreshing && service.devices.isEmpty {
+            centered { ProgressView(L(.bluetoothBatteryReading)) }
+        } else if service.devices.isEmpty {
+            centered {
+                LocalizedText(service.lastError == nil ? .bluetoothBatteryEmpty : .bluetoothBatteryError)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        } else {
+            ScrollView {
+                VStack(spacing: 2) {
+                    ForEach(service.devices) { device in
+                        BluetoothBatteryRow(device: device)
+                    }
+                }
+                .padding(.horizontal, 6).padding(.vertical, 6)
+            }
+            .frame(maxHeight: 360)
+        }
+    }
+
+    private func centered<V: View>(@ViewBuilder _ inner: () -> V) -> some View {
+        VStack {
+            inner()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16).padding(.vertical, 28)
+    }
+}
+
+// MARK: - Device row
+
+private struct BluetoothBatteryRow: View {
+    let device: BluetoothBatteryDevice
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: device.symbol)
+                .font(.system(size: 15))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(device.name)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+                if device.isEarbuds {
+                    earbudsLevels
+                }
+            }
+            Spacer(minLength: 8)
+            if !device.isEarbuds, let main = device.main {
+                BatteryBadge(level: main)
+            }
+        }
+        .padding(.horizontal, 8).padding(.vertical, 6)
+        .contentShape(Rectangle())
+    }
+
+    private var earbudsLevels: some View {
+        HStack(spacing: 8) {
+            if let left = device.left { MiniLevel(label: "L", level: left) }
+            if let right = device.right { MiniLevel(label: "R", level: right) }
+            if let caseLevel = device.caseLevel { MiniLevel(label: L(.bluetoothBatteryCase), level: caseLevel) }
+        }
+    }
+}
+
+// MARK: - Battery badges
+
+private struct BatteryBadge: View {
+    let level: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: level.batterySymbolName)
+                .font(.system(size: 14))
+                .foregroundStyle(BatteryPalette.color(level))
+            Text("\(level)%")
+                .font(.system(size: 12, weight: .medium))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct MiniLevel: View {
+    let label: String
+    let level: Int
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Text("\(level)%")
+                .font(.system(size: 10))
+                .monospacedDigit()
+                .foregroundStyle(BatteryPalette.color(level))
+        }
+    }
+}
+
+private enum BatteryPalette {
+    static func color(_ level: Int) -> Color {
+        switch level {
+        case ...20: return .red
+        case ...35: return .yellow
+        default:    return .green
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/CaptureSettingsView.swift
+++ b/Sources/AnyDoor/Views/CaptureSettingsView.swift
@@ -40,6 +40,7 @@ struct CaptureSettingsView: View {
             Section {
                 Toggle(isOn: autoSave) { LocalizedText(.settingsCaptureAutoSave) }
                 Toggle(isOn: autoCopy) { LocalizedText(.settingsCaptureAutoCopy) }
+                Toggle(isOn: playSound) { LocalizedText(.settingsCapturePlaySound) }
 
                 Picker(selection: timerDelay) {
                     ForEach([3, 5, 10], id: \.self) { seconds in
@@ -93,6 +94,9 @@ struct CaptureSettingsView: View {
     }
     private var autoCopy: Binding<Bool> {
         Binding(get: { settings.autoCopy }, set: { settings.setAutoCopy($0) })
+    }
+    private var playSound: Binding<Bool> {
+        Binding(get: { settings.playSound }, set: { settings.setPlaySound($0) })
     }
     private var timerDelay: Binding<Int> {
         Binding(get: { settings.delaySeconds }, set: { settings.setDelaySeconds($0) })

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -393,6 +393,16 @@ struct MenuBarView: View {
                 )
             }
             popover.show(anchoredTo: convertedTriggerFrame(for: target))
+        case .submenu(.bluetoothBattery):
+            popover.needsKeyFocus = false
+            popover.updateContent {
+                BluetoothBatteryPopoverView(
+                    service: BluetoothBatteryService.shared,
+                    onHoverChange: { gate.popoverHover($0) }
+                )
+            }
+            Task { await BluetoothBatteryService.shared.refresh() }
+            popover.show(anchoredTo: convertedTriggerFrame(for: target))
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.
             break

--- a/Tests/AnyDoorTests/BluetoothBatteryParserTests.swift
+++ b/Tests/AnyDoorTests/BluetoothBatteryParserTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import AnyDoor
+
+final class BluetoothBatteryParserTests: XCTestCase {
+    // Mirrors the real `system_profiler SPBluetoothDataType -json` shape: a
+    // `device_connected` array of single-key dicts, plus a `device_not_connected`
+    // section that must be ignored. The MX Master has no battery field (Logitech
+    // HID++), the AirPods carry the L/R/case triple.
+    private let systemProfilerJSON = """
+    {
+      "SPBluetoothDataType": [
+        {
+          "device_connected": [
+            { "EVO80 BT1": { "device_address": "CA:83:69:5F:28:CE", "device_minorType": "Keyboard", "device_batteryLevelMain": "100%" } },
+            { "MX Master 3S": { "device_address": "DF:52:7C:AF:65:0C", "device_minorType": "Mouse" } },
+            { "AirPods": { "device_address": "10:2F:CA:A6:38:E1", "device_minorType": "Headphones", "device_batteryLevelLeft": "95%", "device_batteryLevelRight": "90%", "device_batteryLevelCase": "80%" } }
+          ],
+          "device_not_connected": [
+            { "Old Keyboard": { "device_address": "00:11:22:33:44:55", "device_minorType": "Keyboard" } }
+          ]
+        }
+      ]
+    }
+    """
+
+    // Real `pmset -g accps` output: internal battery first (must be skipped),
+    // then the two Bluetooth accessories with a single percentage each.
+    private let pmsetOutput = """
+    Now drawing from 'AC Power'
+     -InternalBattery-0 (id=23265379)\t80%; AC attached; not charging present: true
+     -EVO80 BT1 (id=38802332)\t100%;
+     -MX Master 3S (id=38802333)\t55%;
+    """
+
+    private func data(_ s: String) -> Data { Data(s.utf8) }
+
+    // MARK: - system_profiler
+
+    func test_parseSystemProfiler_extractsConnectedOnly() {
+        let devices = BluetoothBatteryParser.parseSystemProfiler(data(systemProfilerJSON))
+        // device_not_connected is ignored.
+        XCTAssertEqual(devices.count, 3)
+
+        let keyboard = devices.first { $0.name == "EVO80 BT1" }
+        XCTAssertEqual(keyboard?.minorType, "Keyboard")
+        XCTAssertEqual(keyboard?.main, 100)
+        XCTAssertNil(keyboard?.left)
+
+        let mouse = devices.first { $0.name == "MX Master 3S" }
+        XCTAssertEqual(mouse?.minorType, "Mouse")
+        XCTAssertFalse(mouse?.hasAnyBattery ?? true)
+
+        let airpods = devices.first { $0.name == "AirPods" }
+        XCTAssertEqual(airpods?.left, 95)
+        XCTAssertEqual(airpods?.right, 90)
+        XCTAssertEqual(airpods?.caseLevel, 80)
+        XCTAssertNil(airpods?.main)
+    }
+
+    func test_parseSystemProfiler_invalidJSON_returnsEmpty() {
+        XCTAssertTrue(BluetoothBatteryParser.parseSystemProfiler(data("not json")).isEmpty)
+        XCTAssertTrue(BluetoothBatteryParser.parseSystemProfiler(data("{}")).isEmpty)
+    }
+
+    // MARK: - pmset
+
+    func test_parsePmsetAccessories_skipsInternalBattery() {
+        let accessories = BluetoothBatteryParser.parsePmsetAccessories(pmsetOutput)
+        XCTAssertEqual(accessories, [
+            .init(name: "EVO80 BT1", percent: 100),
+            .init(name: "MX Master 3S", percent: 55),
+        ])
+    }
+
+    func test_parsePmsetAccessories_emptyOrGarbage() {
+        XCTAssertTrue(BluetoothBatteryParser.parsePmsetAccessories("").isEmpty)
+        XCTAssertTrue(BluetoothBatteryParser.parsePmsetAccessories("Now drawing from 'AC Power'").isEmpty)
+    }
+
+    // MARK: - merge
+
+    func test_merge_foldsPmsetIntoSystemProfilerGaps() {
+        let merged = BluetoothBatteryParser.merge(
+            systemProfilerJSON: data(systemProfilerJSON),
+            pmsetOutput: pmsetOutput
+        )
+        // All three connected devices kept; sorted by name (AirPods, EVO80, MX).
+        XCTAssertEqual(merged.map(\.name), ["AirPods", "EVO80 BT1", "MX Master 3S"])
+
+        let keyboard = merged.first { $0.name == "EVO80 BT1" }
+        XCTAssertEqual(keyboard?.main, 100) // system_profiler value preserved
+
+        // The HID++ mouse had no system_profiler battery → pmset 55% folded in,
+        // while keeping the system_profiler minorType.
+        let mouse = merged.first { $0.name == "MX Master 3S" }
+        XCTAssertEqual(mouse?.main, 55)
+        XCTAssertEqual(mouse?.minorType, "Mouse")
+
+        let airpods = merged.first { $0.name == "AirPods" }
+        XCTAssertTrue(airpods?.isEarbuds ?? false)
+        XCTAssertEqual(airpods?.lowestLevel, 80)
+    }
+
+    func test_merge_dropsDevicesWithNoBatteryFromEitherSource() {
+        // pmset only knows the keyboard; the mouse has no battery anywhere.
+        let pmsetKeyboardOnly = """
+        Now drawing from 'AC Power'
+         -EVO80 BT1 (id=1)\t100%;
+        """
+        let merged = BluetoothBatteryParser.merge(
+            systemProfilerJSON: data(systemProfilerJSON),
+            pmsetOutput: pmsetKeyboardOnly
+        )
+        // MX Master 3S dropped (no battery from either source); AirPods + keyboard remain.
+        XCTAssertEqual(merged.map(\.name), ["AirPods", "EVO80 BT1"])
+    }
+
+    func test_merge_addsPmsetOnlyDevices() {
+        let pmsetExtra = """
+        Now drawing from 'AC Power'
+         -EVO80 BT1 (id=1)\t100%;
+         -Magic Trackpad (id=2)\t60%;
+        """
+        let merged = BluetoothBatteryParser.merge(
+            systemProfilerJSON: data(systemProfilerJSON),
+            pmsetOutput: pmsetExtra
+        )
+        let trackpad = merged.first { $0.name == "Magic Trackpad" }
+        XCTAssertNotNil(trackpad, "pmset-only device should be added")
+        XCTAssertEqual(trackpad?.main, 60)
+        XCTAssertNil(trackpad?.minorType)
+    }
+
+    func test_merge_bothNil_returnsEmpty() {
+        XCTAssertTrue(BluetoothBatteryParser.merge(systemProfilerJSON: nil, pmsetOutput: nil).isEmpty)
+    }
+
+    func test_merge_systemProfilerOnly() {
+        let merged = BluetoothBatteryParser.merge(systemProfilerJSON: data(systemProfilerJSON), pmsetOutput: nil)
+        // Without pmset, the HID++ mouse has no battery and is dropped.
+        XCTAssertEqual(merged.map(\.name), ["AirPods", "EVO80 BT1"])
+    }
+
+    // MARK: - model helpers
+
+    func test_batterySymbolName_buckets() {
+        XCTAssertEqual(100.batterySymbolName, "battery.100")
+        XCTAssertEqual(70.batterySymbolName, "battery.75")
+        XCTAssertEqual(50.batterySymbolName, "battery.50")
+        XCTAssertEqual(20.batterySymbolName, "battery.25")
+        XCTAssertEqual(5.batterySymbolName, "battery.0")
+    }
+
+    func test_device_symbol_byMinorType() {
+        func sym(_ t: String?) -> String {
+            BluetoothBatteryDevice(id: "x", name: "x", minorType: t, main: 50, left: nil, right: nil, caseLevel: nil).symbol
+        }
+        XCTAssertEqual(sym("Keyboard"), "keyboard")
+        XCTAssertEqual(sym("Mouse"), "computermouse")
+        XCTAssertEqual(sym("Magic Trackpad"), "rectangle.and.hand.point.up.left")
+        XCTAssertEqual(sym("Headphones"), "airpods")
+        XCTAssertEqual(sym("Headset"), "headphones")
+        XCTAssertEqual(sym(nil), "dot.radiowaves.left.and.right")
+    }
+}


### PR DESCRIPTION
## Summary

Two menu-bar additions, stacked as two commits on this branch.

### Bluetooth device battery

A new menu-bar panel item whose hover popover lists every connected Bluetooth accessory macOS reports a battery level for — AirPods / earbuds (left / right / case), Apple Magic keyboards, mice, and trackpads, generic BLE keyboards and mice that expose the standard GATT Battery Service, and Logitech HID++ mice (MX Master and similar).

- Reads two public, permission-free sources off the main actor via `ShellRunner`: `system_profiler SPBluetoothDataType -json` (rich; earbud left/right/case triple + device type) and `pmset -g accps` (covers the HID++ mice that system_profiler silently omits).
- A pure, unit-tested `BluetoothBatteryParser` merges them, preferring the richer system_profiler readings and folding pmset in for the gaps.
- Each reading is tinted by charge (red ≤ 20 %, yellow ≤ 35 %, green otherwise).
- macOS exposes no battery-change notification, so the list polls on demand when the popover opens and caches for 30 s to avoid re-spawning subprocesses.
- No new entitlement, TCC prompt, or private API.

Wiring mirrors the existing Port Manager / Brightness hover popovers: a new `.bluetoothBattery` `.submenu` builtin plus a mount case in `MenuBarView`, backed by a MainActor-isolated, observable `BluetoothBatteryService`.

### Capture shutter sound

A successful screenshot now plays the native macOS shutter (`Screen Capture.aif`, falling back to the system `Shutter` / `Grab` sounds) at the moment the capture commits, across region / window / fullscreen / scrolling. A Settings › Capture toggle (on by default) controls it and rides settings backup; screen recording is unaffected.

## Testing

- `swift build` — clean (pre-existing plugin deprecation warnings only).
- `swift test` — 685 passed, 0 failed, including the new `BluetoothBatteryParserTests` and the localization coverage test.
- Verified live on hardware: `system_profiler` + `pmset` return correct levels (keyboard 100 %, MX Master 55 %).
- Not yet visually verified in the running app — the hover popover is a menu-bar UI that can't be triggered headlessly; the data pipeline is tested against real command output.
