### PR TITLE
fix(command-palette): stabilize input and remember window position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ versioning.
 
 ### Added
 
-- Command Palette: remembers its last position across openings and app
-  launches, while falling back to the default placement when its display is
-  unavailable.
+- Command Palette now opens where you last left it, including after restarting
+  AnyDoor. If that monitor is no longer connected, the palette returns to its
+  default position.
 
 ## [3.7.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Command Palette: remembers its last position across openings and app
+  launches, while falling back to the default placement when its display is
+  unavailable.
+
 ## [3.7.0] - 2026-07-12
 
 ### Added

--- a/Sources/AnyDoor/Views/CommandPaletteActivationGate.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteActivationGate.swift
@@ -1,0 +1,87 @@
+import AppKit
+
+/// Presents work only after AnyDoor has actually become the active application.
+/// A global hotkey can summon the palette while this accessory app is in the
+/// background; requesting activation and immediately keying the panel races the
+/// workspace transition. Waiting for the notification keeps first-responder
+/// assignment on the system's real activation boundary.
+@MainActor
+final class CommandPaletteActivationGate {
+    private let notificationCenter: NotificationCenter
+    private let notificationObject: AnyObject
+    private let isActive: @MainActor () -> Bool
+    private let requestActivation: @MainActor () -> Void
+
+    private var observer: NSObjectProtocol?
+    private var pendingPresentation: (@MainActor () -> Void)?
+
+    convenience init(application: NSApplication = .shared) {
+        self.init(
+            notificationCenter: .default,
+            notificationObject: application,
+            isActive: { application.isActive },
+            requestActivation: { application.activate(ignoringOtherApps: true) }
+        )
+    }
+
+    init(
+        notificationCenter: NotificationCenter,
+        notificationObject: AnyObject,
+        isActive: @escaping @MainActor () -> Bool,
+        requestActivation: @escaping @MainActor () -> Void
+    ) {
+        self.notificationCenter = notificationCenter
+        self.notificationObject = notificationObject
+        self.isActive = isActive
+        self.requestActivation = requestActivation
+    }
+
+    var isWaiting: Bool { pendingPresentation != nil }
+
+    func presentWhenActive(
+        prepareForActivation: @MainActor () -> Void = {},
+        _ presentation: @escaping @MainActor () -> Void
+    ) {
+        cancel()
+        guard !isActive() else {
+            presentation()
+            return
+        }
+
+        pendingPresentation = presentation
+        observer = notificationCenter.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: notificationObject,
+            queue: .main
+        ) { [weak self] _ in
+            MainThreadIsolation.run { self?.finishIfActive() }
+        }
+
+        // An accessory app needs an eligible visible window before AppKit will
+        // complete activation. Show it without making it key, then wait for the
+        // real activation boundary before assigning first responder.
+        prepareForActivation()
+        requestActivation()
+        // Close the gap where activation completes between the initial state
+        // check and observer registration without relying on an arbitrary delay.
+        finishIfActive()
+    }
+
+    func cancel() {
+        pendingPresentation = nil
+        if let observer {
+            notificationCenter.removeObserver(observer)
+            self.observer = nil
+        }
+    }
+
+    private func finishIfActive() {
+        guard isActive(), let presentation = pendingPresentation else { return }
+        pendingPresentation = nil
+        if let observer {
+            notificationCenter.removeObserver(observer)
+            self.observer = nil
+        }
+        presentation()
+    }
+}

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -825,16 +825,17 @@ struct CommandPalettePicker: View {
             )
             .frame(maxWidth: .infinity)
             .frame(height: 27)
-            if !state.query.isEmpty {
-                Button {
-                    state.query = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 16))
-                        .foregroundStyle(.tertiary)
-                }
-                .buttonStyle(.plain)
+            Button {
+                state.query = ""
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.tertiary)
             }
+            .buttonStyle(.plain)
+            .opacity(state.query.isEmpty ? 0 : 1)
+            .allowsHitTesting(!state.query.isEmpty)
+            .accessibilityHidden(state.query.isEmpty)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -713,6 +713,10 @@ struct CommandPalettePicker: View {
                 confirmCard(pending.confirmation)
             }
         }
+        // NSHostingView inherits the full-size panel's 32-point titlebar safe
+        // area. Apply this outside the complete surface so the material and its
+        // content expand together instead of moving only the inner stack.
+        .ignoresSafeArea()
         .onChange(of: state.query) { _, _ in
             // Space trigger for the dev-tool scope badge (Tab is handled by the
             // window controller's key monitor). No-ops once a scope is active.

--- a/Sources/AnyDoor/Views/CommandPalettePicker.swift
+++ b/Sources/AnyDoor/Views/CommandPalettePicker.swift
@@ -669,15 +669,7 @@ struct CommandPalettePicker: View {
     let onCancel: () -> Void
     let onConfirm: () -> Void
     let onRefreshRates: () -> Void
-    /// Reports whether the hosting panel is still on screen. Used to keep the
-    /// focus-recovery loop below from resurrecting a palette that was just
-    /// dismissed (see the `onChange(of: searchFocused)` note).
-    let isPresented: () -> Bool
-
-    @FocusState private var searchFocused: Bool
-    // Counts consecutive failed attempts to reclaim focus. Reset whenever focus
-    // is actually regained; used to break the re-focus loop (see below).
-    @State private var refocusStrikes = 0
+    let registerSearchAnchor: (CommandPaletteSearchAnchorView, String, String) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -709,9 +701,7 @@ struct CommandPalettePicker: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         // Liquid Glass on macOS 26+; .thickMaterial on earlier systems.
         // Driving the whole palette from one surface keeps the search field,
-        // rows, and section headers visually consistent — on macOS 26 the
-        // TextField picks up the system glass treatment automatically, which
-        // used to clash with the per-row .thickMaterial below.
+        // rows, and section headers visually consistent.
         .adaptivePanelSurface(cornerRadius: 16)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -721,35 +711,6 @@ struct CommandPalettePicker: View {
         .overlay {
             if let pending = state.pendingConfirmation {
                 confirmCard(pending.confirmation)
-            }
-        }
-        .onAppear {
-            DispatchQueue.main.async { searchFocused = true }
-        }
-        .onChange(of: searchFocused) { _, focused in
-            // Keep the search field as the keyboard target — re-focus if a stray
-            // hit-test in the panel chrome steals it. Two guards on the recovery:
-            //
-            //  1. Bail after a few rapid strikes. Reasserting focus every runloop
-            //     tick pins a CPU core when the system refuses first-responder
-            //     (focus desync while the panel sits on another Space, etc.).
-            //     Regaining focus resets the counter (mirrors SpotlightAppPicker).
-            //  2. Only re-focus while the panel is still on screen. Esc/cancel
-            //     closes the window, which drops first-responder and fires this
-            //     handler; without this guard the deferred `searchFocused = true`
-            //     would make the field first responder again and reorder the just
-            //     -closed panel back in. Esc is the only dismiss path where the
-            //     app stays frontmost with no other window to take focus, so it
-            //     was the one that visibly "wouldn't close".
-            if focused {
-                refocusStrikes = 0
-                return
-            }
-            guard refocusStrikes < 3 else { return }
-            refocusStrikes += 1
-            DispatchQueue.main.async {
-                guard isPresented() else { return }
-                searchFocused = true
             }
         }
         .onChange(of: state.query) { _, _ in
@@ -857,19 +818,13 @@ struct CommandPalettePicker: View {
                     .font(.system(size: 22, weight: .regular))
                     .foregroundStyle(.secondary)
             }
-            TextField(searchFieldPlaceholder, text: $state.query)
-                .textFieldStyle(.plain)
-                .font(.system(size: 22, weight: .regular))
-                .focused($searchFocused)
-                .onSubmit {
-                    // While a confirmation card is up the key monitor already
-                    // swallows Return; guard here too so onSubmit can never
-                    // commit a list row behind the card.
-                    guard !state.isConfirming else { return }
-                    if let entry = state.commitSelection() {
-                        onSelect(entry)
-                    }
-                }
+            CommandPaletteSearchAnchor(
+                text: state.query,
+                placeholder: searchFieldPlaceholder,
+                registerAnchor: registerSearchAnchor
+            )
+            .frame(maxWidth: .infinity)
+            .frame(height: 27)
             if !state.query.isEmpty {
                 Button {
                     state.query = ""

--- a/Sources/AnyDoor/Views/CommandPaletteSearchField.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteSearchField.swift
@@ -1,0 +1,81 @@
+import AppKit
+import SwiftUI
+
+/// Reserves the search field's SwiftUI layout slot. The real NSTextField is an
+/// AppKit sibling of the NSHostingView and is positioned over this anchor, so
+/// SwiftUI never owns its field editor or cursor rects.
+struct CommandPaletteSearchAnchor: NSViewRepresentable {
+    let text: String
+    let placeholder: String
+    let registerAnchor: (CommandPaletteSearchAnchorView, String, String) -> Void
+
+    func makeNSView(context: Context) -> CommandPaletteSearchAnchorView {
+        let anchor = CommandPaletteSearchAnchorView()
+        update(anchor)
+        return anchor
+    }
+
+    func updateNSView(_ anchor: CommandPaletteSearchAnchorView, context: Context) {
+        update(anchor)
+    }
+
+    static func dismantleNSView(_ anchor: CommandPaletteSearchAnchorView, coordinator: Void) {
+        anchor.onLayout = nil
+    }
+
+    private func update(_ anchor: CommandPaletteSearchAnchorView) {
+        let text = text
+        let placeholder = placeholder
+        let registerAnchor = registerAnchor
+        anchor.onLayout = { anchor in
+            registerAnchor(anchor, text, placeholder)
+        }
+        registerAnchor(anchor, text, placeholder)
+    }
+}
+
+final class CommandPaletteSearchAnchorView: NSView {
+    var onLayout: ((CommandPaletteSearchAnchorView) -> Void)?
+
+    override func layout() {
+        super.layout()
+        onLayout?(self)
+    }
+}
+
+@MainActor
+enum CommandPaletteSearchField {
+    static func make(coordinator: Coordinator) -> NSTextField {
+        let field = NSTextField()
+        configure(field)
+        field.delegate = coordinator
+        return field
+    }
+
+    static func configure(_ field: NSTextField) {
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.isEditable = true
+        field.isSelectable = true
+        field.font = .systemFont(ofSize: 22, weight: .regular)
+        field.lineBreakMode = .byTruncatingTail
+        field.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var onChange: (String) -> Void
+
+        init(onChange: @escaping (String) -> Void = { _ in }) {
+            self.onChange = onChange
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            onChange(field.stringValue)
+        }
+    }
+}

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -47,6 +47,21 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         return panel
     }
 
+    static func makeContentContainer(
+        for window: NSWindow,
+        hostingView: NSView,
+        searchField: NSView
+    ) -> NSView {
+        let fullContentBounds = window.contentView?.bounds
+            ?? NSRect(origin: .zero, size: window.frame.size)
+        let contentView = NSView(frame: fullContentBounds)
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+        contentView.addSubview(searchField, positioned: .above, relativeTo: hostingView)
+        return contentView
+    }
+
     private init() {
         let panel = Self.makePanel()
         super.init(window: panel)
@@ -97,6 +112,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
     }
 
     private func show(initialMode: InitialMode = .root) {
+        guard let window else { return }
         activationGate.cancel()
         removeKeyMonitor()
         searchCoordinator.onChange = { _ in }
@@ -141,13 +157,12 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         )
 
         let host = NSHostingView(rootView: view)
-        let contentSize = window?.contentLayoutRect.size ?? .zero
-        let contentView = NSView(frame: NSRect(origin: .zero, size: contentSize))
-        host.frame = contentView.bounds
-        host.autoresizingMask = [.width, .height]
-        contentView.addSubview(host)
-        contentView.addSubview(searchField, positioned: .above, relativeTo: host)
-        window?.contentView = contentView
+        let contentView = Self.makeContentContainer(
+            for: window,
+            hostingView: host,
+            searchField: searchField
+        )
+        window.contentView = contentView
         host.layoutSubtreeIfNeeded()
         layoutSearchField()
 

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate {
     static let shared = CommandPaletteWindowController()
+    private static let paletteControlKeyCodes: Set<UInt16> = [125, 126, 36, 76, 48, 51, 53]
 
     private var state: CommandPaletteState?
     private let activationGate = CommandPaletteActivationGate()
@@ -17,7 +18,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
     /// a fresh `/Applications` walk; empty only before the very first scan returns.
     private var cachedApps: [InstalledApp] = []
 
-    private init() {
+    static func makePanel() -> NSPanel {
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 680, height: 460),
             styleMask: [.titled, .fullSizeContentView],
@@ -29,17 +30,25 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         panel.standardWindowButton(.closeButton)?.isHidden = true
         panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
         panel.standardWindowButton(.zoomButton)?.isHidden = true
-        panel.isMovableByWindowBackground = true
-        panel.backgroundColor = .clear
+        panel.isMovableByWindowBackground = false
+        // A fully clear NSPanel loses the active NSTextField's I-beam cursor on
+        // macOS 26. A visually imperceptible alpha keeps AppKit's cursor rects
+        // intact without changing the transparent rounded-window appearance.
+        panel.backgroundColor = NSColor.windowBackgroundColor.withAlphaComponent(0.001)
         panel.isOpaque = false
         panel.hasShadow = true
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
         panel.isReleasedWhenClosed = false
-        panel.isFloatingPanel = true
+        panel.isFloatingPanel = false
         panel.becomesKeyOnlyIfNeeded = false
         panel.hidesOnDeactivate = false
+        panel.isRestorable = false
+        return panel
+    }
 
+    private init() {
+        let panel = Self.makePanel()
         super.init(window: panel)
         panel.delegate = self
     }
@@ -390,6 +399,8 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
             }
             return true
         }
+
+        guard Self.paletteControlKeyCodes.contains(keyCode) else { return false }
 
         // While the input method is composing (marked text — e.g. typing
         // Chinese pinyin), every key belongs to the IME: Return commits the

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -8,6 +8,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
 
     private var state: CommandPaletteState?
     private let activationGate = CommandPaletteActivationGate()
+    private let windowPlacement = CommandPaletteWindowPlacement()
     private let searchCoordinator = CommandPaletteSearchField.Coordinator()
     private var searchField: NSTextField?
     private weak var searchAnchor: CommandPaletteSearchAnchorView?
@@ -166,7 +167,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         host.layoutSubtreeIfNeeded()
         layoutSearchField()
 
-        positionAtTopCenter()
+        restorePosition()
         activationGate.presentWhenActive(prepareForActivation: { [weak self, weak pickerState] in
             guard let self, let pickerState, self.state === pickerState else { return }
             self.window?.orderFrontRegardless()
@@ -372,14 +373,31 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         return sections
     }
 
-    private func positionAtTopCenter() {
-        guard let window, let screen = NSScreen.main else { return }
-        let visible = screen.visibleFrame
-        let size = window.frame.size
-        let x = visible.midX - size.width / 2
-        let topInset = visible.height * 0.22
-        let y = visible.maxY - size.height - topInset
-        window.setFrameOrigin(NSPoint(x: x, y: y))
+    private func restorePosition() {
+        guard let window else { return }
+        let screens = NSScreen.screens
+        let windowSize = window.frame.size
+
+        if let restoredFrame = windowPlacement.restoredFrame(
+            windowSize: windowSize,
+            visibleFrames: screens.map(\.visibleFrame)
+        ), let screen = screens.first(where: { $0.visibleFrame.intersects(restoredFrame) }) {
+            let constrainedFrame = window.constrainFrameRect(restoredFrame, to: screen)
+            window.setFrame(constrainedFrame, display: false)
+            return
+        }
+
+        guard let visibleFrame = NSScreen.main?.visibleFrame else { return }
+        let defaultFrame = CommandPaletteWindowPlacement.defaultFrame(
+            windowSize: windowSize,
+            visibleFrame: visibleFrame
+        )
+        window.setFrame(defaultFrame, display: false)
+    }
+
+    private func savePosition() {
+        guard let window, window.isVisible else { return }
+        windowPlacement.save(origin: window.frame.origin)
     }
 
     private func installKeyMonitor() {
@@ -578,6 +596,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
     override func close() {
         guard !isClosing else { return }
         isClosing = true
+        savePosition()
         resetPresentation()
         super.close()
         isClosing = false
@@ -595,6 +614,10 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
         resetPresentation()
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        savePosition()
     }
 
     /// Close when focus moves away (Spotlight UX).

--- a/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowController.swift
@@ -6,7 +6,12 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
     static let shared = CommandPaletteWindowController()
 
     private var state: CommandPaletteState?
+    private let activationGate = CommandPaletteActivationGate()
+    private let searchCoordinator = CommandPaletteSearchField.Coordinator()
+    private var searchField: NSTextField?
+    private weak var searchAnchor: CommandPaletteSearchAnchorView?
     private var keyMonitor: Any?
+    private var isClosing = false
     /// Last installed-apps scan, refreshed off the main actor on every open. Seeds
     /// the Applications section instantly so summoning the palette never blocks on
     /// a fresh `/Applications` walk; empty only before the very first scan returns.
@@ -46,7 +51,7 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
 
     /// Toggle visibility: hide if already showing, otherwise show fresh.
     func toggle() {
-        if window?.isVisible == true {
+        if window?.isVisible == true || activationGate.isWaiting {
             close()
         } else {
             show()
@@ -83,6 +88,13 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
     }
 
     private func show(initialMode: InitialMode = .root) {
+        activationGate.cancel()
+        removeKeyMonitor()
+        searchCoordinator.onChange = { _ in }
+        searchAnchor?.onLayout = nil
+        searchField = nil
+        searchAnchor = nil
+
         let sections = collectSections(installedApps: cachedApps)
         prewarmIcons(for: sections)
         let hyperFlags = HyperKeyService.shared.hyperModifierFlags
@@ -93,6 +105,12 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         )
         initialMode.apply(to: pickerState)
         self.state = pickerState
+        searchCoordinator.onChange = { [weak pickerState] text in
+            guard let pickerState, pickerState.query != text else { return }
+            pickerState.query = text
+        }
+        let searchField = CommandPaletteSearchField.make(coordinator: searchCoordinator)
+        self.searchField = searchField
 
         let view = CommandPalettePicker(
             state: pickerState,
@@ -108,29 +126,36 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
             onRefreshRates: { [weak self] in
                 self?.refreshRates()
             },
-            isPresented: { [weak self] in
-                self?.window?.isVisible == true
+            registerSearchAnchor: { [weak self] anchor, text, placeholder in
+                self?.registerSearchAnchor(anchor, text: text, placeholder: placeholder)
             }
         )
 
         let host = NSHostingView(rootView: view)
-        host.frame = window?.contentLayoutRect ?? .zero
+        let contentSize = window?.contentLayoutRect.size ?? .zero
+        let contentView = NSView(frame: NSRect(origin: .zero, size: contentSize))
+        host.frame = contentView.bounds
         host.autoresizingMask = [.width, .height]
-        window?.contentView = host
+        contentView.addSubview(host)
+        contentView.addSubview(searchField, positioned: .above, relativeTo: host)
+        window?.contentView = contentView
+        host.layoutSubtreeIfNeeded()
+        layoutSearchField()
 
-        installKeyMonitor()
         positionAtTopCenter()
-        // Activate the app BEFORE keying the window. Summoned from a global
-        // hotkey, this `.accessory` app is still in the background, so
-        // `makeKeyAndOrderFront` cannot make the panel the key window until the
-        // app is frontmost. With no key window, SwiftUI's @FocusState can't
-        // hold first responder on the search field, and the onAppear/onChange
-        // re-focus path oscillates every runloop tick (visible flicker, no
-        // typing) until the user clicks the field. Activating first lets the
-        // deferred focus assignment land on an already-key window.
-        NSApp.activate(ignoringOtherApps: true)
-        window?.makeKeyAndOrderFront(nil)
+        activationGate.presentWhenActive(prepareForActivation: { [weak self, weak pickerState] in
+            guard let self, let pickerState, self.state === pickerState else { return }
+            self.window?.orderFrontRegardless()
+        }) { [weak self, weak pickerState] in
+            guard let self, let pickerState, self.state === pickerState else { return }
+            self.installKeyMonitor()
+            self.window?.makeKeyAndOrderFront(nil)
+            self.focusSearchField()
+            self.refreshSections(for: pickerState)
+        }
+    }
 
+    private func refreshSections(for pickerState: CommandPaletteState) {
         // After the window is on screen, refresh state that the synchronous
         // seed above can't supply, then repopulate the sections in place (the
         // @Observable state re-renders). Two pieces, folded into one task so the
@@ -157,6 +182,41 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
             )
             self.prewarmIcons(for: refreshed)
         }
+    }
+
+    private func registerSearchAnchor(
+        _ anchor: CommandPaletteSearchAnchorView,
+        text: String,
+        placeholder: String
+    ) {
+        searchAnchor = anchor
+        guard let searchField else { return }
+        searchField.placeholderString = placeholder
+        if searchField.stringValue != text {
+            searchField.stringValue = text
+            if let editor = searchField.currentEditor() as? NSTextView {
+                editor.string = text
+                editor.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+            }
+        }
+        layoutSearchField()
+    }
+
+    private func layoutSearchField() {
+        guard let window, let contentView = window.contentView,
+              let searchAnchor, let searchField, searchAnchor.window === window
+        else { return }
+        let frame = searchAnchor.convert(searchAnchor.bounds, to: contentView)
+        guard frame.width > 0, frame.height > 0 else { return }
+        guard searchField.frame != frame else { return }
+        searchField.frame = frame
+    }
+
+    private func focusSearchField() {
+        guard let window, window.isKeyWindow, let searchField else { return }
+        guard window.makeFirstResponder(searchField) else { return }
+        let end = (searchField.stringValue as NSString).length
+        searchField.currentEditor()?.selectedRange = NSRange(location: end, length: 0)
     }
 
     /// Warm the icon cache for every app-backed row off the main thread, so the
@@ -489,9 +549,26 @@ final class CommandPaletteWindowController: NSWindowController, NSWindowDelegate
         }
     }
 
-    func windowWillClose(_ notification: Notification) {
+    override func close() {
+        guard !isClosing else { return }
+        isClosing = true
+        resetPresentation()
+        super.close()
+        isClosing = false
+    }
+
+    private func resetPresentation() {
+        activationGate.cancel()
         removeKeyMonitor()
+        searchCoordinator.onChange = { _ in }
+        searchAnchor?.onLayout = nil
+        searchField = nil
+        searchAnchor = nil
         state = nil
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        resetPresentation()
     }
 
     /// Close when focus moves away (Spotlight UX).

--- a/Sources/AnyDoor/Views/CommandPaletteWindowPlacement.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteWindowPlacement.swift
@@ -1,0 +1,40 @@
+import AppKit
+import Foundation
+
+struct CommandPaletteWindowPlacement {
+    static let defaultsKey = "commandPalette.windowPosition"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func save(origin: NSPoint) {
+        guard origin.x.isFinite, origin.y.isFinite else { return }
+        defaults.set([Double(origin.x), Double(origin.y)], forKey: Self.defaultsKey)
+    }
+
+    func savedOrigin() -> NSPoint? {
+        guard let values = defaults.array(forKey: Self.defaultsKey) as? [Double],
+              values.count == 2,
+              values.allSatisfy({ $0.isFinite })
+        else { return nil }
+
+        return NSPoint(x: values[0], y: values[1])
+    }
+
+    func restoredFrame(windowSize: NSSize, visibleFrames: [NSRect]) -> NSRect? {
+        guard let origin = savedOrigin() else { return nil }
+        let frame = NSRect(origin: origin, size: windowSize)
+        return visibleFrames.contains(where: { $0.intersects(frame) }) ? frame : nil
+    }
+
+    static func defaultFrame(windowSize: NSSize, visibleFrame: NSRect) -> NSRect {
+        let origin = NSPoint(
+            x: visibleFrame.midX - windowSize.width / 2,
+            y: visibleFrame.maxY - windowSize.height - visibleFrame.height * 0.22
+        )
+        return NSRect(origin: origin, size: windowSize)
+    }
+}

--- a/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
@@ -1,0 +1,167 @@
+import AppKit
+import XCTest
+
+@testable import AnyDoor
+
+@MainActor
+final class CommandPaletteWindowTests: XCTestCase {
+    private final class ActivationState {
+        var isActive = false
+    }
+
+    private final class TextState {
+        var text = ""
+    }
+
+    func testInactiveApplicationWaitsForActivationBeforePresenting() {
+        let center = NotificationCenter()
+        let application = NSObject()
+        let state = ActivationState()
+        var activationRequests = 0
+        var presentations = 0
+        let gate = CommandPaletteActivationGate(
+            notificationCenter: center,
+            notificationObject: application,
+            isActive: { state.isActive },
+            requestActivation: { activationRequests += 1 }
+        )
+
+        gate.presentWhenActive { presentations += 1 }
+
+        XCTAssertEqual(activationRequests, 1)
+        XCTAssertEqual(presentations, 0)
+        XCTAssertTrue(gate.isWaiting)
+
+        state.isActive = true
+        center.post(name: NSApplication.didBecomeActiveNotification, object: application)
+
+        XCTAssertEqual(presentations, 1)
+        XCTAssertFalse(gate.isWaiting)
+
+        center.post(name: NSApplication.didBecomeActiveNotification, object: application)
+        XCTAssertEqual(presentations, 1)
+    }
+
+    func testInactiveApplicationPreparesAVisibleWindowBeforeRequestingActivation() {
+        let center = NotificationCenter()
+        let application = NSObject()
+        let state = ActivationState()
+        var events: [String] = []
+        let gate = CommandPaletteActivationGate(
+            notificationCenter: center,
+            notificationObject: application,
+            isActive: { state.isActive },
+            requestActivation: { events.append("activate") }
+        )
+
+        gate.presentWhenActive(
+            prepareForActivation: { events.append("prepare") },
+            { events.append("present") }
+        )
+
+        XCTAssertEqual(events, ["prepare", "activate"])
+
+        state.isActive = true
+        center.post(name: NSApplication.didBecomeActiveNotification, object: application)
+
+        XCTAssertEqual(events, ["prepare", "activate", "present"])
+    }
+
+    func testActiveApplicationPresentsImmediatelyWithoutAnotherActivationRequest() {
+        let center = NotificationCenter()
+        let application = NSObject()
+        var activationRequests = 0
+        var presentations = 0
+        let gate = CommandPaletteActivationGate(
+            notificationCenter: center,
+            notificationObject: application,
+            isActive: { true },
+            requestActivation: { activationRequests += 1 }
+        )
+
+        gate.presentWhenActive { presentations += 1 }
+
+        XCTAssertEqual(activationRequests, 0)
+        XCTAssertEqual(presentations, 1)
+        XCTAssertFalse(gate.isWaiting)
+    }
+
+    func testActivationCompletingInsideRequestDoesNotNeedANotification() {
+        let center = NotificationCenter()
+        let application = NSObject()
+        let state = ActivationState()
+        var presentations = 0
+        let gate = CommandPaletteActivationGate(
+            notificationCenter: center,
+            notificationObject: application,
+            isActive: { state.isActive },
+            requestActivation: { state.isActive = true }
+        )
+
+        gate.presentWhenActive { presentations += 1 }
+
+        XCTAssertEqual(presentations, 1)
+        XCTAssertFalse(gate.isWaiting)
+    }
+
+    func testCancellingPendingActivationPreventsLatePresentation() {
+        let center = NotificationCenter()
+        let application = NSObject()
+        let state = ActivationState()
+        var presentations = 0
+        let gate = CommandPaletteActivationGate(
+            notificationCenter: center,
+            notificationObject: application,
+            isActive: { state.isActive },
+            requestActivation: {}
+        )
+
+        gate.presentWhenActive { presentations += 1 }
+        gate.cancel()
+        state.isActive = true
+        center.post(name: NSApplication.didBecomeActiveNotification, object: application)
+
+        XCTAssertEqual(presentations, 0)
+        XCTAssertFalse(gate.isWaiting)
+    }
+
+    func testSearchFieldUsesAStableNativeSingleLineControl() {
+        let coordinator = CommandPaletteSearchField.Coordinator()
+        let field = CommandPaletteSearchField.make(coordinator: coordinator)
+
+        XCTAssertTrue(type(of: field) == NSTextField.self)
+        XCTAssertTrue(field.delegate === coordinator)
+        XCTAssertFalse(field.isBordered)
+        XCTAssertFalse(field.drawsBackground)
+        XCTAssertEqual(field.focusRingType, .none)
+        XCTAssertTrue(field.usesSingleLineMode)
+        XCTAssertFalse(field.cell?.wraps ?? true)
+        XCTAssertTrue(field.cell?.isScrollable ?? false)
+        XCTAssertEqual(field.font?.pointSize, 22)
+    }
+
+    func testSearchFieldWritesNativeTextChangesBackToState() {
+        let state = TextState()
+        let coordinator = CommandPaletteSearchField.Coordinator { state.text = $0 }
+        let field = NSTextField()
+        field.stringValue = "clipboard"
+
+        coordinator.controlTextDidChange(
+            Notification(
+                name: NSControl.textDidChangeNotification,
+                object: field
+            ))
+
+        XCTAssertEqual(state.text, "clipboard")
+    }
+
+    func testSearchAnchorReportsLayoutChanges() {
+        let anchor = CommandPaletteSearchAnchorView()
+        var observedAnchor: CommandPaletteSearchAnchorView?
+        anchor.onLayout = { observedAnchor = $0 }
+
+        anchor.layout()
+
+        XCTAssertTrue(observedAnchor === anchor)
+    }
+}

--- a/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
@@ -13,6 +13,61 @@ final class CommandPaletteWindowTests: XCTestCase {
         var text = ""
     }
 
+    private func withWindowPlacement(
+        _ body: (CommandPaletteWindowPlacement) throws -> Void
+    ) throws {
+        let suiteName = "CommandPaletteWindowPlacementTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(CommandPaletteWindowPlacement(defaults: defaults))
+    }
+
+    func testWindowPlacementRoundTripsSavedOrigin() throws {
+        try withWindowPlacement { placement in
+            placement.save(origin: NSPoint(x: 321.5, y: -84.25))
+
+            XCTAssertEqual(placement.savedOrigin(), NSPoint(x: 321.5, y: -84.25))
+        }
+    }
+
+    func testWindowPlacementRestoresCurrentSizeOnSecondaryDisplay() throws {
+        try withWindowPlacement { placement in
+            placement.save(origin: NSPoint(x: 2_100, y: 120))
+
+            let restored = placement.restoredFrame(
+                windowSize: NSSize(width: 680, height: 460),
+                visibleFrames: [
+                    NSRect(x: 0, y: 0, width: 1_920, height: 1_080),
+                    NSRect(x: 1_920, y: 0, width: 1_920, height: 1_080),
+                ]
+            )
+
+            XCTAssertEqual(restored, NSRect(x: 2_100, y: 120, width: 680, height: 460))
+        }
+    }
+
+    func testWindowPlacementRejectsPositionOutsideConnectedDisplays() throws {
+        try withWindowPlacement { placement in
+            placement.save(origin: NSPoint(x: 5_000, y: 5_000))
+
+            let restored = placement.restoredFrame(
+                windowSize: NSSize(width: 680, height: 460),
+                visibleFrames: [NSRect(x: 0, y: 0, width: 1_920, height: 1_080)]
+            )
+
+            XCTAssertNil(restored)
+        }
+    }
+
+    func testWindowPlacementUsesExistingTopCenterDefault() {
+        let frame = CommandPaletteWindowPlacement.defaultFrame(
+            windowSize: NSSize(width: 680, height: 460),
+            visibleFrame: NSRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+
+        XCTAssertEqual(frame, NSRect(x: 380, y: 242, width: 680, height: 460))
+    }
+
     func testInactiveApplicationWaitsForActivationBeforePresenting() {
         let center = NotificationCenter()
         let application = NSObject()

--- a/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
@@ -135,6 +135,24 @@ final class CommandPaletteWindowTests: XCTestCase {
         XCTAssertLessThan(panel.backgroundColor?.alphaComponent ?? 1, 0.01)
     }
 
+    func testPaletteContentCoversFullSizeTitlebar() throws {
+        let panel = CommandPaletteWindowController.makePanel()
+        let fullContentBounds = try XCTUnwrap(panel.contentView?.bounds)
+        let hostingView = NSView()
+        let searchField = NSTextField()
+
+        XCTAssertGreaterThan(fullContentBounds.height, panel.contentLayoutRect.height)
+
+        let container = CommandPaletteWindowController.makeContentContainer(
+            for: panel,
+            hostingView: hostingView,
+            searchField: searchField
+        )
+
+        XCTAssertEqual(container.frame, fullContentBounds)
+        XCTAssertEqual(hostingView.frame, container.bounds)
+    }
+
     func testSearchFieldUsesAStableNativeSingleLineControl() {
         let coordinator = CommandPaletteSearchField.Coordinator()
         let field = CommandPaletteSearchField.make(coordinator: coordinator)

--- a/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteWindowTests.swift
@@ -125,6 +125,16 @@ final class CommandPaletteWindowTests: XCTestCase {
         XCTAssertFalse(gate.isWaiting)
     }
 
+    func testPanelUsesCursorSafeFixedConfiguration() {
+        let panel = CommandPaletteWindowController.makePanel()
+
+        XCTAssertFalse(panel.isMovableByWindowBackground)
+        XCTAssertFalse(panel.isFloatingPanel)
+        XCTAssertFalse(panel.isRestorable)
+        XCTAssertGreaterThan(panel.backgroundColor?.alphaComponent ?? 0, 0)
+        XCTAssertLessThan(panel.backgroundColor?.alphaComponent ?? 1, 0.01)
+    }
+
     func testSearchFieldUsesAStableNativeSingleLineControl() {
         let coordinator = CommandPaletteSearchField.Coordinator()
         let field = CommandPaletteSearchField.make(coordinator: coordinator)


### PR DESCRIPTION
## Summary

- stabilize command-palette activation and search focus with a native single-line AppKit field, preventing intermittent style switching, cursor flicker, and lost input focus
- extend the palette surface through the full-size title bar without reintroducing the transparent top strip or breaking the text cursor
- remember the palette's last position across openings and app launches, while retaining the current fixed size and falling back when the saved display is unavailable
- add focused regression coverage and document the user-visible positioning behavior

## Motivation

Opening the Command Palette with Command-Space could intermittently recreate or refocus the search control, making the entered text alternate between input and placeholder styling while the cursor flickered. The full-size title-bar layout could also expose a transparent strip above the palette. Finally, every invocation reset the panel to its default top-center position instead of respecting where the user moved it.

## How was this tested?

- [x] `swift build` passes
- [x] `swift test` passes (1,243 XCTest cases and 28 Swift Testing cases)
- [x] Manually verified: installed the release build locally; the user confirmed that the input/cursor instability and transparent title-bar area no longer reproduce. Position persistence, secondary-display restoration, and disconnected-display fallback are covered by focused window tests.

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; UI-facing strings are in Chinese via `L10n` / the `.xcstrings` catalog
- [x] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]` (no hand-authored version headings)
- [x] No new Swift 6 strict-concurrency warnings
