### PR TITLE
feat(settings): rebuild Settings window as System Settings-style sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ Sources/AnyDoor/
     ├── Clipboard    ClipboardWall* / ClipboardHistory* / ClipboardCardView
     ├── Cmd Palette  CommandPalettePicker / SpotlightAppPicker (+ WindowController)
     ├── Hosts/       HostsEditorView / PlainTextEditor / HelperApprovalBanner
-    ├── Settings     SettingsView (TabView: Panel + Clipboard + Capture + Translation + General) /
+    ├── Settings     SettingsView (System Settings-style NavigationSplitView: fixed sidebar with
+    │                Panel + Clipboard + Capture + Translation + General, traffic lights inside the
+    │                sidebar; see the chrome notes in SettingsView.swift) /
     │                PanelSettingsView / CaptureSettingsView / TranslationSettingsView /
     │                GeneralSettingsView (embeds SyncSettingsView as a section)
     ├── ImageConv    ImageConversionWindowController / ImageConversionView

--- a/Sources/AnyDoor/AnyDoor.swift
+++ b/Sources/AnyDoor/AnyDoor.swift
@@ -19,5 +19,11 @@ struct AnyDoorApp: App {
                 .environment(appDelegate.localizationManager)
                 .environment(\.locale, appDelegate.localizationManager.effectiveLocale)
         }
+        // System Settings-style chrome: no title-bar strip — the sidebar spans
+        // the window's full height and the traffic lights sit on top of it.
+        // Setting the AppKit flags directly on the NSWindow does NOT achieve
+        // this (SwiftUI still reserves the title-bar safe area); only the
+        // scene-level window style extends the layout into that region.
+        .windowStyle(.hiddenTitleBar)
     }
 }

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -237,35 +237,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         bootstrapUpdater()
         installSettingsOpenerCapture()
 
-        #if DEBUG
-        // Dev-only: `swift run AnyDoor --open-settings[=<tab>]` opens the
-        // Settings window right after launch, so Settings UI work can be
-        // iterated on without clicking through the menu-bar item. The short
-        // delay lets the off-screen capture view resolve `\.openSettings`.
-        if let arg = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix("--open-settings") }) {
-            let tab = arg.split(separator: "=").last.flatMap { SettingsTab(rawValue: String($0)) }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                if let tab {
-                    SettingsOpener.shared.tryOpen(tab: tab)
-                } else {
-                    SettingsOpener.shared.tryOpen()
-                }
-            }
-        }
-        // Dev-only: dump the Settings window's AppKit view tree (frames and
-        // private decoration views included) to /tmp for chrome debugging.
-        if ProcessInfo.processInfo.arguments.contains("--dump-settings-views") {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                guard let window = NSApp.windows.first(where: { $0.frame.width == 680 }),
-                      let frameView = window.contentView?.superview,
-                      let desc = frameView.perform(Selector(("_subtreeDescription")))?
-                          .takeUnretainedValue() as? String
-                else { return }
-                try? desc.write(toFile: "/tmp/settings-views.txt", atomically: true, encoding: .utf8)
-            }
-        }
-        #endif
-
         // First-run onboarding. Shows once on a clean install; afterwards it is
         // only reachable from Settings (the window opts out of state restoration
         // and reverts the app to `.accessory` when closed).

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -237,6 +237,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         bootstrapUpdater()
         installSettingsOpenerCapture()
 
+        #if DEBUG
+        // Dev-only: `swift run AnyDoor --open-settings[=<tab>]` opens the
+        // Settings window right after launch, so Settings UI work can be
+        // iterated on without clicking through the menu-bar item. The short
+        // delay lets the off-screen capture view resolve `\.openSettings`.
+        if let arg = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix("--open-settings") }) {
+            let tab = arg.split(separator: "=").last.flatMap { SettingsTab(rawValue: String($0)) }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if let tab {
+                    SettingsOpener.shared.tryOpen(tab: tab)
+                } else {
+                    SettingsOpener.shared.tryOpen()
+                }
+            }
+        }
+        #endif
+
         // First-run onboarding. Shows once on a clean install; afterwards it is
         // only reachable from Settings (the window opts out of state restoration
         // and reverts the app to `.accessory` when closed).

--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -252,6 +252,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+        // Dev-only: dump the Settings window's AppKit view tree (frames and
+        // private decoration views included) to /tmp for chrome debugging.
+        if ProcessInfo.processInfo.arguments.contains("--dump-settings-views") {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                guard let window = NSApp.windows.first(where: { $0.frame.width == 680 }),
+                      let frameView = window.contentView?.superview,
+                      let desc = frameView.perform(Selector(("_subtreeDescription")))?
+                          .takeUnretainedValue() as? String
+                else { return }
+                try? desc.write(toFile: "/tmp/settings-views.txt", atomically: true, encoding: .utf8)
+            }
+        }
         #endif
 
         // First-run onboarding. Shows once on a clean install; afterwards it is

--- a/Sources/AnyDoor/Services/SettingsOpener.swift
+++ b/Sources/AnyDoor/Services/SettingsOpener.swift
@@ -2,10 +2,10 @@ import AppKit
 import Observation
 import SwiftUI
 
-/// Stable identifiers for the Settings `TabView` tabs, so callers can deep-link
-/// to a specific tab (e.g. the translation gear button) instead of landing on
-/// whatever tab was last open.
-enum SettingsTab: String, Hashable {
+/// Stable identifiers for the Settings sidebar panes, so callers can deep-link
+/// to a specific pane (e.g. the translation gear button) instead of landing on
+/// whatever pane was last open.
+enum SettingsTab: String, Hashable, CaseIterable {
     case panel
     case clipboard
     case capture
@@ -29,7 +29,7 @@ final class SettingsOpener {
     @ObservationIgnored var open: (() -> Void)?
 
     /// The tab `SettingsView` should select. `nil` leaves the last-open tab.
-    /// Observed by `SettingsView`'s `TabView` selection binding.
+    /// Observed by `SettingsView`'s sidebar selection binding.
     var desiredTab: SettingsTab?
 
     func tryOpen() {

--- a/Sources/AnyDoor/Views/SettingsView.swift
+++ b/Sources/AnyDoor/Views/SettingsView.swift
@@ -24,6 +24,13 @@ struct SettingsView: View {
                 }
             }
             .listStyle(.sidebar)
+            // Taller card header: System Settings starts the sidebar content
+            // ~63pt below the window top (measured), giving the traffic
+            // lights a roomier header zone than the split view's built-in
+            // ~48pt toolbar clearance provides.
+            .safeAreaInset(edge: .top, spacing: 0) {
+                Color.clear.frame(height: 14)
+            }
             .navigationSplitViewColumnWidth(180)
             // The sidebar is the window's whole navigation — collapsing it
             // would strand the user, so drop the toggle button.
@@ -71,6 +78,7 @@ struct SettingsView: View {
         // stays reachable (Dock / Cmd-Tab) instead of vanishing when the user
         // focuses another app.
         .background(RegularWindowRegistrar())
+        .background(TrafficLightLayout(headerHeight: 52))
         .focusEffectDisabled()
     }
 
@@ -95,6 +103,91 @@ struct SettingsView: View {
         case .capture: CaptureSettingsView()
         case .translation: TranslationSettingsView()
         case .general: GeneralSettingsView()
+        }
+    }
+}
+
+/// Lowers the traffic lights into the sidebar card's header, System
+/// Settings-style: the standard title bar centers them ~16pt down, hugging the
+/// card's top edge, while System Settings centers them in a taller (~52pt)
+/// header row. There is no public knob for this (`toolbarStyle = .unified` is
+/// ignored in hiddenTitleBar windows), so this uses the same technique as
+/// Electron's `trafficLightPosition`: grow the title-bar container view and
+/// re-center the three buttons inside it, re-applying whenever AppKit re-lays
+/// the title bar out. Only subview frames are touched — never the window
+/// frame, which would loop against the scene's sizing (see the frame trick at
+/// the end of `SettingsView.body`).
+private struct TrafficLightLayout: NSViewRepresentable {
+    let headerHeight: CGFloat
+
+    func makeNSView(context: Context) -> TrackingView {
+        let view = TrackingView()
+        view.headerHeight = headerHeight
+        return view
+    }
+
+    func updateNSView(_ nsView: TrackingView, context: Context) {
+        nsView.headerHeight = headerHeight
+    }
+
+    final class TrackingView: NSView {
+        var headerHeight: CGFloat = 52
+
+        // nonisolated(unsafe): only touched on the main thread — written in
+        // viewDidMoveToWindow, read in deinit after all other refs are gone.
+        private nonisolated(unsafe) var observers: [NSObjectProtocol] = []
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            observers.forEach { NotificationCenter.default.removeObserver($0) }
+            observers = []
+            guard let window else { return }
+            layout(window)
+            // AppKit re-lays the title bar out on these; win the last word.
+            let names: [Notification.Name] = [
+                NSWindow.didResizeNotification,
+                NSWindow.didBecomeKeyNotification,
+                NSWindow.didResignKeyNotification,
+            ]
+            observers = names.map { name in
+                NotificationCenter.default.addObserver(
+                    forName: name, object: window, queue: .main
+                ) { [weak self] notification in
+                    guard let window = notification.object as? NSWindow else { return }
+                    // Same main-thread dance as RegularWindowCoordinator.
+                    MainThreadIsolation.run { self?.layout(window) }
+                }
+            }
+        }
+
+        deinit {
+            observers.forEach { NotificationCenter.default.removeObserver($0) }
+        }
+
+        private func layout(_ window: NSWindow) {
+            let buttons: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+            guard let titlebarView = window.standardWindowButton(.closeButton)?.superview,
+                  let container = titlebarView.superview else { return }
+
+            // Grow the title-bar container downward from the window's top edge
+            // so the lowered buttons stay inside it (hit-testing is bounded by
+            // the container's frame).
+            var containerFrame = container.frame
+            containerFrame.origin.y = window.frame.height - headerHeight
+            containerFrame.size.height = headerHeight
+            container.frame = containerFrame
+
+            var titlebarFrame = titlebarView.frame
+            titlebarFrame.size.height = headerHeight
+            titlebarFrame.origin.y = 0
+            titlebarView.frame = titlebarFrame
+
+            for type in buttons {
+                guard let button = window.standardWindowButton(type) else { continue }
+                var frame = button.frame
+                frame.origin.y = (headerHeight - frame.height) / 2
+                button.setFrameOrigin(frame.origin)
+            }
         }
     }
 }

--- a/Sources/AnyDoor/Views/SettingsView.swift
+++ b/Sources/AnyDoor/Views/SettingsView.swift
@@ -1,40 +1,34 @@
 import SwiftUI
 
+/// System Settings-style Settings window: a fixed-width, non-collapsible
+/// sidebar on the left with the traffic lights sitting inside the sidebar
+/// column, and the selected pane on the right. On macOS 26 the sidebar renders
+/// as the floating Liquid Glass card; earlier systems fall back to the classic
+/// full-height sidebar material (the Ventura–Sequoia System Settings look).
 struct SettingsView: View {
     @State private var opener = SettingsOpener.shared
     @State private var selectedTab: SettingsTab = .panel
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            PanelSettingsView()
-                .tabItem {
-                    Label { LocalizedText(.settingsTabPanel) } icon: { Image(systemName: "rectangle.stack") }
+        NavigationSplitView {
+            List(selection: $selectedTab) {
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    sidebarRow(tab)
                 }
-                .tag(SettingsTab.panel)
-
-            ClipboardSettingsView()
-                .tabItem {
-                    Label { LocalizedText(.settingsTabClipboard) } icon: { Image(systemName: "doc.on.clipboard") }
-                }
-                .tag(SettingsTab.clipboard)
-
-            CaptureSettingsView()
-                .tabItem {
-                    Label { LocalizedText(.settingsTabCapture) } icon: { Image(systemName: "camera.viewfinder") }
-                }
-                .tag(SettingsTab.capture)
-
-            TranslationSettingsView()
-                .tabItem {
-                    Label { LocalizedText(.settingsTabTranslation) } icon: { Image(systemName: "character.bubble") }
-                }
-                .tag(SettingsTab.translation)
-
-            GeneralSettingsView()
-                .tabItem {
-                    Label { LocalizedText(.settingsTabGeneral) } icon: { Image(systemName: "gear") }
-                }
-                .tag(SettingsTab.general)
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(180)
+            // The sidebar is the window's whole navigation — collapsing it
+            // would strand the user, so drop the toggle button.
+            .toolbar(removing: .sidebarToggle)
+        } detail: {
+            detailView
+                // The pane name, like pre-26 System Settings shows in its
+                // detail toolbar. On macOS 26 System Settings shows no toolbar
+                // title, so remove the item there — but keep the title set:
+                // it still names the window (Window menu, accessibility).
+                .navigationTitle(L(selectedTab.titleKey))
+                .modifier(RemoveToolbarTitleOnTahoe())
         }
         // Honor a deep-link request (e.g. the translation gear) then clear it so
         // a later plain open lands on the last-selected tab.
@@ -49,11 +43,91 @@ struct SettingsView: View {
                 opener.desiredTab = nil
             }
         }
-        .frame(width: 560, height: 480)
+        // Fixed width, flexible height: the window stays vertically resizable
+        // like System Settings.
+        .frame(width: 680)
+        .frame(minHeight: 480, idealHeight: 480)
         // Adopt .regular activation policy while Settings is open so the window
         // stays reachable (Dock / Cmd-Tab) instead of vanishing when the user
         // focuses another app.
         .background(RegularWindowRegistrar())
         .focusEffectDisabled()
+    }
+
+    /// System Settings-style row: a small colored icon tile + title.
+    private func sidebarRow(_ tab: SettingsTab) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: tab.systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 24, height: 24)
+                .background(tab.iconColor.gradient, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            LocalizedText(tab.titleKey)
+        }
+        .tag(tab)
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch selectedTab {
+        case .panel: PanelSettingsView()
+        case .clipboard: ClipboardSettingsView()
+        case .capture: CaptureSettingsView()
+        case .translation: TranslationSettingsView()
+        case .general: GeneralSettingsView()
+        }
+    }
+}
+
+/// Drops the toolbar title item on macOS 26, matching Tahoe System Settings.
+/// Do NOT reach for `.navigationTitle("")` or `.toolbarBackground(.hidden)`
+/// instead: both collapse the unified toolbar, which pushes the whole split
+/// view below the title-bar region and strands the traffic lights on a bare
+/// strip above the sidebar card.
+private struct RemoveToolbarTitleOnTahoe: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content
+                .toolbar(removing: .title)
+                // Also drop the toolbar's background so the hairline over the
+                // detail column disappears, like Tahoe System Settings. Note
+                // this is the macOS 26 `toolbarBackgroundVisibility`, NOT the
+                // older `toolbarBackground(.hidden,)` — see above.
+                .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
+        } else {
+            content
+        }
+    }
+}
+
+private extension SettingsTab {
+    var titleKey: L10n.Key {
+        switch self {
+        case .panel: .settingsTabPanel
+        case .clipboard: .settingsTabClipboard
+        case .capture: .settingsTabCapture
+        case .translation: .settingsTabTranslation
+        case .general: .settingsTabGeneral
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .panel: "rectangle.stack"
+        case .clipboard: "doc.on.clipboard"
+        case .capture: "camera.viewfinder"
+        case .translation: "character.bubble"
+        case .general: "gear"
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .panel: .blue
+        case .clipboard: .orange
+        case .capture: .purple
+        case .translation: .teal
+        case .general: .gray
+        }
     }
 }

--- a/Sources/AnyDoor/Views/SettingsView.swift
+++ b/Sources/AnyDoor/Views/SettingsView.swift
@@ -9,6 +9,13 @@ struct SettingsView: View {
     @State private var opener = SettingsOpener.shared
     @State private var selectedTab: SettingsTab = .panel
 
+    /// Full window height, title-bar region included — the root view spans the
+    /// whole window (see the frame trick at the end of `body`).
+    static let contentHeight: CGFloat = 512
+    /// The extra height the Settings scene adds to the reported layout height
+    /// when sizing its window — the hidden title bar's region.
+    static let titleBarAccommodation: CGFloat = 32
+
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedTab) {
@@ -43,10 +50,23 @@ struct SettingsView: View {
                 opener.desiredTab = nil
             }
         }
-        // Fixed width, flexible height: the window stays vertically resizable
-        // like System Settings.
-        .frame(width: 680)
-        .frame(minHeight: 480, idealHeight: 480)
+        // System Settings-style chrome, part 2 (part 1 is the scene-level
+        // .hiddenTitleBar): the sidebar's glass card must reach the window's
+        // top edge and WRAP the traffic lights. SwiftUI fights this two ways:
+        // the scene always sizes the window to the root's layout height PLUS a
+        // 32pt title-bar accommodation, and it lays the root out below that
+        // region (ignoresSafeArea is a dead end: a flexible root just clamps
+        // to the safe-area proposal, a fixed root leaves a 32pt dead band at
+        // the bottom, and correcting the window frame from AppKit loops
+        // against NSHostingView.updateAnimatedWindowSize until AppKit throws).
+        //
+        // So render taller than we report: the inner frame is the real size —
+        // the full window, title bar included — and the outer frame reports a
+        // layout height 32pt shorter, so the scene opens the window at exactly
+        // contentHeight. Bottom alignment makes the overflow stick out the
+        // TOP, covering the title-bar region (SwiftUI doesn't clip frames).
+        .frame(width: 680, height: Self.contentHeight)
+        .frame(height: Self.contentHeight - Self.titleBarAccommodation, alignment: .bottom)
         // Adopt .regular activation policy while Settings is open so the window
         // stays reachable (Dock / Cmd-Tab) instead of vanishing when the user
         // focuses another app.

--- a/Sources/AnyDoor/Views/SettingsView.swift
+++ b/Sources/AnyDoor/Views/SettingsView.swift
@@ -24,10 +24,9 @@ struct SettingsView: View {
                 }
             }
             .listStyle(.sidebar)
-            // Taller card header: System Settings starts the sidebar content
-            // ~63pt below the window top (measured), giving the traffic
-            // lights a roomier header zone than the split view's built-in
-            // ~48pt toolbar clearance provides.
+            // Clearance between the traffic lights (lowered to y=17 by
+            // TrafficLightPosition) and the first row — without it the rows
+            // start at ~33pt and collide with the lights.
             .safeAreaInset(edge: .top, spacing: 0) {
                 Color.clear.frame(height: 14)
             }
@@ -78,7 +77,7 @@ struct SettingsView: View {
         // stays reachable (Dock / Cmd-Tab) instead of vanishing when the user
         // focuses another app.
         .background(RegularWindowRegistrar())
-        .background(TrafficLightLayout(headerHeight: 52))
+        .background(TrafficLightPosition())
         .focusEffectDisabled()
     }
 
@@ -107,32 +106,30 @@ struct SettingsView: View {
     }
 }
 
-/// Lowers the traffic lights into the sidebar card's header, System
-/// Settings-style: the standard title bar centers them ~16pt down, hugging the
-/// card's top edge, while System Settings centers them in a taller (~52pt)
-/// header row. There is no public knob for this (`toolbarStyle = .unified` is
-/// ignored in hiddenTitleBar windows), so this uses the same technique as
-/// Electron's `trafficLightPosition`: grow the title-bar container view and
-/// re-center the three buttons inside it, re-applying whenever AppKit re-lays
-/// the title bar out. Only subview frames are touched — never the window
-/// frame, which would loop against the scene's sizing (see the frame trick at
-/// the end of `SettingsView.body`).
-private struct TrafficLightLayout: NSViewRepresentable {
-    let headerHeight: CGFloat
+/// Moves the traffic lights down and right into the sidebar card's header,
+/// matching System Settings (its buttons sit at ~(18, 18) from the window's
+/// top-left; the default title bar puts them at ~(8, 8), hugging the card's
+/// corner). Only the three buttons' frame origins are translated. Do NOT grow
+/// the title-bar container / title-bar view instead: the sidebar column lays
+/// its glass card out below an internal NSTitlebarBackgroundView whose height
+/// tracks the container, so a taller container pushes the card's top edge
+/// below the buttons — exactly the wrap effect this window is built around.
+/// (And never touch the window frame: that loops against the scene's sizing —
+/// see the frame trick at the end of `SettingsView.body`.)
+private struct TrafficLightPosition: NSViewRepresentable {
+    /// Target distance from the window's top-left corner to the close
+    /// button's top-left corner (measured from System Settings on macOS 26).
+    private static let inset = CGPoint(x: 17, y: 17)
+    /// The sidebar glass card's corner radius (the system default is 8).
+    static let cardCornerRadius: CGFloat = 16
 
     func makeNSView(context: Context) -> TrackingView {
-        let view = TrackingView()
-        view.headerHeight = headerHeight
-        return view
+        TrackingView()
     }
 
-    func updateNSView(_ nsView: TrackingView, context: Context) {
-        nsView.headerHeight = headerHeight
-    }
+    func updateNSView(_ nsView: TrackingView, context: Context) {}
 
     final class TrackingView: NSView {
-        var headerHeight: CGFloat = 52
-
         // nonisolated(unsafe): only touched on the main thread — written in
         // viewDidMoveToWindow, read in deinit after all other refs are gone.
         private nonisolated(unsafe) var observers: [NSObjectProtocol] = []
@@ -142,8 +139,10 @@ private struct TrafficLightLayout: NSViewRepresentable {
             observers.forEach { NotificationCenter.default.removeObserver($0) }
             observers = []
             guard let window else { return }
-            layout(window)
-            // AppKit re-lays the title bar out on these; win the last word.
+            Self.layout(window)
+            // AppKit re-lays the buttons out on these; win the last word.
+            // (layout is a translation by the remaining delta, so re-applying
+            // when already in place is a no-op.)
             let names: [Notification.Name] = [
                 NSWindow.didResizeNotification,
                 NSWindow.didBecomeKeyNotification,
@@ -152,10 +151,10 @@ private struct TrafficLightLayout: NSViewRepresentable {
             observers = names.map { name in
                 NotificationCenter.default.addObserver(
                     forName: name, object: window, queue: .main
-                ) { [weak self] notification in
+                ) { notification in
                     guard let window = notification.object as? NSWindow else { return }
                     // Same main-thread dance as RegularWindowCoordinator.
-                    MainThreadIsolation.run { self?.layout(window) }
+                    MainThreadIsolation.run { Self.layout(window) }
                 }
             }
         }
@@ -164,29 +163,57 @@ private struct TrafficLightLayout: NSViewRepresentable {
             observers.forEach { NotificationCenter.default.removeObserver($0) }
         }
 
-        private func layout(_ window: NSWindow) {
-            let buttons: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
-            guard let titlebarView = window.standardWindowButton(.closeButton)?.superview,
-                  let container = titlebarView.superview else { return }
+        private static func applyCornerRadii(_ window: NSWindow) {
+            guard #available(macOS 26.0, *) else { return }
+            // The WINDOW's corner radius is intentionally left stock (16pt;
+            // System Settings uses ~26.5pt). There is no public NSWindow API,
+            // and every private route leaves the shape inconsistent or
+            // crashes: the frame view's radius setter only rounds the content
+            // (rim + shadow keep the old radius → notched corners), a
+            // transparent window clipped in SwiftUI leaves the same rim and
+            // shadow-hole artifacts, and a runtime subclass of the theme
+            // frame overriding `_cornerRadius` trips AppKit's
+            // NSDynamicProperties assertion at launch.
+            //
+            // Sidebar glass card: public NSGlassEffectView API.
+            if let contentView = window.contentView,
+               let card = findConcentricGlass(in: contentView) as? NSGlassEffectView,
+               card.cornerRadius != TrafficLightPosition.cardCornerRadius {
+                card.cornerRadius = TrafficLightPosition.cardCornerRadius
+            }
+        }
 
-            // Grow the title-bar container downward from the window's top edge
-            // so the lowered buttons stay inside it (hit-testing is bounded by
-            // the container's frame).
-            var containerFrame = container.frame
-            containerFrame.origin.y = window.frame.height - headerHeight
-            containerFrame.size.height = headerHeight
-            container.frame = containerFrame
+        private static func findConcentricGlass(in view: NSView) -> NSView? {
+            if String(describing: type(of: view)).contains("ConcentricGlassEffectView") { return view }
+            for sub in view.subviews {
+                if let hit = findConcentricGlass(in: sub) { return hit }
+            }
+            return nil
+        }
 
-            var titlebarFrame = titlebarView.frame
-            titlebarFrame.size.height = headerHeight
-            titlebarFrame.origin.y = 0
-            titlebarView.frame = titlebarFrame
-
-            for type in buttons {
+        private static func layout(_ window: NSWindow) {
+            // System Settings carries the resizable style bit (it renders the
+            // zoom button in color instead of disabled-gray). It does not
+            // actually make the window user-resizable: the scene pins the
+            // content size to the fixed root frame.
+            window.styleMask.insert(.resizable)
+            applyCornerRadii(window)
+            guard let close = window.standardWindowButton(.closeButton),
+                  let superview = close.superview else { return }
+            // Current distance from the window's top-left to the close
+            // button's top-left, robust against superview flippedness.
+            let currentTop = superview.isFlipped
+                ? close.frame.minY
+                : superview.bounds.height - close.frame.maxY
+            let dx = TrafficLightPosition.inset.x - close.frame.minX
+            let dTop = TrafficLightPosition.inset.y - currentTop
+            guard dx != 0 || dTop != 0 else { return }
+            for type in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
                 guard let button = window.standardWindowButton(type) else { continue }
-                var frame = button.frame
-                frame.origin.y = (headerHeight - frame.height) / 2
-                button.setFrameOrigin(frame.origin)
+                var origin = button.frame.origin
+                origin.x += dx
+                origin.y += superview.isFlipped ? dTop : -dTop
+                button.setFrameOrigin(origin)
             }
         }
     }


### PR DESCRIPTION
## Summary

Rebuild the Settings window to match macOS System Settings: a fixed-width, non-collapsible left sidebar with the traffic lights sitting inside the sidebar's glass card, and the selected pane on the right. Replaces the old `TabView` layout with a `NavigationSplitView`.

## Changes

- Replace the Settings `TabView` with a `NavigationSplitView`: fixed 180pt sidebar (`List(selection:)` over `SettingsTab`), non-collapsible (sidebar toggle removed), colored icon tiles per pane.
- Extend the sidebar glass card to the window's top edge so it wraps the traffic lights, using a "render taller than reported" frame trick (the scene sizes the window to layout height + a title-bar accommodation; bottom-aligned overflow covers the title-bar region).
- Add `.windowStyle(.hiddenTitleBar)` at the Settings scene so layout extends into the title-bar region (setting AppKit flags on the `NSWindow` alone does not).
- Lower the traffic lights to (17, 17) from the window's top-left by translating the three buttons' frame origins (not by growing the title-bar container, which would push the card top edge below the buttons).
- Round the sidebar glass card to 16pt via the public `NSGlassEffectView.cornerRadius`.
- Drop the toolbar title and background on macOS 26 (`toolbar(removing: .title)` + `toolbarBackgroundVisibility(.hidden,)`), gated behind `#available(macOS 26.0, *)`; earlier systems fall back to the classic full-height sidebar look.
- The window corner radius is left stock: no public NSWindow API exists, and every private route either leaves notched corners / shadow artifacts or trips an AppKit assertion at launch (documented inline).
- `SettingsTab` moved to a shared `String, Hashable, CaseIterable` enum so callers can deep-link to a pane.

## Notes

- macOS 26-specific chrome is gated behind availability checks; the layout degrades gracefully on macOS 14+.
- Verified with `swift build` and the full test suite (126 suites, 0 failures).