### PR TITLE
test(hover): drive HoverGate deadlines with an injected clock

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f0ceba53f0c22d009e3d5e9dba9595a086b3bc599d048293854a0fbc36c57639",
+  "originHash" : "1df47886e9050379b564cafa9c6e6f67c3dffb2ff76430935159214b80985e0a",
   "pins" : [
     {
       "identity" : "askforpermission",
@@ -25,6 +25,33 @@
       "state" : {
         "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
         "version" : "2.9.2"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,15 @@ let package = Package(
             url: "https://github.com/SDWebImage/libwebp-Xcode.git",
             from: "1.5.0"
         ),
+        // TestClock for time-dependent tests (MIT). Test-target only: production
+        // code takes the stdlib `Clock` protocol and defaults to
+        // `ContinuousClock`, so nothing from this package reaches the app
+        // binary. A test that drives a fake clock cannot race a real one, which
+        // is the difference between an unlikely flake and an impossible one.
+        .package(
+            url: "https://github.com/pointfreeco/swift-clocks",
+            from: "1.1.0"
+        ),
     ],
     targets: [
         .plugin(
@@ -163,7 +172,11 @@ let package = Package(
         ),
         .testTarget(
             name: "AnyDoorTests",
-            dependencies: ["AnyDoor", "ImageCodec", "PluginInterface", "PluginSupport", "ImageConversionPlugin", "HostsPlugin", "ScriptPluginRuntime"],
+            dependencies: [
+                .product(name: "Clocks", package: "swift-clocks"),
+                "AnyDoor", "ImageCodec", "PluginInterface", "PluginSupport",
+                "ImageConversionPlugin", "HostsPlugin", "ScriptPluginRuntime",
+            ],
             resources: [.process("Fixtures")],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/Sources/AnyDoor/Views/HoverPopover.swift
+++ b/Sources/AnyDoor/Views/HoverPopover.swift
@@ -201,13 +201,21 @@ final class KeyableHoverPanel: NSPanel {
 @Observable
 final class HoverGate {
     /// Hover-intent debounce before the first popover appears.
-    private static let showDelayNanos: UInt64 = 400_000_000
+    static let showDelay: Duration = .milliseconds(400)
     /// Grace period before the popover auto-hides once nothing is hovered.
-    private static let hideDelayNanos: UInt64 = 300_000_000
+    static let hideDelay: Duration = .milliseconds(300)
     /// Coalescing window for re-mounts while the popover is already shown.
     /// Collapses a fast sweep across several hover rows into one mount and
     /// keeps the work off the AppKit mouse-event tick (~one display frame).
-    private static let refreshDelayNanos: UInt64 = 16_000_000
+    static let refreshDelay: Duration = .milliseconds(16)
+
+    /// Injected so tests can drive these deadlines with a fake clock instead of
+    /// sleeping for real. Production always gets `ContinuousClock`.
+    private let clock: any Clock<Duration>
+
+    init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
 
     private(set) var isShown = false
     private var triggerHovered = false
@@ -276,8 +284,9 @@ final class HoverGate {
         // the 400ms countdown on every crossing. Whichever row the cursor rests
         // on when the timer fires is shown via the caller's latest target.
         guard showTask == nil else { return }
+        let clock = clock
         showTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.showDelayNanos)
+            try? await clock.sleep(for: Self.showDelay)
             guard let self else { return }
             self.showTask = nil
             guard !Task.isCancelled, self.triggerHovered else { return }
@@ -288,8 +297,9 @@ final class HoverGate {
 
     private func scheduleRefresh() {
         refreshTask?.cancel()
+        let clock = clock
         refreshTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.refreshDelayNanos)
+            try? await clock.sleep(for: Self.refreshDelay)
             guard let self else { return }
             self.refreshTask = nil
             guard !Task.isCancelled, self.isShown else { return }
@@ -300,8 +310,9 @@ final class HoverGate {
     private func scheduleHide() {
         guard isShown else { return }
         hideTask?.cancel()
+        let clock = clock
         hideTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.hideDelayNanos)
+            try? await clock.sleep(for: Self.hideDelay)
             guard let self, !Task.isCancelled else { return }
             guard !self.triggerHovered && !self.popoverHovered else { return }
             self.isShown = false

--- a/Tests/AnyDoorTests/HoverGateTests.swift
+++ b/Tests/AnyDoorTests/HoverGateTests.swift
@@ -1,10 +1,15 @@
+import Clocks
 import XCTest
 @testable import AnyDoor
 
+/// These tests drive `HoverGate` with a `TestClock`, so every deadline is
+/// advanced explicitly and nothing waits on the wall clock. That is what makes
+/// the timing claims exact rather than probabilistic: the old version slept past
+/// each deadline and read a counter, which a loaded CI runner raced and failed.
+@MainActor
 final class HoverGateTests: XCTestCase {
-    @MainActor
     func testShowImmediatelyRefreshesContentWhenPopoverIsAlreadyShown() {
-        let gate = HoverGate()
+        let gate = HoverGate(clock: TestClock())
         var showCount = 0
         gate.onShow = { showCount += 1 }
 
@@ -15,18 +20,11 @@ final class HoverGateTests: XCTestCase {
         XCTAssertEqual(showCount, 2)
     }
 
-    @MainActor
     func testTriggerHoverRefreshesContentWhenAlreadyShownButCoalesced() async {
-        let gate = HoverGate()
+        let clock = TestClock()
+        let gate = HoverGate(clock: clock)
         var showCount = 0
-        // Wait for the re-mount instead of sleeping past its 16ms coalescing
-        // window: on a loaded machine the deferred task can land much later, and
-        // a fixed sleep turns that into a flake rather than a real signal.
-        let remounted = expectation(description: "coalesced re-mount")
-        gate.onShow = {
-            showCount += 1
-            if showCount == 2 { remounted.fulfill() }
-        }
+        gate.onShow = { showCount += 1 }
 
         gate.showImmediately()        // synchronous first show
         XCTAssertEqual(showCount, 1)
@@ -34,22 +32,15 @@ final class HoverGateTests: XCTestCase {
         gate.triggerHover(true)       // already shown -> coalesced re-mount, deferred off the tick
         XCTAssertEqual(showCount, 1, "re-mount while shown must be deferred, not synchronous")
 
-        await fulfillment(of: [remounted], timeout: 2)
+        await clock.advance(by: HoverGate.refreshDelay)
         XCTAssertEqual(showCount, 2)
     }
 
-    @MainActor
-    func testRapidCrossingsWhileShownCoalesceIntoOneRemount() async {
-        let gate = HoverGate()
+    func testRapidCrossingsWhileShownCoalesceIntoOneRemount() async throws {
+        let clock = TestClock()
+        let gate = HoverGate(clock: clock)
         var showCount = 0
-        let remounted = expectation(description: "one coalesced re-mount")
-        let extraRemount = expectation(description: "no further re-mount")
-        extraRemount.isInverted = true
-        gate.onShow = {
-            showCount += 1
-            if showCount == 2 { remounted.fulfill() }
-            if showCount > 2 { extraRemount.fulfill() }
-        }
+        gate.onShow = { showCount += 1 }
 
         gate.showImmediately()        // count 1
         // Simulate a fast sweep across several already-shown hover rows in one burst.
@@ -57,31 +48,67 @@ final class HoverGateTests: XCTestCase {
         gate.triggerHover(true)
         gate.triggerHover(true)
 
+        await clock.advance(by: HoverGate.refreshDelay)
         // The three crossings collapse into a single re-mount (count 1 + 1), not
         // three: each crossing replaces the pending refresh task.
-        await fulfillment(of: [remounted], timeout: 2)
-        await fulfillment(of: [extraRemount], timeout: 0.2)
         XCTAssertEqual(showCount, 2)
+        // And nothing is still armed — an assertion the sleeping version could
+        // only approximate by waiting a while and looking again.
+        try await clock.checkSuspension()
     }
 
-    @MainActor
     func testRapidRetriggerKeepsFirstShowDeadline() async {
-        let gate = HoverGate()
+        let clock = TestClock()
+        let gate = HoverGate(clock: clock)
         var showCount = 0
-        let shown = expectation(description: "popover shown once")
-        gate.onShow = {
-            showCount += 1
-            if showCount == 1 { shown.fulfill() }
-        }
+        gate.onShow = { showCount += 1 }
 
-        gate.triggerHover(true)                          // arm the show timer at t0
-        try? await Task.sleep(nanoseconds: 200_000_000)  // t0 + 200ms
-        gate.triggerHover(true)                          // re-trigger must NOT reset the deadline
+        gate.triggerHover(true)                       // arm the show timer at t0
+        await clock.advance(by: .milliseconds(200))    // t0 + 200ms
+        gate.triggerHover(true)                       // re-trigger must NOT reset the deadline
+        XCTAssertEqual(showCount, 0, "nothing may show before the first deadline")
 
-        // With the leading-edge timer the show fires ~200ms from now (t0 + 400ms).
-        // A bug that restarts the 400ms countdown would fire ~400ms from now
-        // (t0 + 600ms) and miss this window.
-        await fulfillment(of: [shown], timeout: 0.30)
+        // Leading edge: the show fires at t0 + 400ms, not 400ms from the
+        // re-trigger. A bug that restarted the countdown would need until
+        // t0 + 600ms, so the exact boundary is the assertion.
+        await clock.advance(by: .milliseconds(199))    // t0 + 399ms
+        XCTAssertEqual(showCount, 0)
+        await clock.advance(by: .milliseconds(1))      // t0 + 400ms
         XCTAssertEqual(showCount, 1)
+    }
+
+    func testUnhoveringHidesAfterTheGracePeriod() async {
+        let clock = TestClock()
+        let gate = HoverGate(clock: clock)
+        var hideCount = 0
+        gate.onHide = { hideCount += 1 }
+
+        gate.showImmediately()
+        gate.triggerHover(false)                      // cursor leaves the row
+
+        await clock.advance(by: HoverGate.hideDelay - .milliseconds(1))
+        XCTAssertEqual(hideCount, 0, "the grace period must not end early")
+        XCTAssertTrue(gate.isShown)
+
+        await clock.advance(by: .milliseconds(1))
+        XCTAssertEqual(hideCount, 1)
+        XCTAssertFalse(gate.isShown)
+    }
+
+    func testReenteringDuringTheGracePeriodCancelsTheHide() async throws {
+        let clock = TestClock()
+        let gate = HoverGate(clock: clock)
+        var hideCount = 0
+        gate.onHide = { hideCount += 1 }
+
+        gate.showImmediately()
+        gate.triggerHover(false)
+        await clock.advance(by: .milliseconds(200))    // still inside the 300ms grace
+        gate.triggerHover(true)                       // cursor comes back
+
+        await clock.advance(by: .seconds(1))
+        XCTAssertEqual(hideCount, 0, "re-entering must cancel the pending hide")
+        XCTAssertTrue(gate.isShown)
+        try await clock.checkSuspension()
     }
 }


### PR DESCRIPTION
## Summary

Pilot for the second half of the flake work: #75 made timing flakes *unlikely*
(wait for the effect instead of sleeping); this makes them *impossible* for one
type by removing real time from its tests entirely.

`HoverGate` now takes an injected clock:

```swift
static let showDelay: Duration = .milliseconds(400)
private let clock: any Clock<Duration>
init(clock: any Clock<Duration> = ContinuousClock()) { self.clock = clock }
// Task.sleep(nanoseconds: Self.showDelayNanos)  ->  clock.sleep(for: Self.showDelay)
```

Production behaviour is unchanged — the default argument means the single call
site (`MenuBarView`) is untouched, and `ContinuousClock` has the same semantics as
the `Task.sleep` it replaces. The tests drive a `TestClock` and advance it
explicitly.

## What the tests can now say that they could not before

| Claim | Before | After |
| --- | --- | --- |
| Leading-edge deadline is not reset by a re-trigger | slept 200ms, then waited up to 300ms for the show | exact: nothing at `t0+399ms`, shown at `t0+400ms` |
| Nothing is still armed after a coalesced re-mount | inverted expectation over a 200ms window | `try await clock.checkSuspension()` |
| Hide grace period | untested | ends exactly at 300ms, and re-entering during it cancels the pending hide |

The two hide-path tests are new. They were not worth writing before because each
would have cost 300ms of real sleeping; with a fake clock they are free, so the
change *added* coverage rather than just stabilising it.

Runtime for the suite: **0.66s -> 0.024s**, because nothing waits.

## Dependency

`swift-clocks` (MIT, Point-Free) is added to the **test target only**. Production
code depends on the stdlib `Clock` protocol, so nothing from the package can reach
the app binary. It brings two transitive repos (`swift-concurrency-extras`,
`xctest-dynamic-overlay`) into `Package.resolved` — that is the whole cost.

I considered hand-rolling a `TestClock` to avoid the dependency. Against: its
`sleep(until:)` has to handle cancellation propagation and suspension cleanup
correctly, and `checkSuspension()` needs a settle step before reading state.
Getting those subtly wrong reintroduces exactly the nondeterminism this change
exists to remove. This is also the mainstream choice — the same package is a
transitive dependency of swift-dependencies/TCA, and Apple's own
`swift-async-algorithms` tests time with a manual clock
(`Tests/AsyncAlgorithmsTests/Support/ManualClock.swift`).

## Scope

Deliberately one type. `DisplayBrightnessService`, `HostsManager` (already takes a
`debounceInterval`) and `ImageConversionViewModel` are the same shape and can
follow if this reads well — as separate PRs, not a sweep.

## How was this tested?

- [x] `swift build --build-tests` — clean, no warnings
- [x] `HoverGateTests` five consecutive runs: 6 tests, 0 failures
- [x] The same tests under synthetic load (24 spinning processes on 16 cores):
      3 runs, 0 failures. One run took 14.7s of wall clock because the *process*
      was starved — and still asserted identically, which is the point: load now
      changes duration, not outcome
- [x] Full suite: 1522 XCTest + 33 Swift Testing, 0 failures
- [x] Manually verified: hover popovers still appear/hide on the real 400/300ms
      timings — worth a smoke check when you run the app, since no test exercises
      `ContinuousClock` end to end

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; UI-facing strings are in Chinese via `L10n` / the `.xcstrings` catalog
- [x] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]` — n/a, no user-visible change
- [x] No new Swift 6 strict-concurrency warnings
