### PR TITLE
fix: route feed cache-busting requests

### DIFF
--- a/feed/wrangler.jsonc
+++ b/feed/wrangler.jsonc
@@ -7,7 +7,7 @@
   "preview_urls": false,
   "routes": [
     {
-      "pattern": "anydoor.dev/appcast.xml",
+      "pattern": "anydoor.dev/appcast.xml*",
       "zone_name": "anydoor.dev"
     }
   ],


### PR DESCRIPTION
## Summary

- route cache-busting requests for the canonical appcast through the feed Worker
- keep the Worker's exact pathname and method validation unchanged

## Motivation

The bootstrap deployment succeeded, and the canonical bare URL now serves the appcast. Its post-deploy verification failed because the Cloudflare route `anydoor.dev/appcast.xml` did not match `/appcast.xml?deployment=...`, so the verification request fell through to the landing site and returned 404.

Failed verification: https://github.com/ZingerLittleBee/AnyDoor/actions/runs/31591176574

## How was this tested?

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] Manually verified:

Additional checks:

- `bunx wrangler@4.94.0 deploy --dry-run --config feed/wrangler.jsonc`
- `git diff --check`
- confirmed the deployed bare feed returns `200 application/xml`
- confirmed the cache-busting URL currently falls through with `404`

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No user-facing strings or Swift code changed
- [x] No user-visible change requiring a `CHANGELOG.md` entry
