### PR TITLE
fix: roll back safely when hosts/clipboard/hyperkey writes fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- Clipboard wall cards grew from 190×190 to 230×230 (panel height 285→325),
+  with larger preview and match-snippet text, improving legibility of longer
+  text/OCR/QR previews.
+
 ### Fixed
 
 - Release builds appeared washed-out on macOS 26 (Tahoe). The universal-binary
@@ -30,6 +36,38 @@ versioning.
   `Info.plist` (`LSMinimumSystemVersion`). The `platform_version` override force-
   stamps `minos`, so without this guard a future platform bump would silently
   ship a binary claiming support for an older macOS than it was built for.
+- Clipboard wall cards intermittently showed a blank source-app icon after fast
+  scrolling. The icon was resolved through an async `.task` that could be torn
+  down by the wall's frequent view-body re-evaluations before the detached
+  resolve landed; the source icon is a single cheap Launch Services lookup, so
+  it's now resolved synchronously on the main actor instead.
+- The clipboard wall's source-filter trigger showed a blue keyboard focus ring
+  when the wall opened, unlike the tab row beside it. It's no longer part of
+  the focus chain (mouse clicks still open the menu).
+- Hyper Key: retrying the trigger mapping right after a failed `hidutil` GET
+  could leave a stale signature in the persisted `hyperKey.ownedSignatures`,
+  since only the SET-reached failure path rolled it back. A failed GET (which
+  never mutates `hidutil`) now also rolls the persisted ownership back to its
+  prior state.
+- Hosts: composing or applying against `/etc/hosts` fell back to an empty
+  string when the file couldn't be read, risking a write that wiped the
+  system's own entries. A failed read now aborts the apply with a surfaced
+  error instead.
+- Hosts: deleting an active profile removed its SwiftData row before
+  confirming the block-removal write to `/etc/hosts` succeeded, so a failed
+  write could orphan the block outside any tracked profile. The row is now
+  deleted only after the deactivation is applied and verified — including
+  against a coalesced `scheduleApply()` result, which can otherwise report a
+  batch-mate's success (or a rolled-back no-op retry) instead of this
+  profile's own write.
+- Clipboard: deleting a history item removed its on-disk payload file
+  (PNG/copied files) before the row deletion was saved, so a failed save
+  could leave a surviving row pointing at deleted files — and the failed-save
+  path never rolled back the pending deletion, letting a later unrelated save
+  silently flush it and drop the row anyway. The payload is now captured
+  before, and removed only after, the row deletion is confirmed saved; a
+  failed save rolls back the pending deletion and refreshes from the
+  persisted state.
 
 ## [3.4.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ versioning.
   while `swift run` (native backend, real SDK) looked correct. The release
   script now forces `platform_version` to the real SDK version, keeping `minos`
   at 14.0 so the app still runs on macOS 14+.
+- The Settings window opened by itself on every launch of the released app —
+  most visibly after a reboot/login auto-launch. Same root cause as the
+  washed-out appearance above: with a 14.0 `sdk` stamp, macOS 26's SwiftUI
+  applies the legacy behavior where an app whose only scene is `Settings`
+  presents that window at launch, regardless of the launch mechanism (login
+  item, `open -a`, direct exec). Verified by A/B-stamping the same binary with
+  `vtool`: `sdk 14.0` opens the window, the real SDK keeps it closed. The
+  state-restoration and reopen-suppression defenses in `AppDelegate` were never
+  the trigger. Fixed by the `platform_version` override above.
 
 ## [3.4.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ versioning.
   `vtool`: `sdk 14.0` opens the window, the real SDK keeps it closed. The
   state-restoration and reopen-suppression defenses in `AppDelegate` were never
   the trigger. Fixed by the `platform_version` override above.
+- Release tooling now asserts the minimum-macOS declaration stays in sync across
+  `scripts/release.sh` (`MIN_MACOS`), `Package.swift` (`.macOS`), and
+  `Info.plist` (`LSMinimumSystemVersion`). The `platform_version` override force-
+  stamps `minos`, so without this guard a future platform bump would silently
+  ship a binary claiming support for an older macOS than it was built for.
 
 ## [3.4.0] - 2026-06-29
 

--- a/Sources/AnyDoor/Services/ClipboardHistoryStore.swift
+++ b/Sources/AnyDoor/Services/ClipboardHistoryStore.swift
@@ -409,22 +409,48 @@ final class ClipboardHistoryStore {
     /// Delete a single item and its on-disk payload (image PNG / copied files).
     func delete(_ item: ClipboardHistoryItem) async {
         guard let container = modelContainer else { return }
-        deleteScreenshotFileIfNeeded(for: item)   // covers .screenshot and .image (both use fileName)
-        deleteCopiedFilesIfNeeded(for: item)
+        // Capture the on-disk payload names BEFORE removing the row: after a
+        // successful delete + save the model is deallocated and its properties
+        // are unsafe to read. Persist the row deletion first so a failed save
+        // never leaves a surviving row pointing at deleted files; the worst case
+        // then is orphan files, which pruneExpiredAndOverflow later sweeps.
+        let payloads = payloadFileNames(for: item)
         let kind = item.historyKind
         container.mainContext.delete(item)
-        try? container.mainContext.save()
+        do {
+            try container.mainContext.save()
+        } catch {
+            historyLogger.error("Failed to delete clipboard history item: \(error)")
+            return
+        }
+        removePayloadFiles(payloads)
         if let kind { await reload(kind: kind) }
     }
 
-    /// Remove copied-file payloads for a `.file` entry (no-op for reference-only).
-    private func deleteCopiedFilesIfNeeded(for item: ClipboardHistoryItem) {
-        guard item.kind == ClipboardHistoryKind.file.rawValue else { return }
-        let directory = historyDirectoryProvider()
-        for entry in item.files {
-            if let stored = entry.storedName {
-                try? FileManager.default.removeItem(at: directory.appendingPathComponent(stored))
+    /// Collect the on-disk payload file names an item owns (screenshot/image PNG
+    /// under `fileName`; copied `.file` payloads under `storedName`). Read this
+    /// BEFORE deleting the row so the names survive the model's deallocation.
+    private func payloadFileNames(for item: ClipboardHistoryItem) -> [String] {
+        var names: [String] = []
+        if item.kind == ClipboardHistoryKind.screenshot.rawValue
+            || item.kind == ClipboardHistoryKind.image.rawValue,
+           let fileName = item.fileName {
+            names.append(fileName)
+        }
+        if item.kind == ClipboardHistoryKind.file.rawValue {
+            for entry in item.files {
+                if let stored = entry.storedName { names.append(stored) }
             }
+        }
+        return names
+    }
+
+    /// Remove previously captured payload file names from history storage.
+    private func removePayloadFiles(_ fileNames: [String]) {
+        guard !fileNames.isEmpty else { return }
+        let directory = historyDirectoryProvider()
+        for name in fileNames {
+            try? FileManager.default.removeItem(at: directory.appendingPathComponent(name))
         }
     }
 
@@ -465,11 +491,18 @@ final class ClipboardHistoryStore {
                 }
             }
 
+            // Capture payload names BEFORE deleting rows, then remove files only
+            // after the save succeeds — a failed save must not orphan a surviving
+            // row's payload. Leftover files are handled by the orphan sweep below.
+            var payloadsToDelete: [String] = []
             for item in all where idsToDelete.contains(item.id) {
-                deleteScreenshotFileIfNeeded(for: item)
+                payloadsToDelete.append(contentsOf: payloadFileNames(for: item))
                 context.delete(item)
             }
-            if !idsToDelete.isEmpty { try context.save() }
+            if !idsToDelete.isEmpty {
+                try context.save()
+                removePayloadFiles(payloadsToDelete)
+            }
 
             // Sweep orphan files no longer referenced by surviving rows.
             // Both .screenshot and .image rows persist a single PNG under fileName;
@@ -640,14 +673,6 @@ final class ClipboardHistoryStore {
         } catch {
             historyLogger.error("Failed to clear clipboard history: \(error)")
         }
-    }
-
-    private func deleteScreenshotFileIfNeeded(for item: ClipboardHistoryItem) {
-        guard item.kind == ClipboardHistoryKind.screenshot.rawValue
-                || item.kind == ClipboardHistoryKind.image.rawValue,
-              let fileName = item.fileName else { return }
-        let url = historyDirectoryProvider().appendingPathComponent(fileName)
-        try? FileManager.default.removeItem(at: url)
     }
 
     private func removeOrphanScreenshotFiles(keeping survivingFiles: Set<String>) {

--- a/Sources/AnyDoor/Services/ClipboardHistoryStore.swift
+++ b/Sources/AnyDoor/Services/ClipboardHistoryStore.swift
@@ -421,6 +421,10 @@ final class ClipboardHistoryStore {
             try container.mainContext.save()
         } catch {
             historyLogger.error("Failed to delete clipboard history item: \(error)")
+            // Discard the pending deletion so a later unrelated save can't
+            // silently flush it, and refresh the cache so the UI keeps the row.
+            container.mainContext.rollback()
+            if let kind { await reload(kind: kind) }
             return
         }
         removePayloadFiles(payloads)

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -5,6 +5,19 @@ import Observation
 
 private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "hosts")
 
+/// Errors originating in HostsManager itself (as opposed to the writer/backup).
+enum HostsManagerError: Error {
+    /// Reading the live `/etc/hosts` failed, so we cannot safely compose or write.
+    case liveReadFailed
+
+    /// Chinese UI message, consistent with the other `lastError` strings.
+    var userMessage: String {
+        switch self {
+        case .liveReadFailed: return "无法读取系统 hosts 文件"
+        }
+    }
+}
+
 /// Single source of truth for host profiles. SwiftData-backed, @MainActor.
 /// Persisted state always equals what was successfully applied to the system.
 @Observable @MainActor
@@ -19,7 +32,7 @@ final class HostsManager {
             return AppleScriptWriter()
         },
         backup: HostsBackupStore.makeDefault(),
-        readLiveHosts: { (try? String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8)) ?? "" }
+        readLiveHosts: { try String(contentsOf: URL(fileURLWithPath: "/etc/hosts"), encoding: .utf8) }
     )
 
     private(set) var profiles: [HostProfile] = []
@@ -31,7 +44,9 @@ final class HostsManager {
     private let makeWriter: () -> HostsWriter
     // `var` so tests can inject backupErrorOverride on the value-type HostsBackupStore.
     var backup: HostsBackupStore
-    private let readLiveHosts: () -> String
+    // Throwing: a failed read of `/etc/hosts` must abort composing/applying, never
+    // fall back to an empty string (which would destroy the system's own entries).
+    private let readLiveHosts: () throws -> String
     private var modelContainer: ModelContainer?
 
     // MARK: - Debounce / serialization state
@@ -44,7 +59,7 @@ final class HostsManager {
     /// Designated initialiser. Accepts a factory so the writer can be re-resolved per write.
     init(makeWriter: @escaping () -> HostsWriter,
          backup: HostsBackupStore,
-         readLiveHosts: @escaping () -> String,
+         readLiveHosts: @escaping () throws -> String,
          debounceInterval: Duration = .milliseconds(150)) {
         self.makeWriter = makeWriter
         self.backup = backup
@@ -55,7 +70,7 @@ final class HostsManager {
     /// Convenience initialiser for tests that supply a fixed writer.
     convenience init(writer: HostsWriter,
                      backup: HostsBackupStore,
-                     readLiveHosts: @escaping () -> String,
+                     readLiveHosts: @escaping () throws -> String,
                      debounceInterval: Duration = .milliseconds(150)) {
         self.init(makeWriter: { writer }, backup: backup, readLiveHosts: readLiveHosts,
                   debounceInterval: debounceInterval)
@@ -73,7 +88,11 @@ final class HostsManager {
         profiles = (try? context.fetch(
             FetchDescriptor<HostProfile>(sortBy: [SortDescriptor(\.displayOrder)])
         )) ?? []
-        let parsed = HostsFile.parse(readLiveHosts())
+        // Display-only: if the live read fails, keep the previously shown system
+        // content rather than blanking it. The apply path handles read failures
+        // via `HostsManagerError.liveReadFailed`.
+        guard let live = try? readLiveHosts() else { return }
+        let parsed = HostsFile.parse(live)
         systemHosts = [parsed.prefix, parsed.suffix]
             .filter { !$0.isEmpty }
             .joined(separator: "\n")
@@ -165,7 +184,7 @@ final class HostsManager {
             lastError = backupError != nil ? "备份创建失败，可能无法完整恢复" : nil
             reload()
         } catch {
-            lastError = String(describing: error)
+            lastError = message(for: error)
             logger.error("System hosts edit failed: \(error)")
             reload()
         }
@@ -236,7 +255,7 @@ final class HostsManager {
         } catch {
             // Discard unsaved in-memory mutations so reload() sees the persisted state.
             modelContainer?.mainContext.rollback()
-            lastError = String(describing: error)
+            lastError = message(for: error)
             logger.error("Apply failed: \(error)")
             reload()
         }
@@ -246,12 +265,12 @@ final class HostsManager {
     /// system content is preserved from the live file; otherwise it is replaced
     /// (used by `updateSystemHosts`). The managed block is always rebuilt from
     /// the currently active profiles.
-    private func composedContent(systemPrefix: String?) -> String {
+    private func composedContent(systemPrefix: String?) throws -> String {
         let parsed: HostsFile.Parsed
         if let systemPrefix {
             parsed = HostsFile.Parsed(prefix: systemPrefix, managed: nil, suffix: "")
         } else {
-            parsed = HostsFile.parse(readLiveHosts())
+            parsed = HostsFile.parse(try readLive())
         }
         let active = profiles
             .filter(\.isActive)
@@ -264,8 +283,27 @@ final class HostsManager {
     /// entirely when it would not change the file (e.g. toggling or deleting a
     /// blank profile) so the user is never prompted for a no-op.
     private func applyContent(_ content: String) async throws {
-        guard content != readLiveHosts() else { return }
+        guard content != (try readLive()) else { return }
         let writer = makeWriter()
         try await writer.write(content)
+    }
+
+    /// Read the live `/etc/hosts`, mapping any failure to `liveReadFailed` so
+    /// compose/apply abort with a user-facing Chinese message instead of writing
+    /// against a bogus empty baseline.
+    private func readLive() throws -> String {
+        do {
+            return try readLiveHosts()
+        } catch {
+            logger.error("Reading /etc/hosts failed: \(error)")
+            throw HostsManagerError.liveReadFailed
+        }
+    }
+
+    /// Map an error to a user-facing message. Known HostsManager errors use their
+    /// Chinese text; everything else falls back to a description.
+    private func message(for error: Error) -> String {
+        if let error = error as? HostsManagerError { return error.userMessage }
+        return String(describing: error)
     }
 }

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -138,9 +138,15 @@ final class HostsManager {
         if profile.isActive {
             // Deactivate in memory and apply; the row is only deleted on success.
             profile.isActive = false
-            guard await scheduleApply() else {
-                // scheduleApply's failure path rolled back `isActive` to true and
-                // set `lastError`; keep the row so the block is not orphaned.
+            let applied = await scheduleApply()
+            // scheduleApply coalesces concurrent callers into one task and returns
+            // the shared last-iteration result, so its Bool alone can report a
+            // batch-mate's success — including a no-op retry after a failed write
+            // whose rollback() restored `isActive` to true. Gate the irreversible
+            // delete on the fact that matters: this profile's deactivation was
+            // actually applied and saved (`isActive` stayed false).
+            guard applied, !profile.isActive else {
+                if lastError == nil { lastError = "删除配置失败，请重试" }
                 return
             }
         }

--- a/Sources/AnyDoor/Services/Hosts/HostsManager.swift
+++ b/Sources/AnyDoor/Services/Hosts/HostsManager.swift
@@ -53,6 +53,9 @@ final class HostsManager {
     private let debounceInterval: Duration
     private var applyPending = false
     private var applyTask: Task<Void, Never>?
+    /// Result of the most recent `applyAndPersist`; read by callers that must act
+    /// only on a successful system write (e.g. `deleteProfile`).
+    private var lastApplySucceeded = false
 
     // MARK: - Init
 
@@ -126,13 +129,24 @@ final class HostsManager {
         return profiles.first { $0.id == duplicate.id }
     }
 
+    /// Delete a profile. For an active profile the invariant "persisted state
+    /// equals what was applied" must hold: remove its managed block from the
+    /// system first and only drop the DB row once that write succeeds, so a
+    /// failed write leaves the row (and its block) intact instead of orphaning it.
     func deleteProfile(_ profile: HostProfile) async {
         guard let context = modelContainer?.mainContext else { return }
-        let wasActive = profile.isActive
+        if profile.isActive {
+            // Deactivate in memory and apply; the row is only deleted on success.
+            profile.isActive = false
+            guard await scheduleApply() else {
+                // scheduleApply's failure path rolled back `isActive` to true and
+                // set `lastError`; keep the row so the block is not orphaned.
+                return
+            }
+        }
         context.delete(profile)
         try? context.save()
         reload()
-        if wasActive { await scheduleApply() }
     }
 
     private func copyName(for name: String) -> String {
@@ -214,7 +228,8 @@ final class HostsManager {
 
     /// Coalescing debounced entry-point for composed applies. All callers that
     /// go through the compose path use this instead of `applyAndPersist` directly.
-    private func scheduleApply() async {
+    @discardableResult
+    private func scheduleApply() async -> Bool {
         applyPending = true
         if applyTask == nil {
             applyTask = Task { @MainActor in
@@ -222,17 +237,20 @@ final class HostsManager {
                 // Serial retry loop: pick up any toggle that arrived during the write.
                 while self.applyPending {
                     self.applyPending = false
-                    await self.applyAndPersist()
+                    self.lastApplySucceeded = await self.applyAndPersist()
                 }
                 self.applyTask = nil
             }
         }
         await applyTask?.value
+        return lastApplySucceeded
     }
 
     // MARK: - Apply
 
-    private func applyAndPersist() async {
+    /// Returns `true` when the compose+write+persist succeeded (including a no-op
+    /// skip), `false` when the write failed and the context was rolled back.
+    private func applyAndPersist() async -> Bool {
         // Capture backup error; a failed backup must not abort the write.
         var backupError: Error?
         do {
@@ -252,12 +270,14 @@ final class HostsManager {
                 lastError = nil
             }
             reload()
+            return true
         } catch {
             // Discard unsaved in-memory mutations so reload() sees the persisted state.
             modelContainer?.mainContext.rollback()
             lastError = message(for: error)
             logger.error("Apply failed: \(error)")
             reload()
+            return false
         }
     }
 

--- a/Sources/AnyDoor/Services/HyperKeyController.swift
+++ b/Sources/AnyDoor/Services/HyperKeyController.swift
@@ -105,12 +105,19 @@ actor HyperKeyController {
         do {
             try await readModifyWrite(removeAll: oldOwned, add: newSig, didReachSet: &setReached)
         } catch {
-            // Only attempt revert when the SET phase was reached (GET succeeded).
-            // If the GET itself failed, hidutil is unchanged — no revert needed.
             if setReached {
+                // SET was reached (GET succeeded): hidutil may have been mutated, so
+                // undo the newSig entry and only restore persisted ownership if that
+                // revert succeeds.
                 if (try? await readModifyWrite(removeAll: [newSig], add: nil)) != nil {
                     persistOwned(oldOwned)
                 }
+            } else {
+                // GET failed: hidutil was never mutated, so the pre-persisted newSig
+                // was never applied. Roll persisted ownership back unconditionally —
+                // safe precisely because a failed GET means the system state is
+                // unchanged (avoids a stale signature blocking termination/reconcile).
+                persistOwned(oldOwned)
             }
             throw error
         }

--- a/Sources/AnyDoor/Utilities/AppIconCache.swift
+++ b/Sources/AnyDoor/Utilities/AppIconCache.swift
@@ -78,6 +78,26 @@ enum AppIconCache {
         bundleCache[bundleID]
     }
 
+    /// Synchronous main-actor resolution + memoization by bundle identifier.
+    ///
+    /// The source-app icon is a single, cheap Launch Services lookup
+    /// (`urlForApplication` + `icon(forFile:)`), unlike the potentially heavy
+    /// image-thumbnail decode. Resolving it inline on the main actor — instead of
+    /// through an async `.task`/`@State` hop — keeps the clipboard card's source
+    /// icon reliable: the async path could leave the header's icon slot blank when
+    /// the card's `.task` was torn down by the wall's frequent body re-evaluations
+    /// before the detached resolve landed. Memoized so each distinct source app is
+    /// resolved once; returns nil when the bundle ID maps to no installed app.
+    static func iconForBundleSync(_ bundleID: String) -> NSImage? {
+        if let hit = bundleCache[bundleID] { return hit }
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+            return nil
+        }
+        let image = NSWorkspace.shared.icon(forFile: url.path)
+        bundleCache[bundleID] = image
+        return image
+    }
+
     /// Returns the icon for the app with `bundleID`, resolving its URL and icon on
     /// a background task on a cache miss. Returns nil when the bundle ID maps to no
     /// installed app. Concurrent requests for the same ID share one resolution.

--- a/Sources/AnyDoor/Views/ClipboardCardView.swift
+++ b/Sources/AnyDoor/Views/ClipboardCardView.swift
@@ -29,7 +29,7 @@ struct ClipboardCardView: View {
             Divider()
             preview.frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(width: 190, height: 190)
+        .frame(width: 230, height: 230)
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
@@ -159,12 +159,12 @@ struct ClipboardCardView: View {
         case .text, .ocr, .qrcode:
             VStack(alignment: .leading, spacing: 4) {
                 Text(item.text ?? item.previewTitle)
-                    .font(.system(size: 11)).lineLimit(matchSnippet == nil ? 6 : 3)
+                    .font(.system(size: 13)).lineLimit(matchSnippet == nil ? 6 : 3)
                 // Surface the matched line so a search hit buried below the first
                 // line is visible rather than leaving the card looking unrelated.
                 if let matchSnippet {
                     Text(matchSnippet)
-                        .font(.system(size: 10)).lineLimit(2)
+                        .font(.system(size: 12)).lineLimit(2)
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 5).padding(.vertical, 2)
                         .background(Color.accentColor.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))

--- a/Sources/AnyDoor/Views/ClipboardCardView.swift
+++ b/Sources/AnyDoor/Views/ClipboardCardView.swift
@@ -145,8 +145,11 @@ struct ClipboardCardView: View {
     /// the header stays clean rather than showing a generic placeholder.
     @ViewBuilder
     private var sourceIcon: some View {
-        if let bundleID = item.sourceBundleID {
-            SourceAppIcon(bundleID: bundleID, appName: item.sourceAppName)
+        if let bundleID = item.sourceBundleID,
+           let icon = AppIconCache.iconForBundleSync(bundleID) {
+            Image(nsImage: icon)
+                .resizable().scaledToFit()
+                .help(item.sourceAppName ?? "")
         }
     }
 
@@ -215,36 +218,12 @@ struct ClipboardCardView: View {
         UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) ?? false
     }
 
-    /// Source-app icon resolved off the main thread via `AppIconCache`. Reads the
-    /// cache synchronously in `body` first (so a warm icon renders with no flash),
-    /// and only kicks off the async bundle-ID resolution on a cache miss — keeping
-    /// the disk/`NSWorkspace` lookup off the scrolling card's render path. Renders
-    /// nothing when the bundle ID maps to no installed app.
-    private struct SourceAppIcon: View {
-        let bundleID: String
-        let appName: String?
-        @State private var loaded: NSImage?
-
-        var body: some View {
-            Group {
-                if let icon = loaded ?? AppIconCache.cachedForBundle(bundleID) {
-                    Image(nsImage: icon)
-                        .resizable().scaledToFit()
-                        .help(appName ?? "")
-                }
-            }
-            .task(id: bundleID) {
-                if loaded == nil, AppIconCache.cachedForBundle(bundleID) == nil {
-                    loaded = await AppIconCache.icon(forBundleID: bundleID)
-                }
-            }
-        }
-    }
-
-    /// Image/file-card thumbnail decoded off the main thread via `ClipboardThumbnail`.
-    /// Same warm-path-synchronous / cold-path-async contract as `SourceAppIcon`, so
-    /// many image cards sliding in no longer each run a full-resolution decode on the
-    /// main thread. Shows a `photo` placeholder while the first decode is in flight.
+    /// Image/file-card thumbnail decoded off the main thread via `ClipboardThumbnail`:
+    /// reads the warm cache synchronously in `body`, and only kicks off the async
+    /// decode on a miss, so many image cards sliding in no longer each run a
+    /// full-resolution decode on the main thread. Unlike the lightweight source-app
+    /// icon (resolved inline), the thumbnail decode is heavy enough to keep async.
+    /// Shows a `photo` placeholder while the first decode is in flight.
     private struct ThumbnailView: View {
         let url: URL
         @State private var loaded: NSImage?

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -206,6 +206,10 @@ struct ClipboardWallView: View {
             }
         }
         .buttonStyle(.borderless)
+        // Keep the trigger out of the keyboard focus chain so opening the wall
+        // doesn't land a blue focus ring on it (the ring the tab row also avoids
+        // by not using a Button); mouse clicks still open the menu.
+        .focusable(false)
         .tint(.primary)
         .frame(maxWidth: 150)
         .disabled(sources.isEmpty)

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -47,7 +47,7 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
 
     /// Guards against re-entrant show/dismiss while the slide animation runs.
     private var isAnimating = false
-    private static let panelHeight: CGFloat = 285
+    private static let panelHeight: CGFloat = 325
     private static let animationDuration: TimeInterval = 0.22
 
     private var historyDirectory: URL { ClipboardHistoryStore.defaultHistoryDirectory() }

--- a/Tests/AnyDoorTests/ClipboardHistoryStoreTests.swift
+++ b/Tests/AnyDoorTests/ClipboardHistoryStoreTests.swift
@@ -313,6 +313,48 @@ final class ClipboardHistoryStoreTests: XCTestCase {
         XCTAssertTrue(store.timeline(category: nil, query: "").isEmpty)
     }
 
+    func testDeleteRemovesOnDiskPayloadAfterSave() async throws {
+        let container = try makeContainer()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ClipboardHistoryStore(now: { Date(timeIntervalSinceReferenceDate: 100) }, historyDirectory: directory)
+        store.bootstrap(modelContainer: container)
+
+        await store.record(.image(png: Data([0x89, 0x50, 0x4E, 0x47])), source: nil)
+        let item = try XCTUnwrap(store.timeline(category: nil, query: "").first)
+        let fileName = try XCTUnwrap(item.fileName)
+        let fileURL = directory.appendingPathComponent(fileName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+
+        await store.delete(item)
+
+        // The row is gone and its on-disk payload is removed after the save.
+        XCTAssertTrue(store.timeline(category: nil, query: "").isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func testPruneRemovesOverflowPayloadFiles() async throws {
+        let container = try makeContainer()
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ClipboardHistoryStore(now: { now }, maxItemsPerKind: 1, historyDirectory: directory)
+        store.bootstrap(modelContainer: container)
+
+        await store.record(.image(png: Data([0x89, 0x50, 0x4E, 0x47])), source: nil)
+        let oldest = try XCTUnwrap(store.items(for: .image).first)
+        let oldestFile = directory.appendingPathComponent(try XCTUnwrap(oldest.fileName))
+
+        now = Date(timeIntervalSinceReferenceDate: 200)
+        await store.record(.image(png: Data([0x89, 0x50, 0x4E, 0x47])), source: nil)
+
+        await store.pruneExpiredAndOverflow(force: true)
+
+        // The overflowed row's PNG is removed after the prune save.
+        XCTAssertEqual(store.items(for: .image).count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldestFile.path))
+        try? FileManager.default.removeItem(at: directory)
+    }
+
     func testPruneExemptsFavorites() async throws {
         let container = try makeContainer()
         let now = Date(timeIntervalSinceReferenceDate: 10_000_000)

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -2,6 +2,49 @@ import XCTest
 import SwiftData
 @testable import AnyDoor
 
+/// Test writer whose next write can be suspended until the test releases it,
+/// so a second mutation can join the coalesced applyTask mid-write.
+private final class GatedHostsWriter: HostsWriter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lastWritten: String?
+    private var _gateNext = false
+    private var _isSuspended = false
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    var lastWritten: String? { lock.withLock { _lastWritten } }
+    var isSuspended: Bool { lock.withLock { _isSuspended } }
+
+    func gateNextWrite() { lock.withLock { _gateNext = true } }
+
+    /// Resume the suspended write, optionally failing it.
+    func release(throwing error: Error? = nil) {
+        let cont = lock.withLock {
+            let c = continuation
+            continuation = nil
+            _isSuspended = false
+            return c
+        }
+        if let error { cont?.resume(throwing: error) } else { cont?.resume() }
+    }
+
+    func write(_ content: String) async throws {
+        let gated = lock.withLock {
+            let g = _gateNext
+            _gateNext = false
+            return g
+        }
+        if gated {
+            try await withCheckedThrowingContinuation { (c: CheckedContinuation<Void, Error>) in
+                lock.withLock {
+                    continuation = c
+                    _isSuspended = true
+                }
+            }
+        }
+        lock.withLock { _lastWritten = content }
+    }
+}
+
 @MainActor
 final class HostsManagerTests: XCTestCase {
     private func makeContainer() throws -> ModelContainer {
@@ -199,6 +242,44 @@ final class HostsManagerTests: XCTestCase {
         XCTAssertEqual(mgr.profiles.count, 1, "Profile must survive a failed system write")
         XCTAssertTrue(mgr.profiles[0].isActive, "Active state must be restored on failed delete")
         XCTAssertNotNil(mgr.lastError, "lastError must surface the write failure")
+    }
+
+    /// Regression: deleteProfile must not trust the shared coalesced apply result.
+    /// A delete that joins an in-flight applyTask whose write fails gets rolled
+    /// back (`isActive` restored) — the follow-up retry is then a no-op "success"
+    /// that must NOT let the delete drop the row while its block is still live.
+    func test_deleteActiveProfile_joiningFailedCoalescedApply_keepsRow() async throws {
+        let writer = GatedHostsWriter()
+        let (mgr, _) = try makeManager(writer: writer,
+                                       live: { writer.lastWritten ?? "127.0.0.1 localhost\n" },
+                                       debounceInterval: .milliseconds(10))
+        mgr.createProfile(name: "A", content: "1.1.1.1 a")
+        mgr.createProfile(name: "B", content: "2.2.2.2 b")
+        let aID = mgr.profiles[0].id
+        let bID = mgr.profiles[1].id
+        await mgr.setActive(mgr.profiles[0], true) // A applied; live file has A's block
+
+        // Suspend the next write (B's activation) mid-flight, like an open auth dialog.
+        writer.gateNextWrite()
+        let toggleB = Task { @MainActor in
+            if let b = mgr.profiles.first(where: { $0.id == bID }) { await mgr.setActive(b, true) }
+        }
+        while !writer.isSuspended { try await Task.sleep(for: .milliseconds(5)) }
+
+        // Delete A while the coalesced apply is suspended: it joins the same task.
+        let deleteA = Task { @MainActor in
+            if let a = mgr.profiles.first(where: { $0.id == aID }) { await mgr.deleteProfile(a) }
+        }
+        try await Task.sleep(for: .milliseconds(30))
+        writer.release(throwing: HostsWriterError.writeFailed("denied"))
+        await toggleB.value
+        await deleteA.value
+
+        // Rollback restored A.isActive; the retry was a no-op. A's block is still
+        // in the live file, so its row must survive and the failure must surface.
+        XCTAssertEqual(mgr.profiles.count, 2, "Profile A must survive: its block was never removed")
+        XCTAssertEqual(mgr.profiles.first { $0.id == aID }?.isActive, true)
+        XCTAssertNotNil(mgr.lastError, "The failed delete must surface an error")
     }
 
     func test_deleteActiveProfile_successfulWrite_removesRowAndBlock() async throws {

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -161,6 +161,28 @@ final class HostsManagerTests: XCTestCase {
         XCTAssertTrue(written.contains("2.2.2.2 beta"))
     }
 
+    // MARK: - Fix 1: unreadable /etc/hosts aborts the apply instead of writing empty
+
+    func test_liveReadFailure_abortsApply_setsError_neverWrites() async throws {
+        struct LiveReadError: Error {}
+        let mock = MockHostsWriter()
+        let container = try makeContainer()
+        let live: () throws -> String = { throw LiveReadError() }
+        let mgr = HostsManager(
+            writer: mock,
+            backup: HostsBackupStore(backupDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString), readLiveHosts: live),
+            readLiveHosts: live,
+            debounceInterval: .milliseconds(1))
+        mgr.bootstrap(modelContainer: container)
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        let profile = mgr.profiles[0]
+        await mgr.setActive(profile, true)
+        // A failed read must never destroy the system file: no write may be issued.
+        XCTAssertEqual(mock.writeCount, 0, "A failed /etc/hosts read must abort before any write")
+        XCTAssertNotNil(mgr.lastError, "lastError must surface the read failure")
+    }
+
     // MARK: - Fix 3: backup failure surfaced but write proceeds
 
     func test_backupFailure_surfacedButWriteProceeds() async throws {

--- a/Tests/AnyDoorTests/HostsManagerTests.swift
+++ b/Tests/AnyDoorTests/HostsManagerTests.swift
@@ -183,6 +183,37 @@ final class HostsManagerTests: XCTestCase {
         XCTAssertNotNil(mgr.lastError, "lastError must surface the read failure")
     }
 
+    // MARK: - Fix 2: deleting an active profile survives a failed system write
+
+    func test_deleteActiveProfile_failedWrite_keepsRow_restoresActive() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        await mgr.setActive(mgr.profiles[0], true)
+        XCTAssertEqual(mock.writeCount, 1)
+        // The delete's block-removal write fails.
+        mock.errorToThrow = HostsWriterError.writeFailed("denied")
+        await mgr.deleteProfile(mgr.profiles[0])
+        // Row must survive so its block is not orphaned in /etc/hosts.
+        XCTAssertEqual(mgr.profiles.count, 1, "Profile must survive a failed system write")
+        XCTAssertTrue(mgr.profiles[0].isActive, "Active state must be restored on failed delete")
+        XCTAssertNotNil(mgr.lastError, "lastError must surface the write failure")
+    }
+
+    func test_deleteActiveProfile_successfulWrite_removesRowAndBlock() async throws {
+        let mock = MockHostsWriter()
+        let (mgr, _) = try makeManager(writer: mock,
+                                       live: { mock.lastWritten ?? "127.0.0.1 localhost\n" })
+        mgr.createProfile(name: "Dev", content: "1.2.3.4 dev")
+        await mgr.setActive(mgr.profiles[0], true)
+        await mgr.deleteProfile(mgr.profiles[0])
+        XCTAssertEqual(mgr.profiles.count, 0)
+        let written = try XCTUnwrap(mock.lastWritten)
+        XCTAssertFalse(written.contains(HostsFile.beginMarker), "Managed block removed on delete")
+        XCTAssertTrue(written.contains("127.0.0.1 localhost"))
+    }
+
     // MARK: - Fix 3: backup failure surfaced but write proceeds
 
     func test_backupFailure_surfacedButWriteProceeds() async throws {

--- a/Tests/AnyDoorTests/HyperKeyControllerTests.swift
+++ b/Tests/AnyDoorTests/HyperKeyControllerTests.swift
@@ -46,6 +46,30 @@ final class HyperKeyControllerTests: XCTestCase {
         }
     }
 
+    func testGetFailureRollsBackPersistedOwnership() async throws {
+        let runner = FakeCommandRunner()
+        runner.responses = [
+            // first apply: GET (empty) + SET (ok)
+            CommandResult(stdout: "(null)\n", stderr: "", exitCode: 0),
+            CommandResult(stdout: "", stderr: "", exitCode: 0),
+            // second apply: GET fails — hidutil never mutated, no SET
+            CommandResult(stdout: "", stderr: "boom", exitCode: 1),
+        ]
+        let controller = HyperKeyController(runner: runner)
+        let first = try await controller.apply(trigger: .capsLock, virtualKey: .f19)
+
+        do {
+            _ = try await controller.apply(trigger: .leftControl, virtualKey: .f19)
+            XCTFail("expected throw")
+        } catch {
+            // A failed GET means hidutil is unchanged, so the pre-persisted signature
+            // must be rolled back to the prior state — not left dangling.
+            let data = UserDefaults.standard.data(forKey: "hyperKey.ownedSignatures")!
+            let set = try JSONDecoder().decode(OwnedSignatures.self, from: data)
+            XCTAssertEqual(set, [first])
+        }
+    }
+
     func testApplyRevertsPersistedSetOnSetFailure() async throws {
         let runner = FakeCommandRunner()
         runner.responses = [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,6 +23,12 @@ DIST="$REPO_ROOT/dist"
 ARCHIVE="$REPO_ROOT/scripts/release-archive"
 SPARKLE_BIN="$REPO_ROOT/scripts/sparkle-bin"
 
+# Minimum macOS version stamped into the binary's LC_BUILD_VERSION `minos`
+# field via the platform_version override in the build step. Must stay in sync
+# with Package.swift's `.macOS` platform and Info.plist's LSMinimumSystemVersion;
+# the preflight asserts all three agree.
+MIN_MACOS="14.0"
+
 log() { printf '\033[1;34m▸\033[0m %s\n' "$*" >&2; }
 die() { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
 
@@ -81,6 +87,19 @@ gh auth status -h github.com >/dev/null 2>&1 || die "gh CLI is not authenticated
 command -v create-dmg >/dev/null 2>&1 \
   || die "create-dmg not found in PATH — run: brew install create-dmg"
 
+# The build step force-overrides LC_BUILD_VERSION `minos` to MIN_MACOS via
+# `-platform_version`. The linker applies that value unconditionally (only a
+# warning if the compiled objects target a newer min), so a Package.swift
+# platform bump would otherwise silently ship a binary claiming to support an
+# older macOS than the code was built for. Assert the three min-OS declarations
+# stay in lockstep so any bump must touch all of them together.
+MIN_MACOS_MAJOR="${MIN_MACOS%%.*}"
+grep -q "\.macOS(\.v${MIN_MACOS_MAJOR})" Package.swift \
+  || die "Package.swift platform does not match MIN_MACOS ($MIN_MACOS) — update MIN_MACOS in scripts/release.sh, Package.swift's .macOS(...), and Info.plist LSMinimumSystemVersion together"
+plist_min="$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" Info.plist 2>/dev/null || true)"
+[[ "$plist_min" == "$MIN_MACOS" ]] \
+  || die "Info.plist LSMinimumSystemVersion ($plist_min) does not match MIN_MACOS ($MIN_MACOS) — update MIN_MACOS in scripts/release.sh, Package.swift's .macOS(...), and Info.plist LSMinimumSystemVersion together"
+
 # --- 2. Resolve version --------------------------------------------------
 LAST_STEP=2
 RECOVERY_HINT="nothing to undo; version not yet written"
@@ -138,11 +157,13 @@ RECOVERY_HINT="git checkout -- Info.plist CHANGELOG.md && rm -rf dist/"
 # (the `native` backend writes the real SDK). On macOS 26 (Tahoe) the system
 # gates the modern window appearance on the linked SDK version (>= 26): a
 # 14.0 `sdk` field forces the app into the legacy, washed-out appearance.
-# Override `platform_version` so the binary records minos 14.0 (still runs on
-# macOS 14+) but the real SDK version, restoring the intended appearance.
+# Override `platform_version` so the binary records minos MIN_MACOS (still runs
+# on that macOS and later) but the real SDK version, restoring the intended
+# appearance. The preflight guarantees MIN_MACOS matches Package.swift and
+# Info.plist, so this override can't understate the supported minimum.
 MACOS_SDK_VERSION="$(xcrun --show-sdk-version --sdk macosx)"
 BUILD_FLAGS=(--build-system swiftbuild --arch arm64 --arch x86_64
-    -Xlinker -platform_version -Xlinker macos -Xlinker 14.0 -Xlinker "$MACOS_SDK_VERSION")
+    -Xlinker -platform_version -Xlinker macos -Xlinker "$MIN_MACOS" -Xlinker "$MACOS_SDK_VERSION")
 log "swift build -c release (universal: arm64 + x86_64)"
 swift build -c release "${BUILD_FLAGS[@]}"
 


### PR DESCRIPTION
## Summary

- Hosts: abort apply (instead of falling back to an empty string) when `/etc/hosts` can't be read; delete an active profile's row only after its deactivation write is applied and verified, guarding against a coalesced `scheduleApply()` result that can misreport success.
- Clipboard: capture a deleted item's on-disk payload names before removing the row, delete the files only after the row save is confirmed, and roll back the pending deletion if the save fails.
- Hyper Key: roll back the persisted `hyperKey.ownedSignatures` entry when a `hidutil` GET fails, not just when SET was reached.
- UI polish: clipboard wall source-app icon resolved synchronously (fixes intermittent blank icons after fast scrolling), focus ring removed from the wall's source-filter trigger, and wall cards enlarged (190→230) with larger preview/snippet text.
- CHANGELOG.md updated under `[Unreleased]` for all of the above.

## Test plan

- [x] `swift test --filter 'HostsManagerTests|ClipboardHistoryStoreTests|HyperKeyControllerTests'` — 47/47 passing
- [x] Manual smoke test of Hosts profile activate/delete and clipboard wall in a running build