### PR TITLE
feat(clipboard): wall source-filter icons, keyboard shortcuts, and perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Clipboard wall: ⌘K opens the source-app filter from the keyboard (in both the
+  search-input and card-navigation modes), so the dropdown no longer has to be
+  clicked. A "⌘K 筛选来源" hint is added to the wall footer.
+- Clipboard wall: ⌘← / ⌘→ jump the card selection to the first / last entry
+  (card-navigation mode only — in the search field they still move the text
+  caret). The jump scrolls to the target instantly instead of animating, so a
+  long history doesn't run a multi-frame scroll animation sweeping across the
+  cards. A "⌘←→ 首/尾" hint is added to the footer.
+
+### Changed
+
+- Clipboard wall: the source-app filter now shows real application icons. The
+  dropdown was switched from a SwiftUI `Menu` (which doesn't reliably render
+  custom `Image(nsImage:)` items on macOS) to a native `NSMenu` popped from a
+  view anchor: each source row shows that app's icon via `NSMenuItem.image`, the
+  active source keeps the native checkmark, the menu opens upward from the
+  trigger at the bottom of the wall, and it auto-scrolls when there are more
+  sources than fit. The trigger button itself now shows the selected source's
+  icon instead of a generic glyph.
+- Clipboard wall: the Launchpad-style tab edit / reorder mode is now armed by
+  holding ⌥ instead of ⌘ (the footer hint shows ⌥).
+- Clipboard wall performance with large histories. The source-app grouping is
+  now computed once per render instead of 4–5 times (it feeds the menu, the
+  trigger title, the disable check, and two `onChange` dependencies); the
+  list-sync `onChange` trigger hashes the displayed items instead of allocating a
+  fresh `[UUID]` on every body evaluation; and match snippets are memoized per
+  item for the active query, so a wall re-render or a card re-realized while
+  scrolling no longer re-folds the item's text on the main thread.
+
+### Fixed
+
+- Clipboard wall: scrolling over the open source-filter menu moved the cards
+  underneath it instead of scrolling the menu. Card-navigation scroll now only
+  acts on scroll events targeting the wall window itself, letting scrolls over
+  the menu (and the floating text panel) reach their own window.
+
 ## [3.1.1] - 2026-06-20
 
 ### Fixed

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -3588,6 +3588,23 @@
         }
       }
     },
+    "clipboard.hint.filterSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter source"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筛选来源"
+          }
+        }
+      }
+    },
     "clipboard.hint.pastePlain": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -3605,6 +3605,23 @@
         }
       }
     },
+    "clipboard.hint.jumpEnds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First/last"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首/尾"
+          }
+        }
+      }
+    },
     "clipboard.hint.pastePlain": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -105,6 +105,7 @@ enum L10n {
         case clipboardHintCopy = "clipboard.hint.copy"
         case clipboardHintEditCategories = "clipboard.hint.editCategories"
         case clipboardHintFilterSource = "clipboard.hint.filterSource"
+        case clipboardHintJumpEnds = "clipboard.hint.jumpEnds"
         case clipboardHintDelete = "clipboard.hint.delete"
         case clipboardHintPastePlain = "clipboard.hint.pastePlain"
         case clipboardHintPreview = "clipboard.hint.preview"

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -104,6 +104,7 @@ enum L10n {
         case clipboardHintClose = "clipboard.hint.close"
         case clipboardHintCopy = "clipboard.hint.copy"
         case clipboardHintEditCategories = "clipboard.hint.editCategories"
+        case clipboardHintFilterSource = "clipboard.hint.filterSource"
         case clipboardHintDelete = "clipboard.hint.delete"
         case clipboardHintPastePlain = "clipboard.hint.pastePlain"
         case clipboardHintPreview = "clipboard.hint.preview"

--- a/Sources/AnyDoor/Views/ClipboardWallState.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallState.swift
@@ -135,6 +135,11 @@ final class ClipboardWallState {
         sourceFilterBundleID = nil
     }
 
+    /// Bumped to ask the wall to open the source-filter menu from the keyboard
+    /// shortcut (⌘K). `ClipboardWallView` watches this and pops the native menu.
+    private(set) var sourceMenuOpenToken = 0
+    func requestOpenSourceMenu() { sourceMenuOpenToken += 1 }
+
     /// Cycle the active category tab (Tab / Shift-Tab), wrapping at both ends.
     func selectNextCategory() { stepCategory(by: 1) }
     func selectPreviousCategory() { stepCategory(by: -1) }

--- a/Sources/AnyDoor/Views/ClipboardWallState.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallState.swift
@@ -127,9 +127,21 @@ final class ClipboardWallState {
         return items[selectedIndex]
     }
 
-    func moveLeft() { selectedIndex = max(0, selectedIndex - 1) }
-    func moveRight() { selectedIndex = min(max(0, items.count - 1), selectedIndex + 1) }
-    func select(_ index: Int) { if items.indices.contains(index) { selectedIndex = index } }
+    /// When true the next selection change scrolls instantly instead of
+    /// animating — set by the jump-to-ends commands (⌘← / ⌘→) so a long jump
+    /// gives instant feedback rather than a multi-frame scroll animation across
+    /// the whole list. The single-step moves reset it.
+    private(set) var prefersInstantScroll = false
+
+    func moveLeft() { prefersInstantScroll = false; selectedIndex = max(0, selectedIndex - 1) }
+    func moveRight() { prefersInstantScroll = false; selectedIndex = min(max(0, items.count - 1), selectedIndex + 1) }
+    func select(_ index: Int) {
+        if items.indices.contains(index) { prefersInstantScroll = false; selectedIndex = index }
+    }
+
+    /// Jump the selection to the first / last card (⌘← / ⌘→); scrolls instantly.
+    func moveToStart() { prefersInstantScroll = true; selectedIndex = 0 }
+    func moveToEnd() { prefersInstantScroll = true; selectedIndex = max(0, items.count - 1) }
 
     func clearSourceFilter() {
         sourceFilterBundleID = nil

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -119,6 +119,11 @@ struct ClipboardWallView: View {
                 state.clearSourceFilter()
             }
         }
+        // The ⌘K shortcut (handled by the window controller) bumps this token;
+        // open the native source menu in response, when there is anything to filter.
+        .onChange(of: state.sourceMenuOpenToken) { _, _ in
+            if !sourceOptions.isEmpty { sourceMenuRequested = true }
+        }
         .overlay { if state.tagDialog != nil { tagDialogOverlay } }
     }
 
@@ -632,6 +637,7 @@ struct ClipboardWallView: View {
         HStack(spacing: 16) {
             hint("←→", .clipboardHintSelect)
             hint("⇥", .clipboardHintCategory)
+            hint("⌘K", .clipboardHintFilterSource)
             hint("⌘", .clipboardHintEditCategories)
             hint("↵", .clipboardHintCopy)
             hint("⌥↵", .clipboardHintPastePlain)

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -50,6 +50,10 @@ struct ClipboardWallView: View {
     @State private var dragTranslation: CGFloat = 0
     @State private var dropIndex: Int?
 
+    /// Flips true when the source-filter button is clicked, asking the AppKit
+    /// anchor (see `SourceFilterMenuAnchor`) to pop the native menu.
+    @State private var sourceMenuRequested = false
+
     /// The query result narrowed by the active category tab and search text.
     private var filtered: [ClipboardHistoryItem] {
         ClipboardSearch.filter(allItems,
@@ -159,29 +163,188 @@ struct ClipboardWallView: View {
     }
 
     private var sourceFilterMenu: some View {
-        Menu {
-            Button {
-                state.clearSourceFilter()
-            } label: {
-                Label(L(.clipboardSourceAll), systemImage: state.sourceFilterBundleID == nil ? "checkmark" : "app")
-            }
-            if !sourceOptions.isEmpty { Divider() }
-            ForEach(sourceOptions) { option in
-                Button {
-                    state.sourceFilterBundleID = option.bundleID
-                } label: {
-                    Label("\(option.name) (\(option.count))",
-                          systemImage: state.sourceFilterBundleID == option.bundleID ? "checkmark" : "app")
-                }
-            }
+        // A plain Button trigger styled like the old borderless menu label; the
+        // dropdown itself is a native NSMenu popped by the background anchor.
+        // Rationale: SwiftUI's `Menu` doesn't reliably render custom
+        // `Image(nsImage:)` items on macOS, and `.popover` misbehaves inside
+        // this borderless, non-activating floating panel. NSMenu renders the
+        // real app icon (`NSMenuItem.image`), the native selection checkmark
+        // (`NSMenuItem.state`), and auto-scrolls when taller than the screen.
+        Button {
+            sourceMenuRequested = true
         } label: {
-            Label(sourceFilterTitle, systemImage: "app.connected.to.app.below.fill")
-                .lineLimit(1)
+            HStack(spacing: 3) {
+                Label {
+                    Text(sourceFilterTitle).lineLimit(1)
+                } icon: {
+                    SourceFilterLeadingIcon(bundleID: state.sourceFilterBundleID)
+                }
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
         }
-        .menuStyle(.borderlessButton)
+        .buttonStyle(.borderless)
+        .tint(.primary)
         .frame(maxWidth: 150)
         .disabled(sourceOptions.isEmpty)
         .help(L(.clipboardSourceFilterHelp))
+        .background(
+            SourceFilterMenuAnchor(
+                requested: $sourceMenuRequested,
+                allTitle: L(.clipboardSourceAll),
+                options: sourceOptions,
+                selectedBundleID: state.sourceFilterBundleID,
+                onSelect: { bundleID in
+                    if let bundleID {
+                        state.sourceFilterBundleID = bundleID
+                    } else {
+                        state.clearSourceFilter()
+                    }
+                }
+            )
+        )
+    }
+
+    /// Leading icon for the source-filter trigger: the selected source's real
+    /// app icon, or the generic "all sources" symbol when no source is filtered
+    /// (or while the icon resolves / when the bundle ID maps to no installed
+    /// app). Reads the warm `AppIconCache` synchronously first to avoid a flash.
+    private struct SourceFilterLeadingIcon: View {
+        let bundleID: String?
+        @State private var icon: NSImage?
+
+        var body: some View {
+            Group {
+                if let bundleID, let image = icon ?? AppIconCache.cachedForBundle(bundleID) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.high)
+                        .frame(width: 15, height: 15)
+                } else {
+                    Image(systemName: "app.connected.to.app.below.fill")
+                }
+            }
+            .task(id: bundleID) {
+                guard let bundleID else { icon = nil; return }
+                if let warm = AppIconCache.cachedForBundle(bundleID) {
+                    icon = warm
+                } else {
+                    icon = await AppIconCache.icon(forBundleID: bundleID)
+                }
+            }
+        }
+    }
+
+    /// Bridges a native `NSMenu` for the source filter into SwiftUI. The
+    /// background `NSView` is only an anchor: when `requested` flips true it
+    /// builds the menu (app icon per source via `NSMenuItem.image`, the active
+    /// source marked with the native `.state` checkmark) and pops it just below
+    /// the trigger button. NSMenu runs its own tracking loop, so it works
+    /// reliably inside the wall's borderless, non-activating floating panel and
+    /// auto-scrolls when there are more sources than fit on screen.
+    private struct SourceFilterMenuAnchor: NSViewRepresentable {
+        @Binding var requested: Bool
+        let allTitle: String
+        let options: [SourceOption]
+        let selectedBundleID: String?
+        let onSelect: (String?) -> Void
+
+        func makeCoordinator() -> Coordinator { Coordinator() }
+
+        func makeNSView(context: Context) -> NSView {
+            let view = FlippedAnchorView()
+            context.coordinator.anchor = view
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            let coordinator = context.coordinator
+            coordinator.allTitle = allTitle
+            coordinator.options = options
+            coordinator.selectedBundleID = selectedBundleID
+            coordinator.onSelect = onSelect
+            guard requested else { return }
+            // Defer past the current view update before mutating state or
+            // entering the menu's modal tracking loop.
+            Task { @MainActor in
+                requested = false
+                coordinator.popUp()
+            }
+        }
+
+        @MainActor
+        final class Coordinator: NSObject {
+            weak var anchor: NSView?
+            var allTitle = ""
+            var options: [SourceOption] = []
+            var selectedBundleID: String?
+            var onSelect: (String?) -> Void = { _ in }
+
+            func popUp() {
+                guard let anchor else { return }
+                let menu = NSMenu()
+                menu.autoenablesItems = false
+
+                let all = NSMenuItem(title: allTitle, action: #selector(pickAll), keyEquivalent: "")
+                all.target = self
+                all.state = selectedBundleID == nil ? .on : .off
+                menu.addItem(all)
+
+                if !options.isEmpty { menu.addItem(.separator()) }
+                for option in options {
+                    let item = NSMenuItem(title: "\(option.name) (\(option.count))",
+                                          action: #selector(pick(_:)),
+                                          keyEquivalent: "")
+                    item.target = self
+                    item.representedObject = option.bundleID
+                    item.state = selectedBundleID == option.bundleID ? .on : .off
+                    item.image = Self.icon(forBundleID: option.bundleID)
+                    menu.addItem(item)
+                }
+
+                // The trigger sits at the bottom of the wall, so open the menu
+                // upward — its bottom edge just above the button — matching the
+                // old SwiftUI menu. `menu.size` is resolved once items are added;
+                // in the flipped anchor's coordinates a negative y is above the
+                // button's top edge.
+                let menuHeight = menu.size.height
+                menu.popUp(positioning: nil,
+                           at: NSPoint(x: 0, y: -menuHeight - 4),
+                           in: anchor)
+            }
+
+            /// A 16×16 app icon for the menu row. Prefers an icon already warmed
+            /// by the cards (`AppIconCache`); on a miss it resolves synchronously
+            /// — acceptable here since it only runs on click, not in a scrolling
+            /// list. Falls back to a generic `app` symbol when the bundle ID maps
+            /// to no installed app. Copies before resizing so the shared cached
+            /// image (used at full size by the cards) is never mutated.
+            private static func icon(forBundleID bundleID: String) -> NSImage {
+                let resolved: NSImage
+                if let warm = AppIconCache.cachedForBundle(bundleID) {
+                    resolved = warm
+                } else if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+                    resolved = NSWorkspace.shared.icon(forFile: url.path)
+                } else {
+                    resolved = NSImage(systemSymbolName: "app", accessibilityDescription: nil) ?? NSImage()
+                }
+                let sized = (resolved.copy() as? NSImage) ?? resolved
+                sized.size = NSSize(width: 16, height: 16)
+                return sized
+            }
+
+            @objc private func pickAll() { onSelect(nil) }
+            @objc private func pick(_ sender: NSMenuItem) {
+                onSelect(sender.representedObject as? String)
+            }
+        }
+    }
+
+    /// Flipped so the menu's drop point (`bounds.height`) is the button's bottom
+    /// edge, giving a clean downward drop regardless of the host view geometry.
+    private final class FlippedAnchorView: NSView {
+        override var isFlipped: Bool { true }
     }
 
     private var sourceFilterTitle: String {

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -628,7 +628,16 @@ struct ClipboardWallView: View {
             }
             .onChange(of: state.selectedIndex) { _, new in
                 guard items.indices.contains(new) else { return }
-                withAnimation { proxy.scrollTo(items[new].id, anchor: .center) }
+                // Jump-to-ends scrolls instantly: animating across the whole
+                // list would run a multi-frame scroll animation (CADisplayLink +
+                // GPU compositing, and a layout pass as the offset sweeps past
+                // cards). A direct jump gives instant feedback and skips that;
+                // single steps still animate for visual continuity.
+                if state.prefersInstantScroll {
+                    proxy.scrollTo(items[new].id, anchor: .center)
+                } else {
+                    withAnimation { proxy.scrollTo(items[new].id, anchor: .center) }
+                }
             }
         }
     }
@@ -636,6 +645,7 @@ struct ClipboardWallView: View {
     private var hints: some View {
         HStack(spacing: 16) {
             hint("←→", .clipboardHintSelect)
+            hint("⌘←→", .clipboardHintJumpEnds)
             hint("⇥", .clipboardHintCategory)
             hint("⌘K", .clipboardHintFilterSource)
             hint("⌥", .clipboardHintEditCategories)

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -37,7 +37,7 @@ struct ClipboardWallView: View {
     @State private var lastTap: TapRecord?
     @FocusState private var tagFieldFocused: Bool
 
-    /// ⌘-drag tab reordering. `tabFrames` tracks each capsule's frame in the
+    /// ⌥-drag tab reordering. `tabFrames` tracks each capsule's frame in the
     /// row's named coordinate space; `dragStartFrames` snapshots them when a
     /// drag begins, and all drag math uses the snapshot — live frames would
     /// include the offsets the drag itself applies (a feedback loop). The
@@ -141,7 +141,7 @@ struct ClipboardWallView: View {
                     }
                     .coordinateSpace(name: Self.tabRowSpace)
                 }
-                // The lifted (scaled, shadowed) dragged capsule and the ⌘-mode
+                // The lifted (scaled, shadowed) dragged capsule and the ⌥-mode
                 // delete badges poke past the row's tight bounds; don't clip them.
                 .scrollClipDisabled()
                 .onChange(of: state.category) { _, new in
@@ -381,7 +381,7 @@ struct ClipboardWallView: View {
                     in: Capsule())
         .foregroundStyle(active ? Color.white : Color.primary)
         // Edit-mode cue alongside the jiggle: a dashed outline on every
-        // capsule while ⌘ is held, like a "cut here" marquee.
+        // capsule while ⌥ is held, like a "cut here" marquee.
         .overlay {
             if reorderArmed {
                 Capsule().strokeBorder(
@@ -404,14 +404,14 @@ struct ClipboardWallView: View {
             Color.clear.preference(key: TabFramePreferenceKey.self,
                                    value: [cat: proxy.frame(in: .named(Self.tabRowSpace))])
         })
-        // Jiggle while ⌘ is held — the macOS "icons are movable now" signal.
+        // Jiggle while ⌥ is held — the macOS "icons are movable now" signal.
         // Alternating sign keeps neighbors out of phase; the capsule being
         // dragged stays level under the pointer.
         .modifier(JiggleEffect(active: jiggling, amplitude: jiggleAmplitude(for: cat)))
         // After the rotation on purpose: the badge sits still (anchored to
         // the layout bounds) while the capsule wiggles underneath it.
         .overlay(alignment: .topTrailing) {
-            // Launchpad-style delete badge on custom tags while ⌘-mode is
+            // Launchpad-style delete badge on custom tags while ⌥-mode is
             // active. Routes into the existing confirm dialog, whose copy
             // tells the user the category's items are kept.
             if jiggling, let id = cat.tagFilter {
@@ -434,14 +434,14 @@ struct ClipboardWallView: View {
         .opacity(draggedTab == cat ? 0.85 : 1)
         .shadow(color: .black.opacity(draggedTab == cat ? 0.25 : 0), radius: 4, y: 1)
         .zIndex(draggedTab == cat ? 1 : 0)
-        // Always attached; only a ⌘-initiated drag arms reordering (checked
+        // Always attached; only a ⌥-initiated drag arms reordering (checked
         // in onChanged). High priority so it beats the tap once the pointer
         // actually moves; a plain click stays a tab switch. Mouse drags never
         // scroll an NSScrollView on macOS, so the row's scrolling is fine.
         .highPriorityGesture(reorderGesture(for: cat))
     }
 
-    /// Whether ⌘-reorder mode is active (modifier held, no modal dialog up).
+    /// Whether ⌥-reorder mode is active (modifier held, no modal dialog up).
     private var reorderArmed: Bool {
         state.isReorderModifierHeld && state.tagDialog == nil
     }
@@ -502,9 +502,9 @@ struct ClipboardWallView: View {
         DragGesture(minimumDistance: 4, coordinateSpace: .named(Self.tabRowSpace))
             .onChanged { value in
                 if draggedTab == nil {
-                    // Only a ⌘-initiated drag arms reordering; a plain drag
+                    // Only a ⌥-initiated drag arms reordering; a plain drag
                     // on the row is inert. Once armed it stays armed for the
-                    // whole drag, even if ⌘ lifts mid-way.
+                    // whole drag, even if ⌥ lifts mid-way.
                     guard reorderArmed else { return }
                     draggedTab = cat
                     dragStartFrames = tabFrames
@@ -638,7 +638,7 @@ struct ClipboardWallView: View {
             hint("←→", .clipboardHintSelect)
             hint("⇥", .clipboardHintCategory)
             hint("⌘K", .clipboardHintFilterSource)
-            hint("⌘", .clipboardHintEditCategories)
+            hint("⌥", .clipboardHintEditCategories)
             hint("↵", .clipboardHintCopy)
             hint("⌥↵", .clipboardHintPastePlain)
             hint("space", .clipboardHintPreview)

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -64,6 +64,17 @@ struct ClipboardWallView: View {
                                query: state.query)
     }
 
+    /// An order-sensitive signature of the displayed items, used as the
+    /// `onChange` trigger for mirroring the list into state. Hashing avoids
+    /// allocating a fresh `[UUID]` on every body evaluation (which `items.map`
+    /// would); `count` is folded in so the value also moves on size changes.
+    private func itemsSignature(_ items: [ClipboardHistoryItem]) -> Int {
+        var hasher = Hasher()
+        hasher.combine(items.count)
+        for item in items { hasher.combine(item.id) }
+        return hasher.finalize()
+    }
+
     private struct SourceOption: Identifiable, Equatable {
         let bundleID: String
         let name: String
@@ -109,7 +120,7 @@ struct ClipboardWallView: View {
         // Mirror the displayed list into state for the controller's keyboard
         // handling. Runs after the view updates, so it never mutates during body.
         .onAppear { state.setItems(items) }
-        .onChange(of: items.map(\.id)) { _, _ in state.setItems(items) }
+        .onChange(of: itemsSignature(items)) { _, _ in state.setItems(items) }
         .onAppear {
             state.setCategories(ClipboardCategoryOrder.apply(
                 to: ClipboardWallState.order(tags: ClipboardTagStore.shared.tags)))

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -604,6 +604,29 @@ struct ClipboardWallView: View {
         return menu
     }
 
+    /// Memoizes `matchSnippet` for the current query so a wall re-render (e.g. a
+    /// selection change re-evaluates every visible card's body) or a re-realized
+    /// card while scrolling doesn't re-fold the item's text. Scoped to one query:
+    /// switching queries clears it, so a stale snippet can only briefly survive an
+    /// in-place item edit under the same query (display-only). `[UUID: String?]`
+    /// distinguishes a cached nil result from an absent entry.
+    @MainActor
+    private enum MatchSnippetCache {
+        private static var query = ""
+        private static var cache: [UUID: String?] = [:]
+
+        static func snippet(for item: ClipboardHistoryItem, query: String) -> String? {
+            if query != self.query {
+                self.query = query
+                cache.removeAll(keepingCapacity: true)
+            }
+            if let cached = cache[item.id] { return cached }
+            let computed = ClipboardSearch.matchSnippet(for: item, query: query)
+            cache[item.id] = computed
+            return computed
+        }
+    }
+
     private func cards(_ items: [ClipboardHistoryItem]) -> some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
@@ -615,7 +638,7 @@ struct ClipboardWallView: View {
                             item: item,
                             isSelected: index == state.selectedIndex,
                             historyDirectory: historyDirectory,
-                            matchSnippet: ClipboardSearch.matchSnippet(for: item, query: state.query),
+                            matchSnippet: MatchSnippetCache.snippet(for: item, query: state.query),
                             onToggleFavorite: { onToggleFavorite(item) },
                             // Select the card the user right-clicked so the
                             // action visibly applies to it.

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -88,8 +88,12 @@ struct ClipboardWallView: View {
 
     var body: some View {
         let items = filtered
+        // Compute the source grouping once per body eval and thread it through;
+        // it is O(n) over allItems, and the menu, trigger title, and the two
+        // onChange dependencies below would otherwise each recompute it.
+        let sources = sourceOptions
         return VStack(spacing: 10) {
-            tabs
+            tabs(sources)
             if items.isEmpty {
                 Spacer()
                 LocalizedText(.clipboardEmpty).foregroundStyle(.secondary)
@@ -114,7 +118,7 @@ struct ClipboardWallView: View {
             state.setCategories(ClipboardCategoryOrder.apply(
                 to: ClipboardWallState.order(tags: newTags)))
         }
-        .onChange(of: sourceOptions.map(\.bundleID)) { _, ids in
+        .onChange(of: sources.map(\.bundleID)) { _, ids in
             if let selected = state.sourceFilterBundleID, !ids.contains(selected) {
                 state.clearSourceFilter()
             }
@@ -122,12 +126,12 @@ struct ClipboardWallView: View {
         // The ⌘K shortcut (handled by the window controller) bumps this token;
         // open the native source menu in response, when there is anything to filter.
         .onChange(of: state.sourceMenuOpenToken) { _, _ in
-            if !sourceOptions.isEmpty { sourceMenuRequested = true }
+            if !sources.isEmpty { sourceMenuRequested = true }
         }
         .overlay { if state.tagDialog != nil { tagDialogOverlay } }
     }
 
-    private var tabs: some View {
+    private func tabs(_ sources: [SourceOption]) -> some View {
         HStack(spacing: 8) {
             // Horizontal scroll so many custom tags can't push the search
             // field out of the window.
@@ -152,7 +156,7 @@ struct ClipboardWallView: View {
                 }
             }
             Spacer()
-            sourceFilterMenu
+            sourceFilterMenu(sources)
             // A real, focusable field so an IME can compose CJK search text. The
             // controller toggles focus between this field (input mode) and card
             // navigation; see ClipboardWallWindowController.handle(_:).
@@ -167,7 +171,7 @@ struct ClipboardWallView: View {
         }
     }
 
-    private var sourceFilterMenu: some View {
+    private func sourceFilterMenu(_ sources: [SourceOption]) -> some View {
         // A plain Button trigger styled like the old borderless menu label; the
         // dropdown itself is a native NSMenu popped by the background anchor.
         // Rationale: SwiftUI's `Menu` doesn't reliably render custom
@@ -180,7 +184,7 @@ struct ClipboardWallView: View {
         } label: {
             HStack(spacing: 3) {
                 Label {
-                    Text(sourceFilterTitle).lineLimit(1)
+                    Text(sourceFilterTitle(sources)).lineLimit(1)
                 } icon: {
                     SourceFilterLeadingIcon(bundleID: state.sourceFilterBundleID)
                 }
@@ -192,13 +196,13 @@ struct ClipboardWallView: View {
         .buttonStyle(.borderless)
         .tint(.primary)
         .frame(maxWidth: 150)
-        .disabled(sourceOptions.isEmpty)
+        .disabled(sources.isEmpty)
         .help(L(.clipboardSourceFilterHelp))
         .background(
             SourceFilterMenuAnchor(
                 requested: $sourceMenuRequested,
                 allTitle: L(.clipboardSourceAll),
-                options: sourceOptions,
+                options: sources,
                 selectedBundleID: state.sourceFilterBundleID,
                 onSelect: { bundleID in
                     if let bundleID {
@@ -352,9 +356,9 @@ struct ClipboardWallView: View {
         override var isFlipped: Bool { true }
     }
 
-    private var sourceFilterTitle: String {
+    private func sourceFilterTitle(_ sources: [SourceOption]) -> String {
         guard let selected = state.sourceFilterBundleID else { return L(.clipboardSourceAll) }
-        return sourceOptions.first { $0.bundleID == selected }?.name ?? selected
+        return sources.first { $0.bundleID == selected }?.name ?? selected
     }
 
     @ViewBuilder

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -356,12 +356,16 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
                 paste(item, plain: event.modifierFlags.contains(.option))
             }
             return true
-        case 123:                                        // ←
+        case 123:                                        // ← / ⌘← (jump to first)
             if inputMode { return false }                // move the text caret
-            state.moveLeft(); syncTextPreview(); return true
-        case 124:                                        // →
+            if event.modifierFlags.contains(.command) { state.moveToStart() }
+            else { state.moveLeft() }
+            syncTextPreview(); return true
+        case 124:                                        // → / ⌘→ (jump to last)
             if inputMode { return false }                // field delegate may exit
-            state.moveRight(); syncTextPreview(); return true
+            if event.modifierFlags.contains(.command) { state.moveToEnd() }
+            else { state.moveRight() }
+            syncTextPreview(); return true
         case 49:                                         // space
             if inputMode { return false }                // insert a space
             togglePreview(); return true

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -330,6 +330,13 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             }
         }
         if let consumed = routeToTextWindow(event) { return consumed }
+        // ⌘K opens the source-filter menu, in both input and card-navigation
+        // modes (intercepted before the input-mode passthrough below).
+        if event.modifierFlags.intersection([.command, .control, .option, .shift]) == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "k" {
+            state.requestOpenSourceMenu()
+            return true
+        }
         let inputMode = state.isSearchFocused
         switch event.keyCode {
         case 53:                                         // esc — staged exit

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -99,9 +99,9 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         // Never resurface a stale tag dialog (it may pin a deleted item).
         state.tagDialog = nil
         state.tagDialogText = ""
-        // Seed from the live flags: the wall hotkey itself carries ⌘, and the
-        // monitor only reports subsequent changes.
-        state.isReorderModifierHeld = NSEvent.modifierFlags.contains(.command)
+        // Seed from the live flags: ⌥ may already be held when the wall opens,
+        // and the monitor only reports subsequent changes.
+        state.isReorderModifierHeld = NSEvent.modifierFlags.contains(.option)
         // Force the watcher to capture immediately so content copied just before
         // opening shows up now, rather than after the next ~0.5s poll tick. The
         // @Query-backed view re-renders on its own once the store changes.
@@ -237,10 +237,10 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             let consumed = MainThreadIsolation.run { self?.handleScroll(event) ?? false }
             return consumed ? nil : event
         }
-        // Track ⌘ so the view can enable tab drag-to-reorder reactively.
+        // Track ⌥ so the view can enable tab drag-to-reorder reactively.
         flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             MainThreadIsolation.run {
-                self?.state.isReorderModifierHeld = event.modifierFlags.contains(.command)
+                self?.state.isReorderModifierHeld = event.modifierFlags.contains(.option)
             }
             return event
         }

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -275,16 +275,19 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
     /// trackpad swipe flip through the cards. Negative delta advances right.
     private func handleScroll(_ event: NSEvent) -> Bool {
         guard let window, window.isVisible else { return false }
+        // Only convert scrolls over the wall itself into card navigation. A
+        // scroll targeting any other window — the floating text panel, or an
+        // open NSMenu such as the source filter — must reach that window rather
+        // than being swallowed here (otherwise the menu can't scroll and the
+        // cards advance under it). This subsumes the old floating-text-panel
+        // check, since that panel is a different window.
+        guard event.window === window else { return false }
         // The selection must not change behind the tag dialog's modal dimmer.
         if state.tagDialog != nil { return true }
-        // Scrolling over the floating text panel belongs to its text view,
-        // not to card navigation.
-        if ClipboardTextWindow.shared.owns(event.window) { return false }
         // The top strip (tab row + search field) hosts its own horizontal
         // ScrollView; let scrolls over that area reach it instead of becoming
         // card navigation.
-        if event.window === window,
-           event.locationInWindow.y > window.contentLayoutRect.maxY - Self.topStripHeight {
+        if event.locationInWindow.y > window.contentLayoutRect.maxY - Self.topStripHeight {
             return false
         }
         // Ignore trackpad inertia so flicking doesn't keep advancing after the


### PR DESCRIPTION
## Summary

Reworks the clipboard wall's source-app filter and card navigation, plus a
render-path performance pass.

### Added

- **⌘K opens the source-app filter** from the keyboard (both search-input and
  card-navigation modes); a "⌘K 筛选来源" hint is added to the wall footer.
- **⌘← / ⌘→ jump the selection to the first / last card** (card-navigation mode
  only — in the search field they still move the text caret). The jump scrolls
  instantly instead of animating, so a long history doesn't run a multi-frame
  scroll animation across the cards; a "⌘←→ 首/尾" hint is added to the footer.

### Changed

- **Source-app filter shows real application icons.** The dropdown moved from a
  SwiftUI `Menu` (which doesn't reliably render custom `Image(nsImage:)` items on
  macOS) to a native `NSMenu` popped from a view anchor: each source row shows
  the app icon via `NSMenuItem.image`, the active source keeps the native
  checkmark, the menu opens upward from the bottom-of-wall trigger, and it
  auto-scrolls when long. The trigger button now shows the selected source's icon.
- **Tab edit / reorder mode is armed by holding ⌥ instead of ⌘** (footer hint
  updated to ⌥).
- **Wall render-path performance.** Source-app grouping is computed once per
  render instead of 4–5 times; the list-sync `onChange` trigger hashes the items
  instead of allocating a fresh `[UUID]` per body evaluation; and match snippets
  are memoized per item for the active query, so a re-render or a card re-realized
  while scrolling no longer re-folds the item's text on the main thread.

### Fixed

- **Scrolling the open source-filter menu no longer moves the cards underneath.**
  Card-navigation scroll now only acts on scroll events targeting the wall window
  itself, letting scrolls over the menu (and the floating text panel) reach their
  own window.

## Testing

- `swift build` clean.
- `swift test --filter ClipboardSearchTests` — 28 tests pass (match-snippet
  caching is a pure wrapper; behavior unchanged).

See `CHANGELOG.md` (Unreleased) for the user-facing notes.