### PR TITLE
fix: use available feed XML validator

### DIFF
--- a/.github/workflows/deploy-feed.yml
+++ b/.github/workflows/deploy-feed.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Validate bootstrap feed
         if: github.event_name == 'workflow_dispatch' && inputs.bootstrap
         run: |
-          xmllint --noout appcast.xml
+          python3 -c 'import xml.etree.ElementTree as ET; ET.parse("appcast.xml")'
           if grep -q '<sparkle:channel>' appcast.xml; then
             echo 'Bootstrap feed must contain Stable items only' >&2
             exit 1


### PR DESCRIPTION
## Summary

- replace the unavailable `xmllint` bootstrap check with Python's standard-library XML parser
- keep malformed appcasts blocked before the canonical feed deployment

## Motivation

The first Update Feed bootstrap run failed before deployment because `ubuntu-latest` does not provide `xmllint`. Python 3 is already available on the runner and elsewhere in the release tooling.

Failed run: https://github.com/ZingerLittleBee/AnyDoor/actions/runs/31589920720

## How was this tested?

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] Manually verified:

Additional checks:

- Python XML parsing against the checked-in `appcast.xml`
- `scripts/verify-feed-bootstrap.sh https://anydoor.dev/appcast.xml`
- `actionlint .github/workflows/deploy-feed.yml`
- `git diff --check`

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code comments are in English; no UI-facing strings changed
- [x] No user-visible change requiring a `CHANGELOG.md` entry
- [x] No Swift code or concurrency behavior changed
