### PR TITLE
feat(clipboard): explicit search focus for the clipboard wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ versioning.
   workspace — standard chrome with a transparent title bar, the sidebar
   running full height around the traffic lights at their default position —
   and Esc closes it. It stays fixed-size with a non-collapsible sidebar.
+- Clipboard wall: search is now focused explicitly instead of by typing —
+  ⌘F (shown in the hints footer) or a click focuses the field, ⌘F again or ↓
+  hands the keyboard back to the cards keeping the query, and stray typing in
+  card navigation no longer starts a search. Esc remains the staged exit:
+  clear the query first, then close.
 
 ### Removed
 
@@ -67,6 +72,15 @@ versioning.
   app-filtered ScreenCaptureKit stream) could not start their stream: an
   invisible helper window sat outside every display, which makes
   WindowServer mark the app uncapturable. The window now stays on screen.
+- Clipboard wall: the search field's focus flag could diverge from where
+  keys actually landed. Clicking into the field left the wall routing keys
+  to card navigation (⌫ deleted the selected card while the caret sat in
+  the field) and any view refresh could then yank the caret away; the flag
+  now mirrors the field's real first-responder state. The wall also opens
+  reliably unfocused instead of letting AppKit hand initial focus to the
+  field, and reopening the wall no longer severs the controller's field
+  reference (which silently killed keyboard search focus on every open
+  after the first).
 
 ## [3.6.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,9 @@ versioning.
   workspace — standard chrome with a transparent title bar, the sidebar
   running full height around the traffic lights at their default position —
   and Esc closes it. It stays fixed-size with a non-collapsible sidebar.
-- Clipboard wall: search is now focused explicitly instead of by typing —
-  ⌘F (shown in the hints footer) or a click focuses the field, ⌘F again or ↓
-  hands the keyboard back to the cards keeping the query, and stray typing in
-  card navigation no longer starts a search. Esc remains the staged exit:
-  clear the query first, then close.
+- Clipboard wall: search is focused explicitly instead of by typing — ⌘F
+  toggles the field (↓ also returns to the cards, keeping the query), and
+  the shortcut is shown in the hints footer.
 
 ### Removed
 
@@ -72,15 +70,10 @@ versioning.
   app-filtered ScreenCaptureKit stream) could not start their stream: an
   invisible helper window sat outside every display, which makes
   WindowServer mark the app uncapturable. The window now stays on screen.
-- Clipboard wall: the search field's focus flag could diverge from where
-  keys actually landed. Clicking into the field left the wall routing keys
-  to card navigation (⌫ deleted the selected card while the caret sat in
-  the field) and any view refresh could then yank the caret away; the flag
-  now mirrors the field's real first-responder state. The wall also opens
-  reliably unfocused instead of letting AppKit hand initial focus to the
-  field, and reopening the wall no longer severs the controller's field
-  reference (which silently killed keyboard search focus on every open
-  after the first).
+- Clipboard wall: fixed search-focus desyncs — clicking into the field could
+  leave keys acting on the cards (⌫ deleted the selected card), the wall
+  could open with the field pre-focused, and reopening the wall silently
+  broke keyboard search focus.
 
 ## [3.6.0] - 2026-07-10
 

--- a/Sources/AnyDoor/Resources/Localizable.xcstrings
+++ b/Sources/AnyDoor/Resources/Localizable.xcstrings
@@ -2602,6 +2602,23 @@
         }
       }
     },
+    "clipboard.hint.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
+        }
+      }
+    },
     "clipboard.hint.select": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AnyDoor/Utilities/L10n.swift
+++ b/Sources/AnyDoor/Utilities/L10n.swift
@@ -114,6 +114,7 @@ enum L10n {
         case clipboardHintDelete = "clipboard.hint.delete"
         case clipboardHintPastePlain = "clipboard.hint.pastePlain"
         case clipboardHintPreview = "clipboard.hint.preview"
+        case clipboardHintSearch = "clipboard.hint.search"
         case clipboardHintSelect = "clipboard.hint.select"
         case clipboardSearchPlaceholder = "clipboard.search.placeholder"
         case clipboardSourceAll = "clipboard.source.all"

--- a/Sources/AnyDoor/Views/ClipboardWallState.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallState.swift
@@ -61,8 +61,11 @@ final class ClipboardWallState {
     var query: String = ""
     /// Whether the search field currently owns keyboard focus (input mode). When
     /// false the wall is in card-navigation mode: arrow keys move the selection,
-    /// Enter pastes, etc. The window controller flips this to switch modes and
-    /// the `WallSearchField` follows it to grab or release first responder.
+    /// Enter pastes, etc. Two-way: the controller and views write it to command
+    /// a mode switch (WallSearchField grabs/releases first responder to match),
+    /// and the field reports real focus changes (a mouse click into it, the
+    /// editor resigning) back into it — so the flag can never diverge from
+    /// where keys actually land.
     var isSearchFocused: Bool = false
     private(set) var items: [ClipboardHistoryItem] = []
     private(set) var selectedIndex: Int = 0

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -181,6 +181,11 @@ struct ClipboardWallView: View {
             .frame(width: 160)
             .padding(.horizontal, 8).padding(.vertical, 4)
             .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+            // Clicking the box's chrome (the magnifier / padding, outside the
+            // NSTextField itself) focuses the field too; the field consumes
+            // clicks on itself before this gesture sees them.
+            .contentShape(RoundedRectangle(cornerRadius: 8))
+            .onTapGesture { state.isSearchFocused = true }
         }
     }
 
@@ -708,8 +713,12 @@ struct ClipboardWallView: View {
     }
 
     /// Select on the first tap; treat a quick second tap on the same card as a
-    /// double-click and paste.
+    /// double-click and paste. Tapping a card also hands the keyboard back to
+    /// card navigation — a card is not focusable, so without this the search
+    /// field would keep the caret and arrows would move it instead of the
+    /// selection.
     private func handleTap(index: Int, item: ClipboardHistoryItem) {
+        state.isSearchFocused = false
         let now = Date()
         if let last = lastTap, last.index == index,
            now.timeIntervalSince(last.date) <= NSEvent.doubleClickInterval {

--- a/Sources/AnyDoor/Views/ClipboardWallView.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallView.swift
@@ -697,6 +697,7 @@ struct ClipboardWallView: View {
             hint("←→", .clipboardHintSelect)
             hint("⌘←→", .clipboardHintJumpEnds)
             hint("⇥", .clipboardHintCategory)
+            hint("⌘F", .clipboardHintSearch)
             hint("⌘K", .clipboardHintFilterSource)
             hint("⌥", .clipboardHintEditCategories)
             hint("↵", .clipboardHintCopy)

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -67,6 +67,11 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         // Become key as soon as shown so keyboard nav / search work without
         // waiting for a control to demand it.
         panel.becomesKeyOnlyIfNeeded = false
+        // The wall opens in card-navigation mode: never let AppKit's key-view
+        // loop pick the search field as the initial first responder when the
+        // panel becomes key (Tab is intercepted for category cycling, so the
+        // loop is unused anyway).
+        panel.autorecalculatesKeyViewLoop = false
         super.init(window: panel)
         panel.delegate = self
     }
@@ -134,6 +139,10 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         // previously active app active, so it doesn't visibly lose focus while
         // the wall is up (Paste-style). Keyboard nav and search still work.
         window.makeKeyAndOrderFront(nil)
+        // Safety net: if becoming key still handed first responder to the
+        // search field through any path we didn't defeat above, take it back —
+        // the field reports the resign so state ends up in card navigation.
+        if window.firstResponder !== window { window.makeFirstResponder(nil) }
         isAnimating = true
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = Self.animationDuration
@@ -224,6 +233,10 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         host.frame = window?.contentLayoutRect ?? .zero
         host.autoresizingMask = [.width, .height]
         window?.contentView = host
+        // Setting contentView can (re)assign initialFirstResponder to the first
+        // focusable view — the search field — which would auto-focus it the
+        // moment the panel becomes key. The wall must open unfocused.
+        window?.initialFirstResponder = nil
         hostingView = host
     }
 

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -350,8 +350,9 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
                 // Nothing to step back through: close outright, in either mode.
                 dismiss(restoreFocus: true)
             } else if inputMode {
-                // A non-empty query clears first, leaving the field focused.
-                state.query = ""; searchField?.stringValue = ""
+                // A non-empty query clears first, leaving the field focused;
+                // WallSearchField syncs the field text from state.query.
+                state.query = ""
             } else {
                 // Card navigation over a search → return focus to edit/clear it.
                 state.isSearchFocused = true
@@ -462,7 +463,9 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
     /// consumed, so the same press lands in the now-first-responder field —
     /// keeping IME composition intact). Modifier combos and control keys are
     /// ignored. The caret is parked at the end so an existing query is appended
-    /// to rather than replaced.
+    /// to rather than replaced. `state.isSearchFocused` is not written here:
+    /// the field reports the focus change itself, so a refused
+    /// `makeFirstResponder` can no longer strand the state in input mode.
     private func focusSearchOnType(_ event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection([.command, .control, .option, .function])
         guard modifiers.isEmpty,
@@ -477,7 +480,6 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         window?.makeFirstResponder(field)
         let end = (field.stringValue as NSString).length
         field.currentEditor()?.selectedRange = NSRange(location: end, length: 0)
-        state.isSearchFocused = true
         return false
     }
 

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -305,12 +305,12 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
     }
 
     /// Route a key press by mode. In input mode the search field owns most keys
-    /// (text editing + IME), so we only intercept Esc and Enter and let the rest
-    /// fall through to the field; the field's own delegate hands focus back to
-    /// card navigation when → is pressed at the end of a non-empty query. In card
-    /// navigation mode arrows move the selection, Enter pastes, and typing a
-    /// printable character focuses the field (type-to-search). Returns whether
-    /// the event was consumed (a returned event keeps flowing to the field).
+    /// (text editing + IME), so we only intercept Esc, Enter, and ↓ (which hands
+    /// focus back to card navigation) and let the rest fall through to the
+    /// field. In card navigation mode arrows move the selection, Enter pastes,
+    /// and ⌘F focuses the search field — the wall never focuses it implicitly.
+    /// Returns whether the event was consumed (a returned event keeps flowing
+    /// to the field).
     private func handle(_ event: NSEvent) -> Bool {
         guard let window, window.isVisible else { return false }
         // While the tag dialog overlay is up it owns the keyboard: Return
@@ -343,6 +343,13 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             state.requestOpenSourceMenu()
             return true
         }
+        // ⌘F focuses the search field, in both modes (a no-op re-focus while
+        // already in input mode is harmless).
+        if event.modifierFlags.intersection([.command, .control, .option, .shift]) == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "f" {
+            focusSearchField()
+            return true
+        }
         let inputMode = state.isSearchFocused
         switch event.keyCode {
         case 53:                                         // esc — staged exit
@@ -369,10 +376,17 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             else { state.moveLeft() }
             syncTextPreview(); return true
         case 124:                                        // → / ⌘→ (jump to last)
-            if inputMode { return false }                // field delegate may exit
+            if inputMode { return false }                // move the text caret
             if event.modifierFlags.contains(.command) { state.moveToEnd() }
             else { state.moveRight() }
             syncTextPreview(); return true
+        case 125:                                        // ↓ — leave the search field
+            guard inputMode else { return false }
+            // Hand the keyboard back to card navigation. Resign synchronously
+            // (not via state) so the very next keystroke already routes to the
+            // cards; the field reports the focus change into state itself.
+            window.makeFirstResponder(nil)
+            return true
         case 49:                                         // space
             if inputMode { return false }                // insert a space
             togglePreview(); return true
@@ -397,7 +411,10 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             return true
         default:
             if inputMode { return false }                // field inserts / composes
-            return focusSearchOnType(event)
+            // No type-to-search: the field is only focused explicitly (⌘F or a
+            // click). Swallow plain printable keys so stray typing in card
+            // navigation doesn't fall through to the window and beep.
+            return isPlainPrintable(event)
         }
     }
 
@@ -458,29 +475,31 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         return nil
     }
 
-    /// Type-to-search from card navigation: a printable keystroke focuses the
-    /// search field and is then delivered to it (the event is returned, not
-    /// consumed, so the same press lands in the now-first-responder field —
-    /// keeping IME composition intact). Modifier combos and control keys are
-    /// ignored. The caret is parked at the end so an existing query is appended
-    /// to rather than replaced. `state.isSearchFocused` is not written here:
-    /// the field reports the focus change itself, so a refused
-    /// `makeFirstResponder` can no longer strand the state in input mode.
-    private func focusSearchOnType(_ event: NSEvent) -> Bool {
-        let modifiers = event.modifierFlags.intersection([.command, .control, .option, .function])
-        guard modifiers.isEmpty,
-              let characters = event.characters, !characters.isEmpty,
-              characters.unicodeScalars.allSatisfy({ !CharacterSet.controlCharacters.contains($0) }),
-              let field = searchField
-        else { return false }
+    /// ⌘F: enter input mode. Makes the field first responder synchronously (so
+    /// the very next keystroke can start an IME composition in it) with the
+    /// caret parked at the end, appending to any existing query.
+    /// `state.isSearchFocused` is not written here: the field reports the focus
+    /// change itself, so a refused `makeFirstResponder` can never strand the
+    /// state in input mode.
+    private func focusSearchField() {
         // Focus is moving into the search field; a floating preview would now
         // swallow Space/Esc meant for the query, so drop it (it's stale anyway —
         // searching is about to change the selection).
         if ClipboardTextWindow.shared.isPreviewVisible { ClipboardTextWindow.shared.close() }
+        guard let field = searchField else { return }
         window?.makeFirstResponder(field)
         let end = (field.stringValue as NSString).length
         field.currentEditor()?.selectedRange = NSRange(location: end, length: 0)
-        return false
+    }
+
+    /// A bare printable keystroke (no ⌘/⌃/⌥/fn, no control characters) — the
+    /// kind that used to trigger type-to-search and now gets swallowed in card
+    /// navigation.
+    private func isPlainPrintable(_ event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection([.command, .control, .option, .function])
+        guard modifiers.isEmpty,
+              let characters = event.characters, !characters.isEmpty else { return false }
+        return characters.unicodeScalars.allSatisfy { !CharacterSet.controlCharacters.contains($0) }
     }
 
     private func paste(_ item: ClipboardHistoryItem, plain: Bool) {

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -499,7 +499,13 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
         // swallow Space/Esc meant for the query, so drop it (it's stale anyway —
         // searching is about to change the selection).
         if ClipboardTextWindow.shared.isPreviewVisible { ClipboardTextWindow.shared.close() }
-        guard let field = searchField else { return }
+        guard let field = searchField, field.window === window else {
+            // The reference can lag a host rebuild; command focus through
+            // state and let updateNSView grab first responder on the next
+            // render instead of dropping the shortcut.
+            state.isSearchFocused = true
+            return
+        }
         window?.makeFirstResponder(field)
         let end = (field.stringValue as NSString).length
         field.currentEditor()?.selectedRange = NSRange(location: end, length: 0)

--- a/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
+++ b/Sources/AnyDoor/Views/ClipboardWallWindowController.swift
@@ -356,11 +356,16 @@ final class ClipboardWallWindowController: NSWindowController, NSWindowDelegate,
             state.requestOpenSourceMenu()
             return true
         }
-        // ⌘F focuses the search field, in both modes (a no-op re-focus while
-        // already in input mode is harmless).
+        // ⌘F toggles input mode: focus the search field from card navigation,
+        // and hand the keyboard back to the cards when pressed again while the
+        // field is focused — keeping the query (Esc is the one that clears).
         if event.modifierFlags.intersection([.command, .control, .option, .shift]) == .command,
            event.charactersIgnoringModifiers?.lowercased() == "f" {
-            focusSearchField()
+            if state.isSearchFocused {
+                window.makeFirstResponder(nil)
+            } else {
+                focusSearchField()
+            }
             return true
         }
         let inputMode = state.isSearchFocused

--- a/Sources/AnyDoor/Views/WallSearchField.swift
+++ b/Sources/AnyDoor/Views/WallSearchField.swift
@@ -4,9 +4,16 @@ import SwiftUI
 /// A real, focusable search field for the clipboard wall, backed by an
 /// `NSTextField` so an input method editor can compose CJK text — the previous
 /// type-to-search key monitor only saw raw key codes and could never start an
-/// IME composition. Focus is driven by `state.isSearchFocused`: the window
-/// controller decides which mode the wall is in and this view follows, grabbing
-/// or releasing first responder to match.
+/// IME composition.
+///
+/// Focus model: AppKit's first-responder status is the ground truth and
+/// `state.isSearchFocused` mirrors it. The field reports every real focus
+/// transition (a mouse click into the field, the editor resigning) through
+/// `FocusReportingTextField`, and `updateNSView` applies commanded state the
+/// other way only when the two disagree. Keeping a one-way commanded flag here
+/// used to let a mouse click desync the mode — the caret sat in the field while
+/// the controller still routed ⌫/space/arrows to card navigation, and the next
+/// unrelated view update would then yank focus back out of the field.
 struct WallSearchField: NSViewRepresentable {
     @Bindable var state: ClipboardWallState
     /// Hands the underlying field back to the controller. Type-to-focus must
@@ -16,7 +23,7 @@ struct WallSearchField: NSViewRepresentable {
     let registerField: (NSTextField?) -> Void
 
     func makeNSView(context: Context) -> NSTextField {
-        let field = NSTextField()
+        let field = FocusReportingTextField()
         field.delegate = context.coordinator
         field.isBordered = false
         field.drawsBackground = false
@@ -27,15 +34,17 @@ struct WallSearchField: NSViewRepresentable {
         field.usesSingleLineMode = true
         field.cell?.wraps = false
         field.cell?.isScrollable = true
+        let coordinator = context.coordinator
+        field.onFocusChange = { focused in coordinator.focusDidChange(focused) }
         registerField(field)
         return field
     }
 
     func updateNSView(_ field: NSTextField, context: Context) {
         if field.stringValue != state.query { field.stringValue = state.query }
-        // Follow the controller's focus mode. Placing the caret at the end on
-        // focus (rather than NSTextField's default select-all) keeps the query
-        // intact when the next keystroke arrives.
+        // Reconcile commanded focus with reality. Placing the caret at the end
+        // on focus (rather than NSTextField's default select-all) keeps the
+        // query intact when the next keystroke arrives.
         let editing = field.currentEditor() != nil
         if state.isSearchFocused, !editing {
             field.window?.makeFirstResponder(field)
@@ -63,6 +72,15 @@ struct WallSearchField: NSViewRepresentable {
             self.registerField = registerField
         }
 
+        /// Mirror the field's real focus into state so the controller's mode
+        /// routing always matches where keys actually land. The equality guard
+        /// also keeps the reconciliation in `updateNSView` from writing state
+        /// mid-render: by the time it commands a focus change, state already
+        /// holds the value this callback would set.
+        func focusDidChange(_ focused: Bool) {
+            if state.isSearchFocused != focused { state.isSearchFocused = focused }
+        }
+
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
             state.query = field.stringValue
@@ -74,8 +92,10 @@ struct WallSearchField: NSViewRepresentable {
         }
 
         // Intercept the rightward caret move: once the caret sits at the end of a
-        // non-empty query, a further → hands control to card navigation (focus
-        // leaves the field). An empty query keeps focus so the field stays usable.
+        // non-empty query, a further → hands control to card navigation — the
+        // resign flows back into `state.isSearchFocused` via the field's focus
+        // report, so no direct state write here. An empty query keeps focus so
+        // the field stays usable.
         func control(_ control: NSControl, textView: NSTextView,
                      doCommandBy selector: Selector) -> Bool {
             guard selector == #selector(NSResponder.moveRight(_:)) else { return false }
@@ -83,9 +103,29 @@ struct WallSearchField: NSViewRepresentable {
             let selection = textView.selectedRange()
             let caretAtEnd = selection.length == 0 && selection.location >= length
             guard caretAtEnd, !state.query.isEmpty else { return false }
-            state.isSearchFocused = false
             control.window?.makeFirstResponder(nil)
             return true
         }
+    }
+}
+
+/// An `NSTextField` that reports its real focus lifecycle. `becomeFirstResponder`
+/// covers every way focus arrives (the controller's `makeFirstResponder` AND a
+/// direct mouse click into the field); the end of editing is reported from
+/// `textDidEndEditing` because NSTextField hands first-responder status to the
+/// shared field editor immediately, which makes `resignFirstResponder` useless
+/// as a "focus left" signal.
+final class FocusReportingTextField: NSTextField {
+    var onFocusChange: ((Bool) -> Void)?
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted { onFocusChange?(true) }
+        return accepted
+    }
+
+    override func textDidEndEditing(_ notification: Notification) {
+        super.textDidEndEditing(notification)
+        onFocusChange?(false)
     }
 }

--- a/Sources/AnyDoor/Views/WallSearchField.swift
+++ b/Sources/AnyDoor/Views/WallSearchField.swift
@@ -16,9 +16,9 @@ import SwiftUI
 /// unrelated view update would then yank focus back out of the field.
 struct WallSearchField: NSViewRepresentable {
     @Bindable var state: ClipboardWallState
-    /// Hands the underlying field back to the controller. Type-to-focus must
+    /// Hands the underlying field back to the controller. The ⌘F shortcut must
     /// make the field first responder *synchronously* inside the key monitor so
-    /// the triggering keystroke is delivered to it (IME included); that needs a
+    /// the very next keystroke can start an IME composition in it; that needs a
     /// direct reference the controller can act on.
     let registerField: (NSTextField?) -> Void
 
@@ -89,22 +89,6 @@ struct WallSearchField: NSViewRepresentable {
         func moveCaretToEnd(_ field: NSTextField) {
             let end = (field.stringValue as NSString).length
             field.currentEditor()?.selectedRange = NSRange(location: end, length: 0)
-        }
-
-        // Intercept the rightward caret move: once the caret sits at the end of a
-        // non-empty query, a further → hands control to card navigation — the
-        // resign flows back into `state.isSearchFocused` via the field's focus
-        // report, so no direct state write here. An empty query keeps focus so
-        // the field stays usable.
-        func control(_ control: NSControl, textView: NSTextView,
-                     doCommandBy selector: Selector) -> Bool {
-            guard selector == #selector(NSResponder.moveRight(_:)) else { return false }
-            let length = (textView.string as NSString).length
-            let selection = textView.selectedRange()
-            let caretAtEnd = selection.length == 0 && selection.location >= length
-            guard caretAtEnd, !state.query.isEmpty else { return false }
-            control.window?.makeFirstResponder(nil)
-            return true
         }
     }
 }

--- a/Sources/AnyDoor/Views/WallSearchField.swift
+++ b/Sources/AnyDoor/Views/WallSearchField.swift
@@ -54,11 +54,11 @@ struct WallSearchField: NSViewRepresentable {
         }
     }
 
-    static func dismantleNSView(_ field: NSTextField, coordinator: Coordinator) {
-        // The field is going away with the rebuilt host; drop the controller's
-        // dangling reference so it never makes a stale view first responder.
-        coordinator.registerField(nil)
-    }
+    // No dismantleNSView: the controller's reference is weak, so a torn-down
+    // field nils out on its own. An explicit `registerField(nil)` here is
+    // actively harmful — the old host is deallocated *after* the rebuilt host
+    // has registered its new field (deferred teardown), so it would clobber
+    // the fresh reference and leave ⌘F focusing nothing on every reopen.
 
     func makeCoordinator() -> Coordinator { Coordinator(state: state, registerField: registerField) }
 


### PR DESCRIPTION
## Summary

Reworks the clipboard wall's search-field focus model and interaction.

### Interaction changes
- The wall always opens in card-navigation mode; search is focused explicitly with cmd-F (or a click on the field) instead of type-to-search. Stray typing in card navigation is swallowed rather than starting a search.
- cmd-F toggles: pressing it while the field is focused hands the keyboard back to the cards, keeping the query. Down arrow does the same. Esc keeps its staged exit (clear the query first, then close).
- The cmd-F shortcut is documented in the hints footer (new `clipboard.hint.search` localization entry).

### Bug fixes
- `isSearchFocused` was a one-way commanded flag with no feedback from AppKit, so a mouse click into the field left the wall routing Backspace/Space/arrows to card navigation while the caret sat in the field (Backspace deleted the selected card), and any unrelated view refresh could yank the caret away. A `FocusReportingTextField` subclass now reports the field's real first-responder lifecycle into state, and `updateNSView` only reconciles when commanded state and reality disagree.
- Making the panel key let AppKit's key-view loop hand initial first responder to the search field, opening the wall pre-focused. The key-view loop is no longer recalculated, `initialFirstResponder` is cleared after installing the hosting view, and a post-show reset acts as a safety net.
- Every wall show rebuilds the hosting view, and the old host's deferred `dismantleNSView` ran `registerField(nil)` after the new field had already registered — severing the controller's field reference and silently killing keyboard search focus on every open after the first (the likely cause of the long-standing intermittent type-to-search failures). The dismantle hook is gone (the reference is weak) and cmd-F falls back to state-driven focus if the reference is ever stale.

## Testing
- `swift build` passes.
- Manually verified: opens unfocused across repeated toggles, cmd-F toggles focus reliably, down arrow returns to cards, Esc staged exit, query preserved on focus handoff.