### PR TITLE
fix(ui): light-mode polish across the translucent panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ versioning.
     fixed black wash; the Port Manager warning banner tint is strengthened so it
     stays distinct over light-mode material; and the command-palette confirmation
     scrim is softened a touch so it is less heavy over bright glass.
+- The command palette ignored Esc when the search field was empty. Closing the
+  panel dropped the search field's focus, and an unbounded focus-recovery loop
+  immediately reasserted it on the next runloop tick — which made the field first
+  responder again and reordered the just-closed panel back on screen. Esc was the
+  only dismiss path where the app stayed frontmost with no other window to take
+  focus, so it was the one that visibly "wouldn't close". The recovery now skips
+  reasserting focus once the panel is no longer on screen, and is capped after a
+  few rapid strikes (matching the Spotlight app picker).
 
 ## [3.1.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Light-mode polish across the translucent panels. The menu-bar panel, the hover
+  popovers, and the command palette are built on semantic colors and materials
+  with no light/dark branching, but a few spots were tuned for a dark backdrop and
+  looked off on bright light-mode glass:
+  - **Panel edges vanished.** The command palette, its destructive-action confirm
+    card, and the Spotlight app picker drew their hairline border with a hardcoded
+    `Color.white` opacity, which went white-on-white over the bright surface. They
+    now use the semantic `separatorColor` hairline (the token already used by the
+    toast and clipboard rows), so the edge stays visible in both appearances.
+  - **Rows and buttons rendered too bright.** Interactive rows that sit inside a
+    panel which already supplies a material — the menu-bar panel rows (on macOS
+    earlier than 26), every App Shortcuts / Window Layout / Hosts / Port Manager
+    popover row, and the Port Manager's Refresh / view-mode buttons — each stacked
+    a second interactive glass/material on top, so they lit up noticeably lighter
+    than the surface around them in light mode. Idle rows now stay transparent
+    (letting the single panel material show through) and only paint a neutral hover
+    tint, matching the port list; the popover rows also gain a hover highlight they
+    previously lacked. macOS 26 keeps its per-row interactive Liquid Glass on the
+    menu-bar panel.
+  - **A bright scrollbar track.** The Port Manager (list and tree views), the
+    clipboard-history popover (list and text preview), and the Bluetooth-battery and
+    Spotlight app-picker lists honored the system "Show scroll bars: Always"
+    preference, which painted a persistent white scroller track against the
+    translucent surface. They now force overlay (floating, auto-hiding) scrollers,
+    matching the command palette.
+  - **Smaller tweaks.** The off-state toggle knob gains a hairline edge and a
+    slightly stronger off-track so it reads on the bright panel; the
+    scrolling-capture preview well uses an appearance-adaptive recess instead of a
+    fixed black wash; the Port Manager warning banner tint is strengthened so it
+    stays distinct over light-mode material; and the command-palette confirmation
+    scrim is softened a touch so it is less heavy over bright glass.
+
 ## [3.1.0] - 2026-06-19
 
 ### Added

--- a/Sources/AnyDoor/Views/AppShortcutsPopoverView.swift
+++ b/Sources/AnyDoor/Views/AppShortcutsPopoverView.swift
@@ -64,6 +64,7 @@ private struct AppShortcutRow: View {
     let entry: PanelEntry
     let appPath: String?
     var onSelect: () -> Void
+    @State private var isHovered = false
 
     var body: some View {
         HStack(spacing: 8) {
@@ -77,11 +78,20 @@ private struct AppShortcutRow: View {
             }
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
-        .adaptiveInteractiveSurface(cornerRadius: 6)
         .contentShape(Rectangle())
+        // Idle rows stay transparent so the popover's single .regularMaterial
+        // shows through; only hover paints a neutral tint — matching the
+        // PortListView / PortTreeView rows. (Previously each row stacked an
+        // interactive glass surface that rendered brighter than the popover
+        // background in light mode.)
+        .background(
+            isHovered ? Color.primary.opacity(0.06) : .clear,
+            in: .rect(cornerRadius: 6)
+        )
         .onTapGesture(perform: onSelect)
         .help(L(.panelAppShortcutToggleHelp, entry.localizedTitle()))
         .onHoverSafe { hovering in
+            isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
     }

--- a/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
+++ b/Sources/AnyDoor/Views/BluetoothBatteryPopoverView.swift
@@ -72,6 +72,7 @@ struct BluetoothBatteryPopoverView: View {
                     }
                 }
                 .padding(.horizontal, 6).padding(.vertical, 6)
+                .overlayScrollers()
             }
             .frame(maxHeight: 360)
         }

--- a/Sources/AnyDoor/Views/Capture/ScrollCaptureSessionWindow.swift
+++ b/Sources/AnyDoor/Views/Capture/ScrollCaptureSessionWindow.swift
@@ -84,7 +84,7 @@ private struct ScrollCaptureSessionView: View {
                     .id("bottom")
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(.black.opacity(0.15))
+                .background(Color(nsColor: .controlBackgroundColor))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .onChange(of: model.heightPx) { _, _ in
                     withAnimation(.linear(duration: 0.1)) { proxy.scrollTo("bottom", anchor: .bottom) }

--- a/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
+++ b/Sources/AnyDoor/Views/ClipboardHistoryPopoverView.swift
@@ -135,6 +135,7 @@ struct ClipboardHistoryPopoverView: View {
                 }
                 .padding(.horizontal, 6)
                 .padding(.vertical, 4)
+                .overlayScrollers()
             }
         }
     }
@@ -181,6 +182,7 @@ struct ClipboardHistoryPopoverView: View {
                     .font(.system(.body, design: .monospaced))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .textSelection(.enabled)
+                    .overlayScrollers()
             }
         case .color:
             VStack(spacing: 12) {

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -518,8 +518,15 @@ struct CommandPalettePicker: View {
     let onCancel: () -> Void
     let onConfirm: () -> Void
     let onRefreshRates: () -> Void
+    /// Reports whether the hosting panel is still on screen. Used to keep the
+    /// focus-recovery loop below from resurrecting a palette that was just
+    /// dismissed (see the `onChange(of: searchFocused)` note).
+    let isPresented: () -> Bool
 
     @FocusState private var searchFocused: Bool
+    // Counts consecutive failed attempts to reclaim focus. Reset whenever focus
+    // is actually regained; used to break the re-focus loop (see below).
+    @State private var refocusStrikes = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -567,8 +574,29 @@ struct CommandPalettePicker: View {
             DispatchQueue.main.async { searchFocused = true }
         }
         .onChange(of: searchFocused) { _, focused in
-            if !focused {
-                DispatchQueue.main.async { searchFocused = true }
+            // Keep the search field as the keyboard target — re-focus if a stray
+            // hit-test in the panel chrome steals it. Two guards on the recovery:
+            //
+            //  1. Bail after a few rapid strikes. Reasserting focus every runloop
+            //     tick pins a CPU core when the system refuses first-responder
+            //     (focus desync while the panel sits on another Space, etc.).
+            //     Regaining focus resets the counter (mirrors SpotlightAppPicker).
+            //  2. Only re-focus while the panel is still on screen. Esc/cancel
+            //     closes the window, which drops first-responder and fires this
+            //     handler; without this guard the deferred `searchFocused = true`
+            //     would make the field first responder again and reorder the just
+            //     -closed panel back in. Esc is the only dismiss path where the
+            //     app stays frontmost with no other window to take focus, so it
+            //     was the one that visibly "wouldn't close".
+            if focused {
+                refocusStrikes = 0
+                return
+            }
+            guard refocusStrikes < 3 else { return }
+            refocusStrikes += 1
+            DispatchQueue.main.async {
+                guard isPresented() else { return }
+                searchFocused = true
             }
         }
         .onChange(of: state.query) { _, _ in

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -555,7 +555,7 @@ struct CommandPalettePicker: View {
         .adaptivePanelSurface(cornerRadius: 16)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay {
@@ -585,7 +585,7 @@ struct CommandPalettePicker: View {
     /// Return → confirm and Esc → cancel while this is shown.
     private func confirmCard(_ confirmation: CommandPaletteConfirmation) -> some View {
         ZStack {
-            Color.black.opacity(0.35)
+            Color.black.opacity(0.25)
                 .ignoresSafeArea()
                 .onTapGesture { state.cancelConfirmation() }
 
@@ -621,7 +621,7 @@ struct CommandPalettePicker: View {
             .adaptivePanelSurface(cornerRadius: 14)
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5)
+                    .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
             )
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             .shadow(radius: 24, y: 8)

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -73,6 +73,9 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
             },
             onRefreshRates: { [weak self] in
                 self?.refreshRates()
+            },
+            isPresented: { [weak self] in
+                self?.window?.isVisible == true
             }
         )
 

--- a/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/Hosts/HostsManagerPopoverView.swift
@@ -25,9 +25,9 @@ struct HostsManagerPopoverView: View {
 
             AdaptiveGlassEffectContainer(spacing: 2) {
                 VStack(spacing: 2) {
-                    systemHostsRow
+                    HostsSystemRow()
                     ForEach(manager.profiles) { profile in
-                        profileRow(profile)
+                        HostsProfileRow(profile: profile, manager: manager)
                     }
                 }
             }
@@ -58,9 +58,18 @@ struct HostsManagerPopoverView: View {
         .padding(.horizontal, 12).padding(.vertical, 10)
     }
 
-    // MARK: - Rows
+}
 
-    private var systemHostsRow: some View {
+// MARK: - Rows
+
+/// Idle rows stay transparent so the popover's single `.regularMaterial` shows
+/// through; only hover paints a neutral tint — matching the PortListView /
+/// PortTreeView rows. (Previously each row stacked an interactive glass surface
+/// that rendered noticeably brighter than the popover background in light mode.)
+private struct HostsSystemRow: View {
+    @State private var isHovered = false
+
+    var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "cpu").foregroundStyle(.secondary)
             Text("系统 Hosts")
@@ -72,10 +81,21 @@ struct HostsManagerPopoverView: View {
             .help("用默认编辑器打开")
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
-        .adaptiveInteractiveSurface(cornerRadius: 6)
+        .contentShape(Rectangle())
+        .background(
+            isHovered ? Color.primary.opacity(0.06) : .clear,
+            in: .rect(cornerRadius: 6)
+        )
+        .onHoverSafe { isHovered = $0 }
     }
+}
 
-    private func profileRow(_ profile: HostProfile) -> some View {
+private struct HostsProfileRow: View {
+    let profile: HostProfile
+    let manager: HostsManager
+    @State private var isHovered = false
+
+    var body: some View {
         HStack(spacing: 8) {
             Image(systemName: profile.isActive ? "checkmark.circle.fill" : "circle")
                 .foregroundStyle(profile.isActive ? .green : .secondary)
@@ -84,9 +104,13 @@ struct HostsManagerPopoverView: View {
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
         .contentShape(Rectangle())
-        .adaptiveInteractiveSurface(cornerRadius: 6)
+        .background(
+            isHovered ? Color.primary.opacity(0.06) : .clear,
+            in: .rect(cornerRadius: 6)
+        )
         .onTapGesture {
             Task { await manager.setActive(profile, !profile.isActive) }
         }
+        .onHoverSafe { isHovered = $0 }
     }
 }

--- a/Sources/AnyDoor/Views/LiquidGlassCompatibility.swift
+++ b/Sources/AnyDoor/Views/LiquidGlassCompatibility.swift
@@ -22,6 +22,13 @@ struct AdaptiveGlassEffectContainer<Content: View>: View {
 }
 
 extension View {
+    /// Standalone interactive surface that paints its OWN material / glass. Use
+    /// it only for an interactive element sitting directly on the desktop or on a
+    /// non-material backdrop. Do NOT use it for rows inside a panel that already
+    /// has a material background (the menu-bar panel, the hover popovers) —
+    /// stacking a second material per row brightens and flattens the rows in
+    /// light mode. For those, keep idle rows transparent and paint a hover tint
+    /// (`Color.primary.opacity(0.06)`), or use `adaptiveMenuBarRowSurface`.
     @ViewBuilder
     func adaptiveInteractiveSurface(cornerRadius: CGFloat) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
@@ -30,6 +37,25 @@ extension View {
             self.glassEffect(.regular.interactive(), in: shape)
         } else {
             self.background(.regularMaterial, in: shape)
+        }
+    }
+
+    /// Interactive surface for rows that already live inside a single material
+    /// panel (the menu-bar panel — see `MenuBarController`, whose container is
+    /// already wrapped in `.regularMaterial`). On macOS 26+ each row gets its
+    /// own interactive Liquid Glass capsule, which composites cleanly over the
+    /// panel glass. On earlier systems the row stays transparent instead of
+    /// stacking a second `.regularMaterial` on top of the panel's material —
+    /// two stacked materials brighten and desaturate in light mode, flattening
+    /// the rows into one bright sheet — so idle rows let the panel material show
+    /// through and rely on the caller's hover tint for separation.
+    @ViewBuilder
+    func adaptiveMenuBarRowSurface(cornerRadius: CGFloat) -> some View {
+        if #available(macOS 26.0, *) {
+            let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            self.glassEffect(.regular.interactive(), in: shape)
+        } else {
+            self
         }
     }
 

--- a/Sources/AnyDoor/Views/PanelRowView.swift
+++ b/Sources/AnyDoor/Views/PanelRowView.swift
@@ -57,7 +57,7 @@ struct PanelRowView: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
         }
-        .adaptiveInteractiveSurface(cornerRadius: 8)
+        .adaptiveMenuBarRowSurface(cornerRadius: 8)
         .contentShape(Rectangle())
         .onHoverSafe { isHovered = $0 }
         .animation(.easeOut(duration: 0.12), value: isHovered)
@@ -168,6 +168,11 @@ private struct PanelSwitchIndicator: View {
                 .fill(trackColor)
             Circle()
                 .fill(.white)
+                // Hairline edge so the white knob stays distinct from a light
+                // off-track in light mode (matches the native NSSwitch knob,
+                // which also keeps a subtle edge rather than relying on shadow
+                // alone). Near-invisible against a dark track in dark mode.
+                .overlay(Circle().strokeBorder(Color.black.opacity(0.08), lineWidth: 0.5))
                 .shadow(color: .black.opacity(0.18), radius: 1, y: 1)
                 .padding(2)
         }
@@ -178,6 +183,8 @@ private struct PanelSwitchIndicator: View {
 
     private var trackColor: Color {
         if isOn { return .accentColor }
-        return .secondary.opacity(0.28)
+        // Slightly stronger than before so the off-track reads against the
+        // white knob on the bright light-mode menu-bar panel.
+        return .secondary.opacity(0.4)
     }
 }

--- a/Sources/AnyDoor/Views/PortListView.swift
+++ b/Sources/AnyDoor/Views/PortListView.swift
@@ -10,6 +10,7 @@ struct PortListView: View {
                     PortRowView(record: record, inventory: inventory)
                 }
             }
+            .overlayScrollers()
         }
     }
 }

--- a/Sources/AnyDoor/Views/PortManagerPopoverView.swift
+++ b/Sources/AnyDoor/Views/PortManagerPopoverView.swift
@@ -101,13 +101,13 @@ private struct PortManagerToolbar: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            toolbarButton(
+            PortToolbarButton(
                 action: { Task { await inventory.refresh(force: true) } },
                 label: L(.portToolbarRefresh),
                 systemImage: "arrow.clockwise",
                 shortcut: "⌘R"
             )
-            toolbarButton(
+            PortToolbarButton(
                 action: {
                     inventory.viewMode = (inventory.viewMode == .list) ? .tree : .list
                 },
@@ -118,13 +118,16 @@ private struct PortManagerToolbar: View {
         }
         .padding(.horizontal, 6).padding(.vertical, 4)
     }
+}
 
-    private func toolbarButton(
-        action: @escaping () -> Void,
-        label: String,
-        systemImage: String,
-        shortcut: String
-    ) -> some View {
+private struct PortToolbarButton: View {
+    let action: () -> Void
+    let label: String
+    let systemImage: String
+    let shortcut: String
+    @State private var isHovered = false
+
+    var body: some View {
         Button(action: action) {
             HStack {
                 Label(label, systemImage: systemImage)
@@ -133,12 +136,20 @@ private struct PortManagerToolbar: View {
             }
             .padding(.horizontal, 8).padding(.vertical, 6)
             // Make the entire row strip clickable (label + spacer + shortcut),
-            // not just the text/icon. Matches the pattern used in PortListView /
-            // PortTreeView / AppShortcutsPopoverView for consistent affordance.
+            // not just the text/icon. Idle rows stay transparent so the
+            // popover's single .regularMaterial shows through and only hover
+            // paints a neutral tint — matching the PortListView / PortTreeView
+            // rows. (Previously each button carried an always-on interactive
+            // glass surface, which rendered noticeably brighter than the list
+            // above it in light mode.)
             .contentShape(Rectangle())
-            .adaptiveInteractiveSurface(cornerRadius: 8)
+            .background(
+                isHovered ? Color.primary.opacity(0.06) : .clear,
+                in: .rect(cornerRadius: 8)
+            )
         }
         .buttonStyle(.plain)
+        .onHoverSafe { isHovered = $0 }
     }
 }
 
@@ -165,7 +176,7 @@ private struct PortScanErrorBanner: View {
         // `.regularMaterial` parent background. Intentionally no clipShape:
         // the popover already rounds the outer envelope, and rounding this
         // strip would create misaligned corners against the header divider.
-        .background(Color.yellow.opacity(0.15))
+        .background(Color.yellow.opacity(0.22))
     }
 
     private var message: String {

--- a/Sources/AnyDoor/Views/PortTreeView.swift
+++ b/Sources/AnyDoor/Views/PortTreeView.swift
@@ -10,6 +10,7 @@ struct PortTreeView: View {
                     PortProcessGroupRow(group: group, inventory: inventory)
                 }
             }
+            .overlayScrollers()
         }
     }
 }

--- a/Sources/AnyDoor/Views/SpotlightAppPicker.swift
+++ b/Sources/AnyDoor/Views/SpotlightAppPicker.swift
@@ -176,6 +176,7 @@ struct SpotlightAppPicker: View {
                     }
                 }
                 .padding(.vertical, 12)
+                .overlayScrollers()
             }
             .frame(minHeight: 320, maxHeight: .infinity)
             .onChange(of: state.selectedIndex) { _, newIndex in

--- a/Sources/AnyDoor/Views/SpotlightAppPicker.swift
+++ b/Sources/AnyDoor/Views/SpotlightAppPicker.swift
@@ -90,7 +90,7 @@ struct SpotlightAppPicker: View {
         .background(.thickMaterial)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .onAppear {

--- a/Sources/AnyDoor/Views/WindowLayoutPopoverView.swift
+++ b/Sources/AnyDoor/Views/WindowLayoutPopoverView.swift
@@ -47,6 +47,7 @@ struct WindowLayoutPopoverView: View {
 private struct WindowLayoutRow: View {
     let entry: PanelEntry
     var onSelect: () -> Void
+    @State private var isHovered = false
 
     var body: some View {
         HStack(spacing: 8) {
@@ -62,10 +63,19 @@ private struct WindowLayoutRow: View {
             }
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
-        .adaptiveInteractiveSurface(cornerRadius: 6)
         .contentShape(Rectangle())
+        // Idle rows stay transparent so the popover's single .regularMaterial
+        // shows through; only hover paints a neutral tint — matching the
+        // PortListView / PortTreeView rows. (Previously each row stacked an
+        // interactive glass surface that rendered brighter than the popover
+        // background in light mode.)
+        .background(
+            isHovered ? Color.primary.opacity(0.06) : .clear,
+            in: .rect(cornerRadius: 6)
+        )
         .onTapGesture(perform: onSelect)
         .onHoverSafe { hovering in
+            isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
     }


### PR DESCRIPTION
## Summary

Polish the light theme across AnyDoor's translucent surfaces. The app relies on semantic colors and materials with no light/dark branching, but a handful of spots were tuned for a dark backdrop and looked off on bright light-mode glass. No broad rework — targeted fixes plus a couple of small tweaks. `swift build` passes.

## Changes (one commit per concern)

- **Panel edges stay visible** — the command palette, its destructive-action confirm card, and the Spotlight app picker drew their hairline with a hardcoded `Color.white` opacity, which went white-on-white over bright light-mode glass. Switched to the semantic `separatorColor` hairline (already used by the toast and clipboard rows); also softened the confirm scrim.
- **Rows and buttons no longer over-brighten** — interactive rows that sit inside a panel which already supplies a material each stacked a second interactive glass/material on top, lighting up brighter than the surface in light mode: the menu-bar panel rows (macOS earlier than 26), every App Shortcuts / Window Layout / Hosts / Port Manager popover row, and the Port Manager Refresh / view-mode buttons. Idle rows now stay transparent (single panel material shows through) and only paint a neutral hover tint; the popover rows also gain a hover highlight they previously lacked. macOS 26 keeps its per-row interactive Liquid Glass.
- **Overlay scrollers on popover lists** — the Port Manager (list and tree), clipboard-history popover (list and text preview), and the Bluetooth-battery and Spotlight lists honored the system "Show scroll bars: Always" preference, painting a persistent white legacy track over the translucent surface. They now force overlay (floating, auto-hiding) scrollers, matching the command palette.
- **Smaller tweaks** — an appearance-adaptive recess for the scrolling-capture preview well (was a fixed black wash); a hairline edge plus a stronger off-track on the toggle knob; a stronger Port Manager warning-banner tint.

## Testing

- `swift build` ✓
- Manual (light mode): panel edges visible; popover rows flat when idle and tint on hover; no white scrollbar track.