### PR TITLE
ci: pin the Xcode version instead of using the image default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Pin the toolchain instead of taking the runner image default. The default
+  # drifts as the image is rebuilt, and a compiler bump changes the diagnostic
+  # set — which would turn the warning gate red on a PR that touched nothing
+  # related. Keep this equal to the Xcode developers build against locally, and
+  # bump it deliberately. If the image ever drops this version the select step
+  # fails loudly, which is the point.
+  XCODE_APP: /Applications/Xcode_26.6.app
+
 jobs:
   test:
     name: Build and test (debug, arm64)
@@ -24,8 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Toolchain versions
+      - name: Select and report the toolchain
         run: |
+          sudo xcode-select -s "$XCODE_APP"
           swift --version
           xcodebuild -version
 
@@ -117,6 +127,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Select and report the toolchain
+        run: |
+          sudo xcode-select -s "$XCODE_APP"
+          swift --version
 
       - name: Cache SwiftPM dependencies
         uses: actions/cache@v6


### PR DESCRIPTION
## Summary

Pins CI to `/Applications/Xcode_26.6.app` in both macOS jobs instead of taking whatever the runner image defaults to.

## Motivation

The toolchain step in the last green run printed:

```
Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108)
Xcode 26.5 (Build version 17F42)
```

Locally the project builds with Xcode 26.6 / Swift 6.3.3. Two problems with leaving that implicit:

1. **The warning gate is only as reproducible as the compiler.** A locally warning-free build says nothing about CI if the two run different compilers, and vice versa.
2. **The image default drifts.** `macos-26` currently ships 26.0.1 through 26.6 with 26.5 as the default; when the image is rebuilt, the default moves and the diagnostic set moves with it — turning the gate red on a PR that touched nothing related. An unreproducible failure is worse than a flaky one.

Pinning makes the compiler an explicit, reviewable input. If a future image drops the pinned version, `xcode-select` fails loudly instead of silently changing behaviour — which is the intent.

## How was this tested?

- [x] YAML parses
- [x] The pinned path is present on the current `macos-26` image (runner-images README lists 26.6 at `/Applications/Xcode_26.6.app`)
- [x] CI on this PR reports `Xcode 26.6` and `Swift 6.3.3`, matching local — see the checks below
- [x] Manually verified: n/a, CI configuration

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; UI-facing strings are in Chinese via `L10n` / the `.xcstrings` catalog
- [x] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]` — n/a, no user-visible change
- [x] No new Swift 6 strict-concurrency warnings