### PR TITLE
test: wait on effects instead of fixed sleeps before positive assertions

### DIFF
--- a/Tests/AnyDoorTests/AsyncWaiting.swift
+++ b/Tests/AnyDoorTests/AsyncWaiting.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// Polls `condition` until it holds, failing the test if `timeout` lapses first.
+/// A synchronous closure converts implicitly, so both `{ flag }` and
+/// `{ await actor.count == 2 }` are accepted.
+///
+/// Prefer this over sleeping for a fixed margin before a positive assertion. A
+/// fixed sleep encodes a deadline the machine may miss under load (a loaded CI
+/// runner overran an 80ms wait on a 16ms debounce), and the resulting failure
+/// reads as a flake rather than a real signal. Waiting on the effect keeps the
+/// assertion meaningful: a condition that never holds still fails, just later.
+///
+/// Assertions of the "must NOT happen" kind are the deliberate exception —
+/// those need a bounded wait, and a slow machine only makes them more
+/// conservative.
+@MainActor
+func waitUntil(
+    _ description: String,
+    timeout: TimeInterval = 5,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: @MainActor () async -> Bool
+) async {
+    let deadline = ContinuousClock.now + .seconds(timeout)
+    while ContinuousClock.now < deadline {
+        if await condition() { return }
+        try? await Task.sleep(for: .milliseconds(5))
+    }
+    if await !condition() {
+        XCTFail("timed out after \(timeout)s waiting for \(description)", file: file, line: line)
+    }
+}

--- a/Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift
+++ b/Tests/AnyDoorTests/DisplayBrightnessServiceTests.swift
@@ -31,8 +31,10 @@ final class DisplayBrightnessServiceTests: XCTestCase {
         service.setBrightness(0.1, for: displayID)
         service.setBrightness(0.2, for: displayID)
         service.setBrightness(0.3, for: displayID)
-        // wait for debounce window (30 ms) + execution slack
-        try await Task.sleep(nanoseconds: 200_000_000)
+        // Wait for the 30ms debounce to land its write, then settle briefly so a
+        // second write would still be observed by the count assertion below.
+        await waitUntil("the debounced write") { !backend.writeCalls.isEmpty }
+        try await Task.sleep(for: .milliseconds(100))
 
         XCTAssertEqual(backend.writeCalls.count, 1, "expected one consolidated write")
         XCTAssertEqual(backend.writeCalls.last?.value, 30) // 0.3 * 100
@@ -53,8 +55,10 @@ final class DisplayBrightnessServiceTests: XCTestCase {
         service.bumpForTesting(+0.0625, displayID: displayID)
         service.bumpForTesting(+0.0625, displayID: displayID)
         service.bumpForTesting(+0.0625, displayID: displayID)
-        // wait for debounce window (30 ms) + execution slack
-        try await Task.sleep(nanoseconds: 200_000_000)
+        // Same shape as the debounce test: wait for the write, then settle so an
+        // uncoalesced second write would be caught rather than raced past.
+        await waitUntil("the coalesced write") { !backend.writeCalls.isEmpty }
+        try await Task.sleep(for: .milliseconds(100))
 
         XCTAssertEqual(backend.writeCalls.count, 1, "rapid bumps must collapse to one write")
         XCTAssertEqual(backend.writeCalls.last?.value, 69) // 0.6875 * 100, rounded

--- a/Tests/AnyDoorTests/HostsPluginLifecycleTests.swift
+++ b/Tests/AnyDoorTests/HostsPluginLifecycleTests.swift
@@ -213,7 +213,10 @@ final class HostsPluginLifecycleTests: XCTestCase {
     }
 
     func testUninstallCancelsPendingApplyBeforeReleasingHelper() async throws {
-        let f = try makeFixture(debounceInterval: .milliseconds(100))
+        // A long debounce makes the pending-apply window wide enough that the
+        // uninstall below cannot lose a race with it: the claim under test is
+        // that uninstall cancels a pending apply, not that it beats 100ms.
+        let f = try makeFixture(debounceInterval: .seconds(5))
         defer { f.teardown() }
         f.registry.install(f.plugin.id)
         f.manager.createProfile(name: "Dev", content: "1.2.3.4 dev")
@@ -224,7 +227,11 @@ final class HostsPluginLifecycleTests: XCTestCase {
                 await f.manager.setActive(profile, true)
             }
         }
-        try await Task.sleep(for: .milliseconds(20))
+        // setActive flips isActive before scheduling the debounced apply, so this
+        // is the in-flight signal the fixed sleep was approximating.
+        await waitUntil("the activation to schedule its apply") {
+            f.manager.profiles.first(where: { $0.id == profileID })?.isActive == true
+        }
 
         try await f.registry.uninstall(f.plugin.id)
         await activation.value

--- a/Tests/AnyDoorTests/ImageConversionViewModelTests.swift
+++ b/Tests/AnyDoorTests/ImageConversionViewModelTests.swift
@@ -130,8 +130,9 @@ final class ImageConversionViewModelTests: XCTestCase {
         }
         XCTAssertTrue(model.qualityFirstFrameOnlyItemIDs.contains(item.id))
         model.clear()
-        try await Task.sleep(for: .milliseconds(50))
-        XCTAssertTrue(model.qualityFirstFrameOnlyItemIDs.isEmpty)
+        await waitUntil("clear() to drop the first-frame notice") {
+            model.qualityFirstFrameOnlyItemIDs.isEmpty
+        }
     }
 
     @MainActor
@@ -326,7 +327,9 @@ final class ImageConversionViewModelTests: XCTestCase {
         model.resetSidebarForPresentation()
 
         await model.cancelActiveWork()
-        try await Task.sleep(for: .milliseconds(100))
+        await waitUntil("cancellation to clear the preview and preflight state") {
+            model.previewState == .empty && model.qualityFirstFrameOnlyItemIDs.isEmpty
+        }
 
         XCTAssertEqual(model.previewState, .empty)
         XCTAssertTrue(model.qualityFirstFrameOnlyItemIDs.isEmpty)

--- a/Tests/AnyDoorTests/PortInventoryTests.swift
+++ b/Tests/AnyDoorTests/PortInventoryTests.swift
@@ -85,6 +85,9 @@ final class PortInventoryTests: XCTestCase {
         }
         private var queue: [Pending] = []
         private(set) var calls = 0
+        /// How many scans are parked on a continuation — lets a test wait for a
+        /// refresh to actually reach the scanner instead of sleeping for it.
+        var pendingCount: Int { queue.count }
         func resolve(with records: [PortRecord]) async {
             calls += 1
             if let next = queue.first {
@@ -348,17 +351,18 @@ final class PortInventoryTests: XCTestCase {
 
         // Start refresh #1 — it blocks awaiting the scanner.
         let t1: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
-        try await Task.sleep(for: .milliseconds(50))
+        await waitUntil("refresh #1 to reach the scanner") { await scanner.pendingCount == 1 }
         XCTAssertTrue(inv.isRefreshing, "first refresh should mark isRefreshing")
 
         // Start refresh #2 — also blocked.
         let t2: Task<Void, Never> = Task { @MainActor in await inv.refresh() }
-        try await Task.sleep(for: .milliseconds(50))
+        await waitUntil("refresh #2 to reach the scanner") { await scanner.pendingCount == 2 }
         XCTAssertTrue(inv.isRefreshing, "still refreshing with two in flight")
 
-        // Resolve the older one (refresh #1) first.
+        // Resolve the older one (refresh #1) first and let it finish completely —
+        // awaiting the task is the exact signal a sleep was approximating.
         await scanner.resolve(with: [])
-        try await Task.sleep(for: .milliseconds(50))
+        await t1.value
         XCTAssertTrue(inv.isRefreshing, "stale completion must NOT clear isRefreshing while #2 is still running")
 
         // Resolve the newer one.
@@ -367,7 +371,6 @@ final class PortInventoryTests: XCTestCase {
                        executablePath: nil, commandLine: nil,
                        binds: [PortBind(address: "*", family: .ipv4)])
         ])
-        await t1.value
         await t2.value
         XCTAssertFalse(inv.isRefreshing)
         XCTAssertEqual(inv.records.count, 1)


### PR DESCRIPTION
## Summary

Removes the remaining "sleep, then assert it must have happened" waits from the
test suite. Follow-up to #74, which fixed the one instance CI had already caught.

Adds `Tests/AnyDoorTests/AsyncWaiting.swift` — a `waitUntil(_:timeout:_:)` that
polls a condition and fails on timeout, accepting a sync or async closure (so
`{ flag }` and `{ await someActor.count == 2 }` both work). Then converts the
sites that raced:

| Test | Before | After |
| --- | --- | --- |
| `DisplayBrightnessServiceTests` (debounce, coalescing) | sleep 200ms, assert `writeCalls.count == 1` | wait for the write, settle 100ms, then assert the count — the coalescing claim stays pinned |
| `PortInventoryTests.testIsRefreshingClearsOnlyWhenAllInflightFinish` | three 50ms sleeps around `isRefreshing` | wait for each refresh to reach the scanner (new `pendingCount` on the blocking double), and `await t1.value` instead of sleeping past its completion |
| `ImageConversionViewModelTests` (first-frame notice, cancellation) | sleep 50ms / 100ms, assert cleared | wait for the state to settle |
| `HostsPluginLifecycleTests.testUninstallCancelsPendingApplyBeforeReleasingHelper` | sleep 20ms to get the activation in flight | wait for the real in-flight signal (`isActive`), and widen the fixture debounce to 5s |

That last one had a second, opposite race: the test had to fire `uninstall`
*within* the fixture's 100ms debounce or the apply would land and
`writeCount == 0` would fail. The claim under test is that uninstall cancels a
pending apply, not that it beats 100ms, so the window is now wide enough that
neither direction can race.

## Deliberately left alone

- **Sleeps backing a "must NOT happen" assertion** (`DisplayBrightnessServiceTests`
  backfill guard, `TranslationCoordinatorTests` deferred service,
  `PluginRegistryTests` uninstall drain, `PortScannerTests` cancellation). A
  bounded wait is inherent to an inverted claim, and a slow machine makes those
  more conservative, not flakier.
- **Sleeps inside test doubles** that simulate I/O latency (`MockDDCBackend`).
- **`HoverGateTests.testRapidRetriggerKeepsFirstShowDeadline`**, where the timing
  *is* the behaviour under test.
- **Existing poll-with-deadline helpers** (`AppIconCacheTests`,
  `ScriptDevPluginReloadTests`, `TranslationCoordinatorTests`,
  `HostsManagerTests`, and most of `ImageConversionViewModelTests`) already do
  the right thing; I did not churn them to route through the new helper.

## How was this tested?

- [x] `swift build --build-tests` — clean, no warnings
- [x] The five touched suites, three consecutive runs: 57 tests, 0 failures each
- [x] The same suites under synthetic load (32 spinning processes on 16 cores;
      runtime rose from 6.0s to 8.3s, so the load was real): 57 tests, 0 failures
- [x] Full suite: 1520 XCTest + 33 Swift Testing, 0 failures
- [x] Manually verified: n/a, test-only change

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; UI-facing strings are in Chinese via `L10n` / the `.xcstrings` catalog
- [x] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]` — n/a, no user-visible change
- [x] No new Swift 6 strict-concurrency warnings
