### PR TITLE
fix: add safe feed deployment recovery

### DIFF
--- a/.github/workflows/deploy-feed.yml
+++ b/.github/workflows/deploy-feed.yml
@@ -20,6 +20,10 @@ on:
         description: 'Deploy the checked-in Stable-only feed when the endpoint does not exist yet'
         type: boolean
         default: false
+      repair:
+        description: 'Redeploy routing only when the live feed exactly matches the checked-in feed'
+        type: boolean
+        default: false
 
 concurrency:
   group: anydoor-update-feed
@@ -81,6 +85,10 @@ jobs:
       - name: Validate bootstrap feed
         if: github.event_name == 'workflow_dispatch' && inputs.bootstrap
         run: |
+          if [[ "${{ inputs.repair }}" == 'true' ]]; then
+            echo 'Bootstrap and repair cannot run together' >&2
+            exit 1
+          fi
           python3 -c 'import xml.etree.ElementTree as ET; ET.parse("appcast.xml")'
           if grep -q '<sparkle:channel>' appcast.xml; then
             echo 'Bootstrap feed must contain Stable items only' >&2
@@ -88,15 +96,25 @@ jobs:
           fi
           scripts/verify-feed-bootstrap.sh 'https://anydoor.dev/appcast.xml'
 
+      - name: Validate repair feed
+        if: github.event_name == 'workflow_dispatch' && inputs.repair
+        run: |
+          curl --fail --silent --show-error \
+            --connect-timeout 10 --max-time 60 \
+            -H 'Cache-Control: no-cache' \
+            'https://anydoor.dev/appcast.xml' \
+            -o /tmp/live-appcast.xml
+          cmp appcast.xml /tmp/live-appcast.xml
+
       - name: Deploy canonical feed
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.bootstrap)
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.bootstrap || inputs.repair))
         run: bunx wrangler@4.94.0 deploy --config feed/wrangler.jsonc
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Verify deployed bytes
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.bootstrap)
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.bootstrap || inputs.repair))
         run: |
           curl --fail --silent --show-error \
             --connect-timeout 10 --max-time 60 \


### PR DESCRIPTION
## Summary

- add an explicit Update Feed repair operation for post-deploy recovery
- require the live feed to match the checked-in appcast byte-for-byte before redeploying
- keep bootstrap restricted to an absent endpoint and reject combined bootstrap/repair requests

## Motivation

The initial bootstrap deployed the canonical feed successfully, but its cache-busting verification URL fell through to the landing site. After the route fix, bootstrap cannot safely be rerun because the endpoint now exists. The repair operation closes that recovery gap without permitting feed content changes or rollbacks.

Related runs:

- initial bootstrap deployment with failed post-check: https://github.com/ZingerLittleBee/AnyDoor/actions/runs/31591176574
- route fix: #104

## How was this tested?

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] Manually verified:

Additional checks:

- `actionlint .github/workflows/deploy-feed.yml`
- live canonical feed compared byte-for-byte with `appcast.xml`
- `bunx wrangler@4.94.0 deploy --dry-run --config feed/wrangler.jsonc`
- `git diff --check`

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No user-facing strings or Swift code changed
- [x] No user-visible change requiring a `CHANGELOG.md` entry
