### PR TITLE
test: wait for the hover re-mount instead of sleeping past it

### DIFF
--- a/Tests/AnyDoorTests/HoverGateTests.swift
+++ b/Tests/AnyDoorTests/HoverGateTests.swift
@@ -19,7 +19,14 @@ final class HoverGateTests: XCTestCase {
     func testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced() async {
         let gate = HoverGate()
         var showCount = 0
-        gate.onShow = { showCount += 1 }
+        // Wait for the re-mount instead of sleeping past its 16ms coalescing
+        // window: on a loaded machine the deferred task can land much later, and
+        // a fixed sleep turns that into a flake rather than a real signal.
+        let remounted = expectation(description: "coalesced re-mount")
+        gate.onShow = {
+            showCount += 1
+            if showCount == 2 { remounted.fulfill() }
+        }
 
         gate.showImmediately()        // synchronous first show
         XCTAssertEqual(showCount, 1)
@@ -27,8 +34,7 @@ final class HoverGateTests: XCTestCase {
         gate.triggerHover(true)       // already shown -> coalesced re-mount, deferred off the tick
         XCTAssertEqual(showCount, 1, "re-mount while shown must be deferred, not synchronous")
 
-        // The coalesced refresh fires on a later runloop turn.
-        try? await Task.sleep(nanoseconds: 80_000_000)
+        await fulfillment(of: [remounted], timeout: 2)
         XCTAssertEqual(showCount, 2)
     }
 
@@ -36,7 +42,14 @@ final class HoverGateTests: XCTestCase {
     func testRapidCrossingsWhileShownCoalesceIntoOneRemount() async {
         let gate = HoverGate()
         var showCount = 0
-        gate.onShow = { showCount += 1 }
+        let remounted = expectation(description: "one coalesced re-mount")
+        let extraRemount = expectation(description: "no further re-mount")
+        extraRemount.isInverted = true
+        gate.onShow = {
+            showCount += 1
+            if showCount == 2 { remounted.fulfill() }
+            if showCount > 2 { extraRemount.fulfill() }
+        }
 
         gate.showImmediately()        // count 1
         // Simulate a fast sweep across several already-shown hover rows in one burst.
@@ -44,8 +57,10 @@ final class HoverGateTests: XCTestCase {
         gate.triggerHover(true)
         gate.triggerHover(true)
 
-        try? await Task.sleep(nanoseconds: 80_000_000)
-        // The three crossings collapse into a single re-mount (count 1 + 1), not three.
+        // The three crossings collapse into a single re-mount (count 1 + 1), not
+        // three: each crossing replaces the pending refresh task.
+        await fulfillment(of: [remounted], timeout: 2)
+        await fulfillment(of: [extraRemount], timeout: 0.2)
         XCTAssertEqual(showCount, 2)
     }
 


### PR DESCRIPTION
## Summary

Makes `HoverGateTests` wait for the coalesced re-mount instead of sleeping past
its window.

## Motivation

The first CI run on `main` after #73 failed here:

```
HoverGateTests.swift:32: error: testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced
  : XCTAssertEqual failed: ("1") is not equal to ("2")
```

`HoverGate` defers a re-mount by 16ms (`refreshDelayNanos`) and the tests slept a
fixed 80ms before reading the count. That margin holds on a developer Mac and
does not on a loaded CI VM, so the assertion raced the deferred task. Two tests
are affected; both now wait on the effect:

- `testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced` fulfils an
  expectation from `onShow`, so it waits as long as the machine needs (2s cap)
  and still fails if the re-mount never happens.
- `testRapidCrossingsWhileShownCoalesceIntoOneRemount` additionally pins the
  coalescing claim with an inverted expectation — "no third show" is now an
  explicit assertion rather than a count read after a sleep.

The synchronous claims (`showImmediately` mounts inline, a re-mount while shown
is *not* synchronous) are unchanged, and `testRapidRetriggerKeepsFirstShowDeadline`
is untouched: its timing is the behaviour under test, and a slow host makes it
pass early rather than flake.

## Known remaining exposure

12 test files use `Task.sleep` across 32 call sites. Most are await-then-assert
against work with a much larger margin than 16ms, but the same class of flake can
surface there on a slow runner. I have not rewritten them in this PR — worth
doing opportunistically as each one is touched, rather than in one sweep.

## How was this tested?

- [x] `swift test --filter HoverGateTests` five consecutive runs, 4 tests, 0
      failures each
- [x] Manually verified: n/a, test-only change

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; UI-facing strings are in Chinese via `L10n` / the `.xcstrings` catalog
- [x] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]` — n/a, no user-visible change
- [x] No new Swift 6 strict-concurrency warnings
