### PR TITLE
fix(menubar): smooth hover popovers, top-align them, and add a row hover highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ versioning.
 
 ### Changed
 
+- Menu-bar panel rows now show a subtle hover highlight — a neutral rounded
+  fill (8 % of the foreground color, so it reads as a slight lighten in dark
+  mode and a slight darken in light mode) layered above the material / glass
+  row surface, fading in and out on a short ease. It gives the same
+  row-tracking affordance as the command palette and native menus. Only the
+  top-level panel rows are highlighted, and hover is detected through the
+  AppKit-backed tracking path rather than SwiftUI's `.onHover`.
 - Menu-bar hover popovers now align their top edge with the hovered row (a
   drop-down submenu feel) instead of centering vertically on it, shifting up
   only when a tall popover would otherwise run off the bottom of the screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,48 @@ versioning.
   re-spawning the subprocesses; no new entitlement, TCC prompt, or private API is
   involved.
 
+### Changed
+
+- Menu-bar hover popovers now align their top edge with the hovered row (a
+  drop-down submenu feel) instead of centering vertically on it, shifting up
+  only when a tall popover would otherwise run off the bottom of the screen.
+  Placement is computed by a pure, unit-tested `HoverPopover.anchorOrigin`.
+
+### Fixed
+
+- Menu-bar hover popovers — App Shortcuts, Port Manager, brightness, Hosts,
+  Bluetooth battery, and the clipboard-history side popovers — were janky to
+  switch between (worst on rows that open a popover), sometimes failed to
+  appear, and could be left on screen as a stray window. Several root causes in
+  the shared hover pipeline:
+  - Every show and every row-to-row crossing built a throwaway `NSHostingView`
+    solely to measure the content's fitting size, and re-mounted synchronously
+    on the AppKit mouse-event tick. The popover now reuses a single measuring
+    host (one layout pass, no per-show allocation) and coalesces re-mounts a
+    frame later off the event tick, so a fast sweep across rows rebuilds once
+    instead of once per row crossed.
+  - The 400 ms hover-intent delay restarted on every crossing, so a continuous
+    sweep never reached it and the popover only appeared once the cursor
+    settled; and the hover tracking area was torn down and re-added on every
+    layout pass, which drops the mouse-enter edge when it is rebuilt under an
+    already-stationary cursor, silently losing the hover. The delay now keeps
+    its first deadline (leading-edge), and the tracking area is rebuilt only
+    when missing and reconciled against the live cursor so a dropped edge is
+    recovered.
+  - When a row's on-screen frame had not been recorded yet, the popover
+    anchored to the whole menu-bar panel frame, placing it against the panel
+    edge instead of beside the row; it no longer falls back to a panel anchor.
+  - A key-focus popover (Port Manager or clipboard history) could be orphaned
+    as a zombie window when the panel was dismissed by an outside click;
+    dismissal now orders out any stray hover panel.
+- The clipboard-history popover for 截图到剪贴板 (screenshot to clipboard) opened
+  far from the row — pinned near the bottom of the screen — because the four
+  screenshot-producing builtins (screenshot, capture window, capture fullscreen,
+  capture timer) all map to the same `screenshot` history kind and shared a
+  single anchor entry keyed by kind, so whichever row reported its position last
+  clobbered the others. Hover anchors are now keyed per row, so each row anchors
+  to itself while still showing the shared screenshot history.
+
 ## [3.0.0] - 2026-06-18
 
 ### Added

--- a/Sources/AnyDoor/Services/MenuBarController.swift
+++ b/Sources/AnyDoor/Services/MenuBarController.swift
@@ -211,6 +211,13 @@ final class MenuBarController {
         removeClickMonitors()
         removeKeyMonitors()
         statusItem?.button?.highlight(false)
+        // Authoritatively dismiss any hover popover too. A key-focus popover
+        // (Port Manager / clipboard history) makes the panel's `onDisappear`
+        // skip `popover.hide()`, which would otherwise orphan the
+        // `KeyableHoverPanel` as a zombie window once MenuBarView is torn down.
+        for case let hoverPanel as KeyableHoverPanel in NSApp.windows where hoverPanel.isVisible {
+            hoverPanel.orderOut(nil)
+        }
         panel?.orderOut(nil)
         panel?.contentView = nil
         panel = nil

--- a/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
+++ b/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
@@ -130,13 +130,17 @@ private struct BatteryBadge: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Image(systemName: level.batterySymbolName)
-                .font(.system(size: 14))
-                .foregroundStyle(BatteryPalette.color(level))
+            // Number first, icon last: the badge is right-aligned in the row, so
+            // a trailing fixed-width icon keeps every icon's right edge aligned
+            // and the percentages right-aligned against it (regardless of 2- vs
+            // 3-digit levels like 85% / 100%).
             Text("\(level)%")
                 .font(.system(size: 12, weight: .medium))
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
+            Image(systemName: level.batterySymbolName)
+                .font(.system(size: 14))
+                .foregroundStyle(BatteryPalette.color(level))
         }
     }
 }

--- a/Sources/AnyDoor/Views/Common/HoverReader.swift
+++ b/Sources/AnyDoor/Views/Common/HoverReader.swift
@@ -45,14 +45,35 @@ struct HoverReader: NSViewRepresentable {
 
         override func updateTrackingAreas() {
             super.updateTrackingAreas()
-            for area in trackingAreas { removeTrackingArea(area) }
-            // `.activeAlways` so a non-activating menu panel still tracks hover;
-            // `.inVisibleRect` keeps the area sized to the view across layout.
-            addTrackingArea(NSTrackingArea(
-                rect: .zero,
-                options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
-                owner: self
-            ))
+            // `.inVisibleRect` keeps the area sized to the view across layout, so
+            // it rarely needs rebuilding; only (re)install when actually missing.
+            // Tearing it down and re-adding on every layout pass is gratuitous and
+            // also drops the enter edge: AppKit does not synthesize `mouseEntered:`
+            // when an area is re-added under an already-stationary cursor.
+            if trackingAreas.isEmpty {
+                // `.activeAlways` so a non-activating menu panel still tracks hover.
+                addTrackingArea(NSTrackingArea(
+                    rect: .zero,
+                    options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
+                    owner: self
+                ))
+            }
+            // Reconcile against the live cursor: if a layout/attach left the cursor
+            // resting inside (or outside) the view without a crossing event, emit
+            // the edge that AppKit skipped so the hover state can't get stuck.
+            reconcileHover()
+        }
+
+        /// Recover a missing enter/exit edge by comparing the actual cursor
+        /// position to the tracked `inside` flag. See `updateTrackingAreas`.
+        private func reconcileHover() {
+            guard let window, window.isVisible else { return }
+            let pointInWindow = window.mouseLocationOutsideOfEventStream
+            let pointInView = convert(pointInWindow, from: nil)
+            let nowInside = bounds.contains(pointInView)
+            guard nowInside != inside else { return }
+            inside = nowInside
+            onChange?(nowInside)
         }
 
         nonisolated override func mouseEntered(with event: NSEvent) {

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -123,20 +123,38 @@ final class HoverPopover {
 
         let screen = NSScreen.screens.first(where: { $0.frame.intersects(referenceFrame) }) ?? NSScreen.main
         let screenFrame = screen?.visibleFrame ?? .zero
+        let origin = Self.anchorOrigin(
+            referenceFrame: referenceFrame,
+            size: panel.frame.size,
+            screenFrame: screenFrame
+        )
 
-        let size = panel.frame.size
-        let rightX = referenceFrame.maxX + 4
-        let leftX = referenceFrame.minX - 4 - size.width
-        let originX = (rightX + size.width <= screenFrame.maxX) ? rightX : leftX
-        let originY = max(screenFrame.minY,
-                          min(referenceFrame.midY - size.height / 2,
-                              screenFrame.maxY - size.height))
-
-        panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+        panel.setFrameOrigin(origin)
         panel.orderFrontRegardless()
         if needsKeyFocus {
             panel.makeKey()
         }
+    }
+
+    /// Compute the popover's bottom-left origin (AppKit screen coordinates).
+    ///
+    /// Horizontally it sits just to the right of `referenceFrame`, flipping to
+    /// the left only when there isn't room on the right. Vertically it aligns
+    /// the popover's **top** edge with the row's top edge (a drop-down submenu
+    /// feel), shifting up only when a tall popover would overflow the bottom of
+    /// the screen — i.e. top-aligned by default, clamped on-screen otherwise.
+    static func anchorOrigin(referenceFrame: NSRect, size: NSSize, screenFrame: NSRect) -> NSPoint {
+        let rightX = referenceFrame.maxX + 4
+        let leftX = referenceFrame.minX - 4 - size.width
+        let originX = (rightX + size.width <= screenFrame.maxX) ? rightX : leftX
+
+        // Top of popover (origin.y + height) == top of the row (referenceFrame.maxY).
+        var originY = referenceFrame.maxY - size.height
+        // Don't let the top run past the top of the screen.
+        originY = min(originY, screenFrame.maxY - size.height)
+        // Don't let the bottom run past the bottom of the screen.
+        originY = max(originY, screenFrame.minY)
+        return NSPoint(x: originX, y: originY)
     }
 
     func scheduleHide(after delay: TimeInterval = 0.3) {

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -22,6 +22,13 @@ final class HoverPopover {
     private let panel: KeyableHoverPanel
     private let containerView: NSView
     private let hostingView: NSHostingView<AnyView>
+    /// Reusable, never-displayed scratch host used only to read `fittingSize`.
+    /// Created once and its `rootView` swapped per measure, so showing a popover
+    /// no longer allocates a throwaway `NSHostingView` (which rebuilt the whole
+    /// SwiftUI graph from scratch) on every hover/crossing. The live
+    /// `hostingView` keeps `sizingOptions = []` so it can never drive a
+    /// window-resize recursion (see `MenuBarController.showPanel`).
+    private let measuringView: NSHostingView<AnyView>
     private var hideTask: Task<Void, Never>?
     // nonisolated(unsafe) so deinit can remove observers without a MainActor hop.
     @ObservationIgnored nonisolated(unsafe) private var keyObserver: NSObjectProtocol?
@@ -36,7 +43,17 @@ final class HoverPopover {
 
     init<Content: View>(@ViewBuilder content: () -> Content) {
         let rootView = AnyView(content())
-        let initialSize = Self.fittingSize(for: rootView, fallback: NSSize(width: 240, height: 200))
+
+        let measuringView = NSHostingView(rootView: rootView)
+        measuringView.sizingOptions = .intrinsicContentSize
+        measuringView.layoutSubtreeIfNeeded()
+        self.measuringView = measuringView
+
+        let measured = measuringView.fittingSize
+        let initialSize = (measured.width > 0 && measured.height > 0)
+            ? measured
+            : NSSize(width: 240, height: 200)
+
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.sizingOptions = []
         hostingView.frame = NSRect(origin: .zero, size: initialSize)
@@ -83,9 +100,20 @@ final class HoverPopover {
 
     func updateContent<Content: View>(@ViewBuilder content: () -> Content) {
         let rootView = AnyView(content())
+        // Measure on the reusable scratch host first, then install + resize in
+        // one pass. The live host lays out once at its final size instead of
+        // once before measuring and again after the resize.
+        let size = measure(rootView)
         hostingView.rootView = rootView
-        hostingView.layoutSubtreeIfNeeded()
-        resizePanel(to: Self.fittingSize(for: rootView, fallback: panel.frame.size))
+        resizePanel(to: size)
+    }
+
+    private func measure(_ rootView: AnyView) -> NSSize {
+        measuringView.rootView = rootView
+        measuringView.layoutSubtreeIfNeeded()
+        let fitting = measuringView.fittingSize
+        if fitting.width > 0 && fitting.height > 0 { return fitting }
+        return panel.frame.size
     }
 
     /// Show the popover anchored to the right side of `referenceFrame` (screen coordinates).
@@ -137,15 +165,6 @@ final class HoverPopover {
         containerView.frame = NSRect(origin: .zero, size: size)
         hostingView.frame = NSRect(origin: .zero, size: size)
     }
-
-    private static func fittingSize(for rootView: AnyView, fallback: NSSize) -> NSSize {
-        let measuringView = NSHostingView(rootView: rootView)
-        measuringView.sizingOptions = .intrinsicContentSize
-        measuringView.layoutSubtreeIfNeeded()
-        let fitting = measuringView.fittingSize
-        if fitting.width > 0 && fitting.height > 0 { return fitting }
-        return fallback
-    }
 }
 
 /// NSPanel subclass whose key-eligibility is controlled by an opt-in flag.
@@ -161,11 +180,21 @@ final class KeyableHoverPanel: NSPanel {
 @MainActor
 @Observable
 final class HoverGate {
+    /// Hover-intent debounce before the first popover appears.
+    private static let showDelayNanos: UInt64 = 400_000_000
+    /// Grace period before the popover auto-hides once nothing is hovered.
+    private static let hideDelayNanos: UInt64 = 300_000_000
+    /// Coalescing window for re-mounts while the popover is already shown.
+    /// Collapses a fast sweep across several hover rows into one mount and
+    /// keeps the work off the AppKit mouse-event tick (~one display frame).
+    private static let refreshDelayNanos: UInt64 = 16_000_000
+
     private(set) var isShown = false
     private var triggerHovered = false
     private var popoverHovered = false
     private var showTask: Task<Void, Never>?
     private var hideTask: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
 
     var onShow: () -> Void = {}
     var onHide: () -> Void = {}
@@ -177,12 +206,21 @@ final class HoverGate {
 
     func popoverHover(_ hovered: Bool) {
         popoverHovered = hovered
-        if hovered { showTask?.cancel(); hideTask?.cancel() }
-        else { scheduleHide() }
+        if hovered {
+            // Cancel AND nil, like every other cancel site: a cancelled-but-
+            // pending showTask would otherwise wedge the `guard showTask == nil`
+            // leading-edge re-arm in scheduleShow until it self-heals on wake.
+            showTask?.cancel(); showTask = nil
+            refreshTask?.cancel(); refreshTask = nil
+            hideTask?.cancel()
+        } else {
+            scheduleHide()
+        }
     }
 
     func showImmediately() {
-        showTask?.cancel()
+        showTask?.cancel(); showTask = nil
+        refreshTask?.cancel(); refreshTask = nil
         hideTask?.cancel()
         if !isShown { isShown = true }
         onShow()
@@ -193,8 +231,10 @@ final class HoverGate {
     func reset() {
         showTask?.cancel()
         hideTask?.cancel()
+        refreshTask?.cancel()
         showTask = nil
         hideTask = nil
+        refreshTask = nil
         triggerHovered = false
         popoverHovered = false
         if isShown {
@@ -206,14 +246,33 @@ final class HoverGate {
     private func scheduleShow() {
         hideTask?.cancel()
         if isShown {
-            onShow()
+            // Already visible: a row-to-row crossing only needs to re-mount the
+            // new content. Coalesce these off the mouse-event tick so a fast
+            // sweep doesn't rebuild the popover once per row crossed.
+            scheduleRefresh()
             return
         }
-        showTask?.cancel()
+        // Leading-edge: keep the first hover's deadline instead of restarting
+        // the 400ms countdown on every crossing. Whichever row the cursor rests
+        // on when the timer fires is shown via the caller's latest target.
+        guard showTask == nil else { return }
         showTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 400_000_000)
-            guard let self, !Task.isCancelled, self.triggerHovered else { return }
+            try? await Task.sleep(nanoseconds: Self.showDelayNanos)
+            guard let self else { return }
+            self.showTask = nil
+            guard !Task.isCancelled, self.triggerHovered else { return }
             self.isShown = true
+            self.onShow()
+        }
+    }
+
+    private func scheduleRefresh() {
+        refreshTask?.cancel()
+        refreshTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.refreshDelayNanos)
+            guard let self else { return }
+            self.refreshTask = nil
+            guard !Task.isCancelled, self.isShown else { return }
             self.onShow()
         }
     }
@@ -222,7 +281,7 @@ final class HoverGate {
         guard isShown else { return }
         hideTask?.cancel()
         hideTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 300_000_000)
+            try? await Task.sleep(nanoseconds: Self.hideDelayNanos)
             guard let self, !Task.isCancelled else { return }
             guard !self.triggerHovered && !self.popoverHovered else { return }
             self.isShown = false

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -28,6 +28,9 @@ struct MenuBarView: View {
     @State private var triggerFrames: [HoverPopoverTarget: NSRect] = [:]
     // The target whose popover should be mounted on the next `gate.onShow`.
     @State private var activeHoverTarget: HoverPopoverTarget? = nil
+    // The target whose content is currently mounted in the popover. Lets a
+    // re-fire for the same row re-anchor instead of rebuilding the SwiftUI tree.
+    @State private var mountedTarget: HoverPopoverTarget? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -277,17 +280,17 @@ struct MenuBarView: View {
         gate.onHide = {
             popover?.scheduleHide()
             popover?.needsKeyFocus = false
+            mountedTarget = nil
         }
     }
 
     /// Drive `HoverGate` from a row's `onHover` while keeping `activeHoverTarget`
     /// in sync. `activeHoverTarget` MUST be updated before calling
     /// `gate.triggerHover(true)`: when the gate is already shown,
-    /// `HoverGate.scheduleShow` re-invokes `onShow` synchronously, which reads
-    /// `activeHoverTarget` to decide what to mount. That re-fire is also what
-    /// re-mounts the correct content when the user crosses from one hover row
-    /// to another (it additionally cancels the pending hide queued by the
-    /// previous row's leave event).
+    /// `HoverGate.scheduleShow` schedules a coalesced `onShow` that reads
+    /// `activeHoverTarget` (the latest crossed row) to decide what to mount.
+    /// `scheduleShow` also cancels the pending hide queued by the previous row's
+    /// leave event synchronously, so the popover stays open across the crossing.
     private func triggerHover(_ hovered: Bool, target: HoverPopoverTarget) {
         if hovered {
             activeHoverTarget = target
@@ -302,14 +305,23 @@ struct MenuBarView: View {
     /// popover's `needsKeyFocus` flag for views that need first-responder.
     ///
     /// Sole owner of `popover.show(anchoredTo:)` for hover-anchored content:
-    /// submenu cases call it synchronously at the end of their branch;
-    /// `.history` defers it inside a `Task` so the popover only appears after
-    /// the store cache has been pruned + reloaded. Invoked both from
-    /// `wireGate`'s `onShow` (first show) and again synchronously from
-    /// `HoverGate.scheduleShow` when the gate is already shown and the user
-    /// crosses to a new hover target.
+    /// submenu cases anchor at the end of their branch via `anchorPopover`;
+    /// `.history` and `.hostsManager` defer inside a `Task` so the popover only
+    /// appears after their store work completes. Invoked from `wireGate`'s
+    /// `onShow` — once after the 400ms first-show delay, and again (coalesced
+    /// one frame later by `HoverGate.scheduleRefresh`) when the gate is already
+    /// shown and the user crosses to a new hover target.
     private func mountPopoverContent(for target: HoverPopoverTarget) {
         let popover = ensurePopover()
+        // Re-fire for the row already mounted (coalesced crossing back onto the
+        // same row): the popover views observe their own stores and update in
+        // place, so just re-anchor instead of rebuilding the SwiftUI tree.
+        if target == mountedTarget {
+            if let frame = convertedTriggerFrame(for: target) {
+                popover.show(anchoredTo: frame)
+            }
+            return
+        }
         switch target {
         case .submenu(.appShortcuts):
             popover.needsKeyFocus = false
@@ -333,7 +345,7 @@ struct MenuBarView: View {
                     }
                 )
             }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            anchorPopover(popover, to: target)
         case .submenu(.portManager):
             popover.needsKeyFocus = true
             popover.updateContent {
@@ -348,13 +360,13 @@ struct MenuBarView: View {
                 )
             }
             Task { await PortInventory.shared.refresh() }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            anchorPopover(popover, to: target)
         case .brightnessControl:
             popover.needsKeyFocus = false
             popover.updateContent {
                 BrightnessPopoverView(onHoverChange: { gate.popoverHover($0) })
             }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            anchorPopover(popover, to: target)
         case .submenu(.windowLayout):
             popover.needsKeyFocus = false
             popover.updateContent {
@@ -369,30 +381,41 @@ struct MenuBarView: View {
                     }
                 )
             }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            anchorPopover(popover, to: target)
         case .submenu(.hostsManager):
             popover.needsKeyFocus = false
-            // Refresh before measuring so the panel sizes to the current profile
-            // list; deferring this left the popover too short and clipped the
-            // bottom rows.
-            HostsManager.shared.refresh()
-            popover.updateContent {
-                HostsManagerPopoverView(
-                    manager: HostsManager.shared,
-                    onHoverChange: { gate.popoverHover($0) },
-                    onEdit: {
-                        gate.reset()
-                        popover.hide()
-                        HostsEditorWindowController.shared.show()
-                        onRequestClose()
-                    },
-                    onClose: {
-                        gate.reset()
-                        popover.hide()
-                    }
-                )
+            // Mount from already-loaded state first so the hover crossing never
+            // blocks on the synchronous SwiftData fetch + /etc/hosts read, then
+            // refresh off the tick and re-measure (profiles loading in would
+            // otherwise clip a popover sized to the stale list).
+            func mountHosts() {
+                popover.updateContent {
+                    HostsManagerPopoverView(
+                        manager: HostsManager.shared,
+                        onHoverChange: { gate.popoverHover($0) },
+                        onEdit: {
+                            gate.reset()
+                            popover.hide()
+                            HostsEditorWindowController.shared.show()
+                            onRequestClose()
+                        },
+                        onClose: {
+                            gate.reset()
+                            popover.hide()
+                        }
+                    )
+                }
             }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            mountHosts()
+            anchorPopover(popover, to: target)
+            Task { @MainActor in
+                HostsManager.shared.refresh()
+                guard activeHoverTarget == .submenu(.hostsManager) else { return }
+                mountHosts()
+                if let frame = convertedTriggerFrame(for: .submenu(.hostsManager)) {
+                    popover.show(anchoredTo: frame)
+                }
+            }
         case .submenu(.bluetoothBattery):
             popover.needsKeyFocus = false
             popover.updateContent {
@@ -402,7 +425,7 @@ struct MenuBarView: View {
                 )
             }
             Task { await BluetoothBatteryService.shared.refresh() }
-            popover.show(anchoredTo: convertedTriggerFrame(for: target))
+            anchorPopover(popover, to: target)
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.
             break
@@ -434,9 +457,18 @@ struct MenuBarView: View {
                         }
                     )
                 }
-                popover.show(anchoredTo: convertedTriggerFrame(for: .history(kind)))
+                anchorPopover(popover, to: .history(kind))
             }
         }
+    }
+
+    /// Anchor `popover` to `target`'s cached row frame and record what is now
+    /// mounted. A missing frame is a no-op: never fall back to anchoring the
+    /// popover against the whole panel, which mispositions it (see #P1).
+    private func anchorPopover(_ popover: HoverPopover, to target: HoverPopoverTarget) {
+        mountedTarget = target
+        guard let frame = convertedTriggerFrame(for: target) else { return }
+        popover.show(anchoredTo: frame)
     }
 
     private func ensurePopover() -> HoverPopover {
@@ -446,15 +478,10 @@ struct MenuBarView: View {
         return created
     }
 
-    /// Returns the hover target's row frame in AppKit screen coordinates.
-    private func convertedTriggerFrame(for target: HoverPopoverTarget) -> NSRect {
-        triggerFrames[target] ?? menuBarPanelWindow()?.frame ?? .zero
-    }
-
-    private func menuBarPanelWindow() -> NSWindow? {
-        NSApp.windows.first { window in
-            window.isVisible && !(window is KeyableHoverPanel)
-        }
+    /// The hover target's row frame in AppKit screen coordinates, or `nil` when
+    /// it hasn't been reported yet (callers must not anchor to a fallback).
+    private func convertedTriggerFrame(for target: HoverPopoverTarget) -> NSRect? {
+        triggerFrames[target]
     }
 
     private func triggerSubmenu(_ item: BuiltinItem) {

--- a/Sources/AnyDoor/Views/MenuBarView.swift
+++ b/Sources/AnyDoor/Views/MenuBarView.swift
@@ -6,10 +6,15 @@ import AppKit
 /// Built-in `.submenu` rows (e.g. App Shortcuts, Port Manager) hover-show
 /// their dedicated popover content. Built-in `.action` rows that produce
 /// clipboard history (OCR / pick color / QR code / screenshot) hover-show
-/// the unified `ClipboardHistoryPopoverView` for the matching kind.
+/// the unified `ClipboardHistoryPopoverView`. The `.history` case carries the
+/// owning `BuiltinItem` (not the `ClipboardHistoryKind`) so the anchor frame is
+/// keyed per row: several builtins map to the same kind (e.g. screenshot /
+/// captureWindow / captureFullscreen / captureTimer all use `.screenshot`), and
+/// keying by kind let the last row to report a frame clobber the others' anchor.
+/// The popover content is still derived from `item.historyKind`.
 private enum HoverPopoverTarget: Hashable {
     case submenu(BuiltinItem)
-    case history(ClipboardHistoryKind)
+    case history(BuiltinItem)
     case brightnessControl(BuiltinItem)
 }
 
@@ -134,8 +139,8 @@ struct MenuBarView: View {
             }
         } else if case let .builtin(item) = entry.source,
                   item.kind == .action,
-                  let historyKind = item.historyKind {
-            let target = HoverPopoverTarget.history(historyKind)
+                  item.historyKind != nil {
+            let target = HoverPopoverTarget.history(item)
             PanelRowView(
                 entry: entry,
                 onToggle: {},
@@ -429,7 +434,10 @@ struct MenuBarView: View {
         case .submenu:
             // Other builtin submenu items (none today) — nothing to mount.
             break
-        case .history(let kind):
+        case .history(let item):
+            // Content is keyed by the kind (several items share `.screenshot`);
+            // the anchor is keyed by the item so each row anchors to itself.
+            guard let kind = item.historyKind else { break }
             let store = ClipboardHistoryStore.shared
             Task { @MainActor in
                 await store.pruneExpiredAndOverflow(force: false)
@@ -438,7 +446,7 @@ struct MenuBarView: View {
                 // Guard against the user moving off the row before reload finished.
                 // Setting `needsKeyFocus` is deferred until after this guard so we
                 // never briefly flip the flag for a popover we will not show.
-                guard activeHoverTarget == .history(kind) else { return }
+                guard activeHoverTarget == .history(item) else { return }
                 popover.needsKeyFocus = true
 
                 popover.updateContent {
@@ -457,7 +465,7 @@ struct MenuBarView: View {
                         }
                     )
                 }
-                anchorPopover(popover, to: .history(kind))
+                anchorPopover(popover, to: .history(item))
             }
         }
     }

--- a/Sources/AnyDoor/Views/PanelRowView.swift
+++ b/Sources/AnyDoor/Views/PanelRowView.swift
@@ -20,6 +20,7 @@ struct PanelRowView: View {
     var trailingAccessory: AnyView? = nil
 
     @State private var activationPulse = 0
+    @State private var isHovered = false
 
     private var needsPermission: Bool { entry.permission == .denied }
 
@@ -48,8 +49,18 @@ struct PanelRowView: View {
             trailing
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
+        // Subtle neutral hover highlight, layered above the material/glass
+        // surface so it reads on both macOS < 26 and Liquid Glass. Uses the
+        // AppKit-backed `onHoverSafe` (not SwiftUI `.onHover`, which can resume
+        // off the main thread and crash on this toolchain — see HoverReader).
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+        }
         .adaptiveInteractiveSurface(cornerRadius: 8)
         .contentShape(Rectangle())
+        .onHoverSafe { isHovered = $0 }
+        .animation(.easeOut(duration: 0.12), value: isHovered)
         .onTapGesture {
             if needsPermission { onPermission(); return }
             triggerFeedback()

--- a/Tests/AnyDoorTests/HoverGateTests.swift
+++ b/Tests/AnyDoorTests/HoverGateTests.swift
@@ -3,18 +3,6 @@ import XCTest
 
 final class HoverGateTests: XCTestCase {
     @MainActor
-    func testTriggerHoverRefreshesContentWhenPopoverIsAlreadyShown() {
-        let gate = HoverGate()
-        var showCount = 0
-        gate.onShow = { showCount += 1 }
-
-        gate.showImmediately()
-        gate.triggerHover(true)
-
-        XCTAssertEqual(showCount, 2)
-    }
-
-    @MainActor
     func testShowImmediatelyRefreshesContentWhenPopoverIsAlreadyShown() {
         let gate = HoverGate()
         var showCount = 0
@@ -23,6 +11,62 @@ final class HoverGateTests: XCTestCase {
         gate.showImmediately()
         gate.showImmediately()
 
+        // showImmediately stays synchronous (click path wants an instant mount).
         XCTAssertEqual(showCount, 2)
+    }
+
+    @MainActor
+    func testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced() async {
+        let gate = HoverGate()
+        var showCount = 0
+        gate.onShow = { showCount += 1 }
+
+        gate.showImmediately()        // synchronous first show
+        XCTAssertEqual(showCount, 1)
+
+        gate.triggerHover(true)       // already shown -> coalesced re-mount, deferred off the tick
+        XCTAssertEqual(showCount, 1, "re-mount while shown must be deferred, not synchronous")
+
+        // The coalesced refresh fires on a later runloop turn.
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(showCount, 2)
+    }
+
+    @MainActor
+    func testRapidCrossingsWhileShownCoalesceIntoOneRemount() async {
+        let gate = HoverGate()
+        var showCount = 0
+        gate.onShow = { showCount += 1 }
+
+        gate.showImmediately()        // count 1
+        // Simulate a fast sweep across several already-shown hover rows in one burst.
+        gate.triggerHover(true)
+        gate.triggerHover(true)
+        gate.triggerHover(true)
+
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        // The three crossings collapse into a single re-mount (count 1 + 1), not three.
+        XCTAssertEqual(showCount, 2)
+    }
+
+    @MainActor
+    func testRapidRetriggerKeepsFirstShowDeadline() async {
+        let gate = HoverGate()
+        var showCount = 0
+        let shown = expectation(description: "popover shown once")
+        gate.onShow = {
+            showCount += 1
+            if showCount == 1 { shown.fulfill() }
+        }
+
+        gate.triggerHover(true)                          // arm the show timer at t0
+        try? await Task.sleep(nanoseconds: 200_000_000)  // t0 + 200ms
+        gate.triggerHover(true)                          // re-trigger must NOT reset the deadline
+
+        // With the leading-edge timer the show fires ~200ms from now (t0 + 400ms).
+        // A bug that restarts the 400ms countdown would fire ~400ms from now
+        // (t0 + 600ms) and miss this window.
+        await fulfillment(of: [shown], timeout: 0.30)
+        XCTAssertEqual(showCount, 1)
     }
 }

--- a/Tests/AnyDoorTests/HoverPopoverTests.swift
+++ b/Tests/AnyDoorTests/HoverPopoverTests.swift
@@ -19,4 +19,41 @@ final class HoverPopoverTests: XCTestCase {
         let hostingView = try XCTUnwrap(contentView.subviews.first as? NSHostingView<AnyView>)
         XCTAssertTrue(hostingView.sizingOptions.isEmpty)
     }
+
+    // MARK: - Anchor geometry
+
+    private let screen = NSRect(x: 0, y: 0, width: 1920, height: 1050)
+
+    @MainActor
+    func testAnchorAlignsPopoverTopWithRowTopWhenItFits() {
+        // Row mid-screen; a 420-tall popover fits below the row top.
+        let row = NSRect(x: 100, y: 600, width: 244, height: 36) // top (maxY) = 636
+        let origin = HoverPopover.anchorOrigin(
+            referenceFrame: row, size: NSSize(width: 320, height: 420), screenFrame: screen
+        )
+        // To the right of the row.
+        XCTAssertEqual(origin.x, row.maxX + 4)
+        // Popover top edge equals the row's top edge.
+        XCTAssertEqual(origin.y + 420, row.maxY, accuracy: 0.5)
+    }
+
+    @MainActor
+    func testAnchorClampsUpWhenPopoverWouldOverflowBottom() {
+        // Row near the bottom of the screen; a tall popover can't fit below it,
+        // so it shifts up and pins to the screen bottom.
+        let row = NSRect(x: 100, y: 100, width: 244, height: 36) // top = 136
+        let origin = HoverPopover.anchorOrigin(
+            referenceFrame: row, size: NSSize(width: 320, height: 420), screenFrame: screen
+        )
+        XCTAssertEqual(origin.y, screen.minY, accuracy: 0.5)
+    }
+
+    @MainActor
+    func testAnchorFlipsToLeftWhenNoRoomOnRight() {
+        // Row hugging the right edge: not enough room on the right, flip left.
+        let row = NSRect(x: 1456, y: 600, width: 244, height: 36) // maxX = 1700
+        let size = NSSize(width: 320, height: 420)
+        let origin = HoverPopover.anchorOrigin(referenceFrame: row, size: size, screenFrame: screen)
+        XCTAssertEqual(origin.x, row.minX - 4 - size.width)
+    }
 }


### PR DESCRIPTION
Menu-bar hover popovers (App Shortcuts, Port Manager, brightness, Hosts, Bluetooth battery, and the clipboard-history side popovers) were janky to switch between, sometimes failed to appear, and could be left on screen as a stray window. This branch reworks the shared hover pipeline so popovers feel like proper drop-down submenus: smoothed and coalesced, top-aligned with the hovered row, with a subtle per-row hover highlight; it also fixes a mispositioned screenshot-history popover and tweaks the Bluetooth battery badge layout.

## What changed

### Hover pipeline smoothness / coalescing (`HoverPopover`, `HoverGate`)
- Removed the per-show throwaway `NSHostingView`. `HoverPopover` now keeps a single reusable, never-displayed `measuringView` whose `rootView` is swapped per measure, so a show/crossing no longer rebuilds the whole SwiftUI graph just to read `fittingSize`. `updateContent` measures on the scratch host, then installs and resizes in one layout pass.
- `HoverGate` gained a coalescing re-mount path: when the popover is already shown, a row-to-row crossing schedules a single `scheduleRefresh` (~16ms / one frame, off the AppKit mouse-event tick) instead of re-mounting synchronously once per row crossed. New `showDelayNanos` / `hideDelayNanos` / `refreshDelayNanos` constants centralize the timings.
- Tightened task lifecycle: `popoverHover`, `showImmediately`, and `reset` now cancel AND nil `showTask` / `refreshTask` so a cancelled-but-pending show can't wedge the leading-edge re-arm.

### Leading-edge intent delay + tracking-area reconcile (`HoverGate`, `HoverReader`)
- `scheduleShow` is now leading-edge: it keeps the first hover's 400ms deadline (`guard showTask == nil`) instead of restarting the countdown on every crossing, so a continuous sweep still surfaces the popover for whichever row the cursor rests on when the timer fires.
- `HoverReader` no longer tears down and re-adds its `NSTrackingArea` on every `updateTrackingAreas` pass (which dropped the mouse-enter edge when rebuilt under a stationary cursor). It rebuilds the area only when missing and adds `reconcileHover`, which compares the live cursor position (`mouseLocationOutsideOfEventStream`) against the tracked `inside` flag and emits the skipped enter/exit edge so hover state can't get stuck.

### Per-row anchor keying for the screenshot-history popover (`MenuBarView`)
- `HoverPopoverTarget.history` now carries the owning `BuiltinItem` instead of the `ClipboardHistoryKind`. The four screenshot-producing builtins (screenshot / captureWindow / captureFullscreen / captureTimer) all map to the same `.screenshot` kind, so keying anchors by kind let the last row to report a frame clobber the others — pinning the 截图到剪贴板 popover near the bottom of the screen. Anchors are now keyed per row (content is still derived from `item.historyKind`).
- Added `mountedTarget` tracking so re-firing for the already-mounted row just re-anchors (the popover views observe their own stores) instead of rebuilding the SwiftUI tree.
- Hosts mount now renders from already-loaded state immediately and refreshes off the tick, re-measuring afterward, so the hover crossing doesn't block on the synchronous SwiftData fetch + `/etc/hosts` read.

### Top-align placement (`HoverPopover.anchorOrigin`)
- Extracted placement into a pure, unit-tested `HoverPopover.anchorOrigin(referenceFrame:size:screenFrame:)`. It sits the popover just right of the row (flipping left when there's no room), and aligns the popover's top edge with the row's top edge (drop-down feel), shifting up only when a tall popover would overflow the bottom — replacing the previous vertical-center placement.

### Orphan / zombie hover-panel cleanup (`MenuBarController`, `MenuBarView`)
- `convertedTriggerFrame` now returns `nil` when a row's frame hasn't been reported yet, and the new `anchorPopover` treats a missing frame as a no-op — it no longer falls back to anchoring against the whole panel frame (which placed the popover against the panel edge). The unused `menuBarPanelWindow()` helper was removed.
- `MenuBarController` dismissal now orders out any visible `KeyableHoverPanel`. A key-focus popover (Port Manager / clipboard history) made the panel's `onDisappear` skip `popover.hide()`, which could leave the hover panel as a zombie window after an outside click tore down `MenuBarView`.

### Bluetooth battery badge ordering (`BluetoothBatteryPopoverView`)
- `BatteryBadge` now renders the percentage first and the fixed-width battery icon last. Because the badge is right-aligned in the row, a trailing icon keeps every icon's right edge aligned and right-aligns the percentages regardless of 2- vs 3-digit levels (85% / 100%).

### Top-level-row hover highlight (`PanelRowView`)
- Added a subtle neutral hover highlight: a rounded fill at 8% of the foreground color, layered above the material / glass row surface (so it reads on both macOS < 26 and Liquid Glass), fading in/out on a short `.easeOut`. Hover is detected via the AppKit-backed `onHoverSafe` (not SwiftUI `.onHover`) to match the rest of the hover path.

## Testing
- `swift build` is clean (only the pre-existing `XCStringsCompiler` plugin deprecation warnings).
- `swift test` passes: 702 tests, 0 failures. New coverage includes `HoverGate` leading-edge / coalescing behavior (`testRapidRetriggerKeepsFirstShowDeadline`, `testRapidCrossingsWhileShownCoalesceIntoOneRemount`, `testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced`) and `HoverPopover.anchorOrigin` geometry (top-align, clamp-up on bottom overflow, flip-left).

## Notes
- CHANGELOG.md [Unreleased] gets `### Changed` (row hover highlight, top-align placement) and `### Fixed` (the hover-pipeline root causes and the screenshot-history anchor) entries describing these user-visible changes.
