### PR TITLE
fix: retry feed deployment verification

### DIFF
--- a/.github/workflows/deploy-feed.yml
+++ b/.github/workflows/deploy-feed.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           curl --fail --silent --show-error \
             --connect-timeout 10 --max-time 60 \
+            --retry 12 --retry-delay 2 --retry-max-time 60 --retry-all-errors \
             -H 'Cache-Control: no-cache' \
             "https://anydoor.dev/appcast.xml?deployment=${GITHUB_RUN_ID}" \
             -o /tmp/deployed-appcast.xml


### PR DESCRIPTION
## Summary

- retry post-deploy appcast verification during the bounded Cloudflare route propagation window
- preserve cache-busting and byte-for-byte comparison after a successful response

## Motivation

The repaired route deployed successfully and the exact live feed matched the checked-in appcast. Its immediate verification request briefly returned 404, then the same cache-busting URL returned `200 application/xml` seconds later. This is a propagation race, not a failed deployment.

Failed immediate verification: https://github.com/ZingerLittleBee/AnyDoor/actions/runs/31592004373

## How was this tested?

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] Manually verified:

Additional checks:

- `actionlint .github/workflows/deploy-feed.yml`
- the retry-enabled curl command fetched the cache-busting URL
- downloaded bytes matched `appcast.xml`
- `git diff --check`

## Checklist

- [x] Commit messages are in English and follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No user-facing strings or Swift code changed
- [x] No user-visible change requiring a `CHANGELOG.md` entry
