### PR TITLE
refactor(clipboard): deepen history mutation seams

### DIFF
--- a/Sources/AnyDoor/AppDelegate.swift
+++ b/Sources/AnyDoor/AppDelegate.swift
@@ -14,6 +14,7 @@ private let logger = Logger(subsystem: "dev.bybee.AnyDoor", category: "persisten
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let modelContainer: ModelContainer
     let clipboardHistoryModule: ClipboardHistoryModule
+    let clipboardProduction: ClipboardProductionAdapter
     private let persistenceBootstrap: AppPersistenceBootstrap
     @MainActor lazy var clipboardHistoryLifecycle = {
         let appSupport = FileManager.default.urls(
@@ -90,7 +91,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // scrollbar entirely, and the one-frame flash that any after-the-fact
         // restyling causes on a Settings tab switch. See OverlayScrollers.swift.
         UserDefaults.standard.set("WhenScrolling", forKey: "AppleShowScrollBars")
-        clipboardHistoryModule = ClipboardHistoryModule()
+        let clipboardHistoryModule = ClipboardHistoryModule()
+        self.clipboardHistoryModule = clipboardHistoryModule
+        clipboardProduction = ClipboardProductionAdapter(
+            module: clipboardHistoryModule,
+            selfWrites: clipboardHistoryModule.pasteboardSelfWrites
+        )
         do {
             let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
             let storeDir = appSupport.appendingPathComponent("dev.bybee.AnyDoor", isDirectory: true)
@@ -158,7 +164,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             lifecycle: clipboardHistoryLifecycle
         )
         CaptureCoordinator.shared.configure(
-            clipboardHistoryModule: clipboardHistoryModule
+            clipboardHistoryModule: clipboardHistoryModule,
+            clipboardProduction: clipboardProduction
         )
 
         // Run migrations / seeding on the main context
@@ -203,7 +210,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             PluginUsageMigration.runIfNeeded(plugins: plugins, in: context)
         }
         let coreProviders = BuiltinProviderRegistry.makeAll(
-            clipboardHistoryModule: clipboardHistoryModule,
+            clipboardProduction: clipboardProduction,
             clipboardHistoryLifecycle: clipboardHistoryLifecycle,
             onKeepAwakeChange: { state in
                 PanelStore.shared.onKeepAwakeStateChange(state)

--- a/Sources/AnyDoor/Services/Capture/CaptureCoordinator.swift
+++ b/Sources/AnyDoor/Services/Capture/CaptureCoordinator.swift
@@ -22,6 +22,7 @@ final class CaptureCoordinator {
 
     private let settings: CaptureSettings
     private var clipboardHistoryModule: ClipboardHistoryModule?
+    private var clipboardProduction: ClipboardProductionAdapter?
     private let selectionOverlay = SelectionOverlayWindow()
     private var lastRegionRequest: CaptureRequest?
     private var inFlight = false
@@ -33,13 +34,16 @@ final class CaptureCoordinator {
     }
 
     func configure(
-        clipboardHistoryModule: ClipboardHistoryModule
+        clipboardHistoryModule: ClipboardHistoryModule,
+        clipboardProduction: ClipboardProductionAdapter
     ) {
         precondition(
-            self.clipboardHistoryModule == nil,
+            self.clipboardHistoryModule == nil
+                && self.clipboardProduction == nil,
             "CaptureCoordinator may only be configured once"
         )
         self.clipboardHistoryModule = clipboardHistoryModule
+        self.clipboardProduction = clipboardProduction
     }
 
     /// Entry point used by every provider. Guards against re-entrancy.
@@ -293,8 +297,9 @@ final class CaptureCoordinator {
     /// Apply output policy and show the quick-access overlay. The PNG encode and
     /// auto-save disk write run OFF the main actor (a fullscreen Retina/5K grab
     /// is tens of MB; doing them inline beachballed the menu bar / all UI until
-    /// the shot landed). The clipboard copy stays inline so it is ready instantly;
-    /// the overlay + toast resume on the main actor once the heavy work finishes.
+    /// the shot landed). Once encoding finishes, the production adapter performs
+    /// the optional clipboard copy and explicit history capture in order; the
+    /// overlay and toast resume on the main actor afterward.
     ///
     /// Safe w.r.t. the SCK executor-tracking bug documented on the type: the
     /// capture grab is already complete and synchronous, and this mirrors the
@@ -306,18 +311,9 @@ final class CaptureCoordinator {
 
         let image = NSImage(cgImage: cg, size: .zero)
 
-        // Cheap and latency-sensitive: copy to the pasteboard right away (AppKit
-        // encodes the bitmap lazily) so the clipboard is ready the instant the
-        // shot lands, before the PNG encode below.
-        if settings.autoCopy {
-            ClipboardSelfWrites.perform { pb in
-                pb.clearContents()
-                pb.writeObjects([image])
-            }
-        }
-
         // Snapshot the main-actor settings the off-main save needs (all Sendable).
         let autoSave = settings.autoSave
+        let autoCopy = settings.autoCopy
         let saveDir = settings.saveDirectory
         let template = settings.namingTemplate
         let overlayTimeout = settings.overlayTimeout
@@ -335,6 +331,24 @@ final class CaptureCoordinator {
                 return
             }
 
+            let recordedID = HistoryIDBox()
+            if let clipboardProduction = self.clipboardProduction {
+                do {
+                    recordedID.value = try await clipboardProduction
+                        .produceScreenshot(
+                            image: image,
+                            png: png,
+                            copyToPasteboard: autoCopy
+                        ).capture.entryID
+                } catch {
+                    ToastPresenter.shared.show(
+                        .failure(L(.captureToastFailed))
+                    )
+                }
+            } else {
+                ToastPresenter.shared.show(.failure(L(.captureToastFailed)))
+            }
+
             var savedURL: URL?
             if autoSave {
                 savedURL = await Task.detached(priority: .userInitiated) {
@@ -344,29 +358,6 @@ final class CaptureCoordinator {
                     ToastPresenter.shared.show(.success(L(.captureToastSaved, saveDir.lastPathComponent)))
                 } else {
                     ToastPresenter.shared.show(.failure(L(.captureToastFailed)))
-                }
-            }
-
-            // Shared box so the delete action can remove the exact history entry
-            // once the async record completes (both hops run on the main actor).
-            let recordedID = HistoryIDBox()
-            if let module = self.clipboardHistoryModule {
-                Task {
-                    recordedID.value = try? await module.capture(
-                        ClipboardHistoryCaptureRequest(
-                            source: .anyDoor,
-                            content: .bitmap(
-                                png,
-                                provenance: .anyDoorScreenshot
-                            )
-                        )
-                    ).entryID
-                    if recordedID.value != nil {
-                        NotificationCenter.default.post(
-                            name: .clipboardHistoryV2DidMutate,
-                            object: nil
-                        )
-                    }
                 }
             }
 
@@ -388,14 +379,7 @@ final class CaptureCoordinator {
                         let module = self.clipboardHistoryModule
                     {
                         Task {
-                            if (try? await module.apply(.delete(id)))
-                                != nil
-                            {
-                                NotificationCenter.default.post(
-                                    name: .clipboardHistoryV2DidMutate,
-                                    object: nil
-                                )
-                            }
+                            _ = try? await module.apply(.delete(id))
                         }
                     }
                     ToastPresenter.shared.show(.success(L(.captureToastDeleted)))
@@ -476,11 +460,16 @@ final class CaptureCoordinator {
     }
 
     private func copyToPasteboard(_ image: NSImage) {
-        ClipboardSelfWrites.perform { pb in
-            pb.clearContents()
-            pb.writeObjects([image])
+        guard let clipboardProduction else {
+            ToastPresenter.shared.show(.failure(L(.captureToastFailed)))
+            return
         }
-        ToastPresenter.shared.show(.success(L(.captureToastCopied)))
+        do {
+            try clipboardProduction.copyExistingScreenshot(image)
+            ToastPresenter.shared.show(.success(L(.captureToastCopied)))
+        } catch {
+            ToastPresenter.shared.show(.failure(L(.captureToastFailed)))
+        }
     }
 
     private func runOCR(_ image: NSImage) {
@@ -495,22 +484,24 @@ final class CaptureCoordinator {
                         ToastPresenter.shared.show(.failure(L(.toastOcrNoText)))
                         return
                     }
-                    ClipboardSelfWrites.write(string: text)
-                    if let module = self.clipboardHistoryModule {
-                        Task {
-                            _ = try? await module.capture(
-                                ClipboardHistoryCaptureRequest(
-                                    source: .anyDoor,
-                                    content: .ocr(text)
-                                )
+                    guard let clipboardProduction = self.clipboardProduction else {
+                        ToastPresenter.shared.show(
+                            .failure(L(.toastRecognitionFailed))
+                        )
+                        return
+                    }
+                    Task {
+                        do {
+                            _ = try await clipboardProduction.produceOCR(text)
+                            ToastPresenter.shared.show(
+                                .success(L(.toastCopiedToClipboard))
                             )
-                            NotificationCenter.default.post(
-                                name: .clipboardHistoryV2DidMutate,
-                                object: nil
+                        } catch {
+                            ToastPresenter.shared.show(
+                                .failure(L(.toastRecognitionFailed))
                             )
                         }
                     }
-                    ToastPresenter.shared.show(.success(L(.toastCopiedToClipboard)))
                 }
             } catch {
                 await MainActor.run { ToastPresenter.shared.show(.failure(L(.toastRecognitionFailed))) }
@@ -544,9 +535,7 @@ final class CaptureCoordinator {
     }
 }
 
-/// Mutable holder for the recorded history id, shared between the async record
-/// task and the overlay's delete action. Main-actor confined, so the two hops
-/// never race.
+/// Mutable holder for the recorded history id captured by the overlay actions.
 @MainActor private final class HistoryIDBox {
     var value: ClipboardHistoryEntryID?
 }

--- a/Sources/AnyDoor/Services/ClipboardHistoryPresentationModel.swift
+++ b/Sources/AnyDoor/Services/ClipboardHistoryPresentationModel.swift
@@ -371,7 +371,6 @@ final class ClipboardHistoryPresentationModel {
             )
             upsertTagDefinition(assignment.definition)
             replaceEntry(assignment.entry)
-            notifyMutation()
             return true
         } catch {
             actionFailure = ClipboardHistoryActionFailure(error)
@@ -390,7 +389,6 @@ final class ClipboardHistoryPresentationModel {
                 name
             )
             upsertTagDefinition(definition)
-            notifyMutation()
             return true
         } catch {
             actionFailure = ClipboardHistoryActionFailure(error)
@@ -415,7 +413,6 @@ final class ClipboardHistoryPresentationModel {
                     source: entry.source
                 )
             }
-            notifyMutation()
             return true
         } catch {
             actionFailure = ClipboardHistoryActionFailure(error)
@@ -532,7 +529,6 @@ final class ClipboardHistoryPresentationModel {
                     entries[index] = entry
                 }
                 invalidateMaterializations(for: entry.id)
-                notifyMutation()
                 if Self.requiresRefetch(for: mutation, query: query) {
                     await loadFirstPage(preservingSelection: true)
                 }
@@ -559,7 +555,6 @@ final class ClipboardHistoryPresentationModel {
                 if entries.isEmpty {
                     contentState = .empty
                 }
-                notifyMutation()
             case .notFound:
                 break
             }
@@ -793,13 +788,6 @@ final class ClipboardHistoryPresentationModel {
         }
         entries[index] = entry
         invalidateMaterializations(for: entry.id)
-    }
-
-    private func notifyMutation() {
-        NotificationCenter.default.post(
-            name: .clipboardHistoryV2DidMutate,
-            object: nil
-        )
     }
 
     private static func sourceName(

--- a/Sources/AnyDoor/Services/ClipboardHistorySettingsModel.swift
+++ b/Sources/AnyDoor/Services/ClipboardHistorySettingsModel.swift
@@ -281,7 +281,6 @@ final class ClipboardHistorySettingsModel {
             switch try await module.confirm(confirmation.preview.token) {
             case .applied:
                 clearConfirmation = nil
-                await module.advanceMonitoringBaseline()
                 await refreshStorageUsage()
             case .stale(let preview):
                 clearConfirmation = ClipboardHistoryClearConfirmation(

--- a/Sources/AnyDoor/Services/ClipboardSelfWrites.swift
+++ b/Sources/AnyDoor/Services/ClipboardSelfWrites.swift
@@ -34,3 +34,136 @@ enum ClipboardSelfWrites {
         funnel
     }
 }
+
+struct ClipboardProductionOutcome: Equatable, Sendable {
+    let capture: ClipboardHistoryCaptureOutcome
+    let pasteboardChangeCount: Int?
+}
+
+enum ClipboardProductionError: Error, Equatable {
+    case pasteboardWriteFailed
+}
+
+/// Produces explicit AnyDoor clipboard values through one ordered host seam.
+///
+/// Every production first suppresses its optional pasteboard write, then records
+/// the corresponding semantic Clipboard History capture. A successful result is
+/// returned only after both required mutations complete.
+@MainActor
+final class ClipboardProductionAdapter {
+    private let module: ClipboardHistoryModule
+    private let selfWrites: ClipboardHistoryPasteboardSelfWriteFunnel
+    private let pasteboard: NSPasteboard
+
+    init(
+        module: ClipboardHistoryModule,
+        selfWrites: ClipboardHistoryPasteboardSelfWriteFunnel,
+        pasteboard: NSPasteboard = .general
+    ) {
+        self.module = module
+        self.selfWrites = selfWrites
+        self.pasteboard = pasteboard
+    }
+
+    func produceOCR(_ text: String) async throws
+        -> ClipboardProductionOutcome
+    {
+        try await produce(
+            content: .ocr(text),
+            write: Self.writeString(text)
+        )
+    }
+
+    func produceQRCode(_ text: String) async throws
+        -> ClipboardProductionOutcome
+    {
+        try await produce(
+            content: .qrCode(text),
+            write: Self.writeString(text)
+        )
+    }
+
+    func produceColor(
+        hex: String,
+        pasteboardValue: String
+    ) async throws -> ClipboardProductionOutcome {
+        try await produce(
+            content: .color(hex),
+            write: Self.writeString(pasteboardValue)
+        )
+    }
+
+    func produceScreenshot(
+        image: NSImage,
+        png: Data,
+        copyToPasteboard: Bool
+    ) async throws -> ClipboardProductionOutcome {
+        try await produce(
+            content: .bitmap(
+                png,
+                provenance: .anyDoorScreenshot
+            ),
+            write: copyToPasteboard
+                ? { pasteboard in
+                    pasteboard.clearContents()
+                    guard pasteboard.writeObjects([image]) else {
+                        throw ClipboardProductionError.pasteboardWriteFailed
+                    }
+                }
+                : nil
+        )
+    }
+
+    /// Copying an already-recorded screenshot is usage, not a new capture.
+    @discardableResult
+    func copyExistingScreenshot(_ image: NSImage) throws -> Int {
+        try write { pasteboard in
+            pasteboard.clearContents()
+            guard pasteboard.writeObjects([image]) else {
+                throw ClipboardProductionError.pasteboardWriteFailed
+            }
+        }
+    }
+
+    private func produce(
+        content: ClipboardHistoryCaptureContent,
+        write pasteboardWrite: ((NSPasteboard) throws -> Void)?
+    ) async throws -> ClipboardProductionOutcome {
+        let changeCount: Int?
+        if let pasteboardWrite {
+            changeCount = try write(pasteboardWrite)
+        } else {
+            changeCount = nil
+        }
+        let capture = try await module.capture(
+            ClipboardHistoryCaptureRequest(
+                source: .anyDoor,
+                content: content
+            )
+        )
+        return ClipboardProductionOutcome(
+            capture: capture,
+            pasteboardChangeCount: changeCount
+        )
+    }
+
+    private func write(
+        _ pasteboardWrite: (NSPasteboard) throws -> Void
+    ) throws -> Int {
+        try selfWrites.perform(to: pasteboard) { pasteboard in
+            try pasteboardWrite(pasteboard)
+            return pasteboard.changeCount
+        }
+    }
+
+    private static func writeString(
+        _ value: String
+    ) -> (NSPasteboard) throws -> Void {
+        { pasteboard in
+            pasteboard.clearContents()
+            guard pasteboard.setString(value, forType: .string) else {
+                throw ClipboardProductionError.pasteboardWriteFailed
+            }
+        }
+    }
+}

--- a/Sources/AnyDoor/Services/Providers/BuiltinProviderRegistry.swift
+++ b/Sources/AnyDoor/Services/Providers/BuiltinProviderRegistry.swift
@@ -1,4 +1,3 @@
-import ClipboardHistory
 import Foundation
 import PluginInterface
 
@@ -15,7 +14,7 @@ import PluginInterface
 @MainActor
 enum BuiltinProviderRegistry {
     static func makeAll(
-        clipboardHistoryModule: ClipboardHistoryModule,
+        clipboardProduction: ClipboardProductionAdapter,
         clipboardHistoryLifecycle: ClipboardHistoryLifecycle? = nil,
         onKeepAwakeChange: @escaping @MainActor @Sendable (KeepAwakeState) -> Void
     ) -> [any BuiltinProvider] {
@@ -46,9 +45,9 @@ enum BuiltinProviderRegistry {
             RestartMenuBarProvider(),
             FlushDNSProvider(),
             KeyboardLockProvider(),
-            OCRProvider(module: clipboardHistoryModule),
-            QRCodeProvider(module: clipboardHistoryModule),
-            PickColorProvider(module: clipboardHistoryModule),
+            OCRProvider(clipboardProduction: clipboardProduction),
+            QRCodeProvider(clipboardProduction: clipboardProduction),
+            PickColorProvider(clipboardProduction: clipboardProduction),
             ClipboardMonitoringProvider(
                 lifecycle: clipboardHistoryLifecycle
             ),

--- a/Sources/AnyDoor/Services/Providers/OCRProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/OCRProvider.swift
@@ -1,6 +1,4 @@
 import AppKit
-import ClipboardHistory
-import Foundation
 import PluginInterface
 
 /// Captures a screen region, recognizes its text with Vision, copies the text to
@@ -9,10 +7,10 @@ import PluginInterface
 /// Every error is absorbed and mapped to a toast — `run()` never propagates.
 actor OCRProvider: ActionProvider {
     let itemKey: BuiltinItem = .ocr
-    private let module: ClipboardHistoryModule
+    private let clipboardProduction: ClipboardProductionAdapter
 
-    init(module: ClipboardHistoryModule) {
-        self.module = module
+    init(clipboardProduction: ClipboardProductionAdapter) {
+        self.clipboardProduction = clipboardProduction
     }
 
     var permission: PermissionStatus { .notRequired }
@@ -29,19 +27,7 @@ actor OCRProvider: ActionProvider {
                 return
             }
             let text = lines.joined(separator: "\n")
-            // Self-write so the watcher doesn't re-capture this OCR result as
-            // a generic text entry.
-            await ClipboardSelfWrites.write(string: text)
-            _ = try await module.capture(
-                ClipboardHistoryCaptureRequest(
-                    source: .anyDoor,
-                    content: .ocr(text)
-                )
-            )
-            NotificationCenter.default.post(
-                name: .clipboardHistoryV2DidMutate,
-                object: nil
-            )
+            _ = try await clipboardProduction.produceOCR(text)
             let successMsg = await MainActor.run { L(.toastCopiedToClipboard) }
             await ToastPresenter.shared.show(.success(successMsg))
         } catch OCRError.screenCapturePermissionDenied {

--- a/Sources/AnyDoor/Services/Providers/PickColorProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/PickColorProvider.swift
@@ -1,6 +1,4 @@
 import AppKit
-import ClipboardHistory
-import Foundation
 import PluginInterface
 
 /// Presents the macOS system color-sampling loupe, copies the picked color to
@@ -10,10 +8,10 @@ import PluginInterface
 /// Every error is absorbed and mapped to a toast — `run()` never propagates.
 actor PickColorProvider: ActionProvider {
     let itemKey: BuiltinItem = .pickColor
-    private let module: ClipboardHistoryModule
+    private let clipboardProduction: ClipboardProductionAdapter
 
-    init(module: ClipboardHistoryModule) {
-        self.module = module
+    init(clipboardProduction: ClipboardProductionAdapter) {
+        self.clipboardProduction = clipboardProduction
     }
 
     var permission: PermissionStatus { .notRequired }
@@ -29,19 +27,10 @@ actor PickColorProvider: ActionProvider {
             // Copy in the user's preferred output format; history still stores the
             // raw hex (the color bucket is hex-based and renders the swatch).
             let formatted = ColorFormat.current.format(hex: hex) ?? hex
-            // Self-write so the watcher doesn't re-capture this picked color
-            // as a generic text entry.
-            await ClipboardSelfWrites.write(string: formatted)
             do {
-                _ = try await module.capture(
-                    ClipboardHistoryCaptureRequest(
-                        source: .anyDoor,
-                        content: .color(hex)
-                    )
-                )
-                NotificationCenter.default.post(
-                    name: .clipboardHistoryV2DidMutate,
-                    object: nil
+                _ = try await clipboardProduction.produceColor(
+                    hex: hex,
+                    pasteboardValue: formatted
                 )
             } catch {
                 let msg = await MainActor.run { L(.toastPickColorFailed) }

--- a/Sources/AnyDoor/Services/Providers/QRCodeProvider.swift
+++ b/Sources/AnyDoor/Services/Providers/QRCodeProvider.swift
@@ -1,6 +1,4 @@
 import AppKit
-import ClipboardHistory
-import Foundation
 import PluginInterface
 
 /// Captures a screen region, decodes any QR codes inside it with Vision, copies
@@ -13,10 +11,10 @@ import PluginInterface
 /// Every error is absorbed and mapped to a toast — `run()` never propagates.
 actor QRCodeProvider: ActionProvider {
     let itemKey: BuiltinItem = .qrcode
-    private let module: ClipboardHistoryModule
+    private let clipboardProduction: ClipboardProductionAdapter
 
-    init(module: ClipboardHistoryModule) {
-        self.module = module
+    init(clipboardProduction: ClipboardProductionAdapter) {
+        self.clipboardProduction = clipboardProduction
     }
 
     var permission: PermissionStatus { .notRequired }
@@ -33,19 +31,7 @@ actor QRCodeProvider: ActionProvider {
                 return
             }
             let text = payloads.joined(separator: "\n")
-            // Self-write so the watcher doesn't re-capture this QR payload as
-            // a generic text entry.
-            await ClipboardSelfWrites.write(string: text)
-            _ = try await module.capture(
-                ClipboardHistoryCaptureRequest(
-                    source: .anyDoor,
-                    content: .qrCode(text)
-                )
-            )
-            NotificationCenter.default.post(
-                name: .clipboardHistoryV2DidMutate,
-                object: nil
-            )
+            _ = try await clipboardProduction.produceQRCode(text)
             let successMsg = await MainActor.run { L(.toastCopiedToClipboard) }
             await ToastPresenter.shared.show(.success(successMsg))
         } catch OCRError.screenCapturePermissionDenied {

--- a/Sources/ClipboardHistory/ClipboardHistoryCapture.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryCapture.swift
@@ -136,6 +136,9 @@ extension ClipboardHistoryModule {
         _ request: ClipboardHistoryPasteboardCaptureRequest,
         source: ClipboardHistoryCaptureSource
     ) throws -> ClipboardHistoryPasteboardCaptureOutcome {
+        guard !isFinalizingClear else {
+            return .skipped(.generationChanged)
+        }
         switch request.snapshotRead {
         case .rejected(let rejection):
             return .skipped(rejection)
@@ -148,6 +151,7 @@ extension ClipboardHistoryModule {
                 snapshot = value
             }
             let outcome = try persist(snapshot, source: source)
+            publishMutation()
             return .captured(outcome)
         }
     }

--- a/Sources/ClipboardHistory/ClipboardHistoryCaptureMonitor.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryCaptureMonitor.swift
@@ -287,10 +287,6 @@ final class ClipboardHistoryCaptureMonitor {
                         observationRequested = true
                     } else if case .captured = outcome {
                         instrumentation.recordCapture()
-                        NotificationCenter.default.post(
-                            name: .clipboardHistoryV2DidMutate,
-                            object: nil
-                        )
                     }
                 } catch {
                     reportOperationFailureIfNeeded(at: now())

--- a/Sources/ClipboardHistory/ClipboardHistoryLegacyRestore.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryLegacyRestore.swift
@@ -306,6 +306,7 @@ extension ClipboardHistoryModule {
             throw ClipboardHistoryModuleError.legacyFileRestoreFailed
         }
         await enqueueReclamation(for: retiredPayloadPaths)
+        publishMutation()
         return .restored(memberCount: resolved.count)
     }
 

--- a/Sources/ClipboardHistory/ClipboardHistoryModule.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryModule.swift
@@ -20,8 +20,10 @@ public actor ClipboardHistoryModule {
     var monitoringRequested = false
     var monitoringConfiguration = ClipboardHistoryMonitoringConfiguration()
     var captureMonitor: ClipboardHistoryCaptureMonitor?
+    var isFinalizingClear = false
     let selfWriteSuppression: ClipboardHistorySelfWriteSuppression
     let monitorInstrumentation: ClipboardHistoryMonitorInstrumentation
+    let notificationCenter: NotificationCenter
     public nonisolated let pasteboardSelfWrites:
         ClipboardHistoryPasteboardSelfWriteFunnel
     let storeRoot: URL
@@ -56,6 +58,7 @@ public actor ClipboardHistoryModule {
         let suppression = ClipboardHistorySelfWriteSuppression()
         selfWriteSuppression = suppression
         monitorInstrumentation = ClipboardHistoryMonitorInstrumentation()
+        notificationCenter = .default
         pasteboardSelfWrites = ClipboardHistoryPasteboardSelfWriteFunnel(
             suppression: suppression
         )
@@ -115,11 +118,13 @@ public actor ClipboardHistoryModule {
         faultInjector: ClipboardHistoryFaultInjector =
             ClipboardHistoryFaultInjector(),
         visionRecognizer: any ClipboardHistoryVisionRecognizing =
-            ClipboardHistoryVisionRecognizer()
+            ClipboardHistoryVisionRecognizer(),
+        notificationCenter: NotificationCenter = .default
     ) throws {
         let suppression = ClipboardHistorySelfWriteSuppression()
         selfWriteSuppression = suppression
         monitorInstrumentation = ClipboardHistoryMonitorInstrumentation()
+        self.notificationCenter = notificationCenter
         pasteboardSelfWrites = ClipboardHistoryPasteboardSelfWriteFunnel(
             suppression: suppression
         )
@@ -174,11 +179,13 @@ public actor ClipboardHistoryModule {
             CanonicalIdentity.sha256,
         duplicateReuseEnabled: Bool = true,
         visionRecognizer: any ClipboardHistoryVisionRecognizing =
-            ClipboardHistoryVisionRecognizer()
+            ClipboardHistoryVisionRecognizer(),
+        notificationCenter: NotificationCenter = .default
     ) {
         let suppression = ClipboardHistorySelfWriteSuppression()
         selfWriteSuppression = suppression
         monitorInstrumentation = ClipboardHistoryMonitorInstrumentation()
+        self.notificationCenter = notificationCenter
         pasteboardSelfWrites = ClipboardHistoryPasteboardSelfWriteFunnel(
             suppression: suppression
         )
@@ -351,8 +358,17 @@ public actor ClipboardHistoryModule {
         monitorInstrumentation.snapshot()
     }
 
-    public func advanceMonitoringBaseline() async {
-        await captureMonitor?.establishBaseline()
+    func publishMutation() {
+        notificationCenter.post(
+            name: .clipboardHistoryV2DidMutate,
+            object: nil
+        )
+    }
+
+    func installCaptureMonitorForTesting(
+        _ monitor: ClipboardHistoryCaptureMonitor
+    ) {
+        captureMonitor = monitor
     }
 }
 

--- a/Sources/ClipboardHistory/ClipboardHistoryOperations.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryOperations.swift
@@ -3,10 +3,17 @@ import Foundation
 import GRDB
 
 extension ClipboardHistoryModule {
+    struct MutationApplyResult: Sendable {
+        let outcome: ClipboardHistoryMutationOutcome
+        let didMutate: Bool
+    }
+
     public func capture(
         _ request: ClipboardHistoryCaptureRequest
     ) throws -> ClipboardHistoryCaptureOutcome {
-        try captureExplicit(request)
+        let outcome = try captureExplicit(request)
+        publishMutation()
+        return outcome
     }
 
     public func page(
@@ -26,24 +33,29 @@ extension ClipboardHistoryModule {
         _ mutation: ClipboardHistoryMutation
     ) async throws -> ClipboardHistoryMutationOutcome {
         let database = try requiredDatabase()
+        let result: MutationApplyResult
         switch mutation {
         case .delete(let entryID):
-            return try await delete(entryID, from: database)
+            result = try await delete(entryID, from: database)
         case .setFavorite(let entryID, let isFavorite):
-            return try setFavorite(
+            result = try setFavorite(
                 isFavorite,
                 for: entryID,
                 in: database
             )
         case .setTags(let entryID, let tagIDs):
-            return try setTags(tagIDs, for: entryID, in: database)
+            result = try setTags(tagIDs, for: entryID, in: database)
         case .editText(let entryID, let text):
-            return try await editText(
+            result = try await editText(
                 text,
                 for: entryID,
                 in: database
             )
         }
+        if result.didMutate {
+            publishMutation()
+        }
+        return result.outcome
     }
 
     public func materialize(
@@ -579,7 +591,7 @@ extension ClipboardHistoryModule {
     fileprivate func delete(
         _ entryID: ClipboardHistoryEntryID,
         from database: DatabasePool
-    ) async throws -> ClipboardHistoryMutationOutcome {
+    ) async throws -> MutationApplyResult {
         let storedID = entryID.value.uuidString.lowercased()
         let date = now()
         let result: EntryDeletionResult
@@ -606,10 +618,15 @@ extension ClipboardHistoryModule {
         } catch {
             throw ClipboardHistoryModuleError.storageFailure
         }
-        guard result.didDelete else { return .notFound }
+        guard result.didDelete else {
+            return MutationApplyResult(
+                outcome: .notFound,
+                didMutate: false
+            )
+        }
         cancelDerivedJobs(for: [storedID])
         await enqueueReclamation(for: result.payloadPaths)
-        return .deleted
+        return MutationApplyResult(outcome: .deleted, didMutate: true)
     }
 
     fileprivate func materializePayload(

--- a/Sources/ClipboardHistory/ClipboardHistoryRetention.swift
+++ b/Sources/ClipboardHistory/ClipboardHistoryRetention.swift
@@ -49,7 +49,7 @@ extension ClipboardHistoryModule {
         let database = try requiredDatabase()
         let storedEntryID = entryID.value.uuidString.lowercased()
         let timestamp = now()
-        return try mapMutationStorageFailure {
+        let result: TagAssignmentMutationResult = try mapMutationStorageFailure {
             try database.write { database in
                 guard try isLiveEntry(
                     storedEntryID,
@@ -130,18 +130,25 @@ extension ClipboardHistoryModule {
                     try Self.bumpHistoryRevision(in: database)
                     try Self.bumpSearchIndexGeneration(in: database)
                 }
-                return ClipboardHistoryTagAssignment(
-                    definition: definition,
-                    entry: try Self.entry(
-                        from: try requiredEntryRow(
-                            storedEntryID,
+                return TagAssignmentMutationResult(
+                    assignment: ClipboardHistoryTagAssignment(
+                        definition: definition,
+                        entry: try Self.entry(
+                            from: try requiredEntryRow(
+                                storedEntryID,
+                                in: database
+                            ),
                             in: database
-                        ),
-                        in: database
-                    )
+                        )
+                    ),
+                    didMutate: insertedDefinition || !hadMembership
                 )
             }
         }
+        if result.didMutate {
+            publishMutation()
+        }
+        return result.assignment
     }
 
     public func renameTagDefinition(
@@ -155,7 +162,7 @@ extension ClipboardHistoryModule {
             throw ClipboardHistoryModuleError.invalidTagName
         }
         let database = try requiredDatabase()
-        return try mapMutationStorageFailure {
+        let result: TagDefinitionMutationResult = try mapMutationStorageFailure {
             try database.write { database in
                 guard
                     let currentName = try String.fetchOne(
@@ -186,7 +193,8 @@ extension ClipboardHistoryModule {
                 guard !duplicateExists else {
                     throw ClipboardHistoryModuleError.duplicateTagName
                 }
-                if currentName != displayName {
+                let didMutate = currentName != displayName
+                if didMutate {
                     try database.execute(
                         sql: """
                             UPDATE clipboard_tag_definitions
@@ -197,12 +205,19 @@ extension ClipboardHistoryModule {
                     )
                     try Self.bumpHistoryRevision(in: database)
                 }
-                return ClipboardHistoryTagDefinition(
-                    id: id,
-                    displayName: displayName
+                return TagDefinitionMutationResult(
+                    definition: ClipboardHistoryTagDefinition(
+                        id: id,
+                        displayName: displayName
+                    ),
+                    didMutate: didMutate
                 )
             }
         }
+        if result.didMutate {
+            publishMutation()
+        }
+        return result.definition
     }
 
     public func deleteTagDefinition(
@@ -210,7 +225,7 @@ extension ClipboardHistoryModule {
     ) throws -> ClipboardHistoryTagDefinitionUpdate {
         let database = try requiredDatabase()
         let timestamp = now().timeIntervalSince1970
-        return try mapMutationStorageFailure {
+        let result: TagDefinitionUpdateMutationResult = try mapMutationStorageFailure {
             try database.write { database in
                 let definitionExists =
                     (try Bool.fetchOne(
@@ -308,12 +323,19 @@ extension ClipboardHistoryModule {
                     try Self.bumpHistoryRevision(in: database)
                     try Self.bumpSearchIndexGeneration(in: database)
                 }
-                return ClipboardHistoryTagDefinitionUpdate(
-                    removedMembershipCount: removedMembershipCount,
-                    unprotectedEntryCount: newlyUnprotected.count
+                return TagDefinitionUpdateMutationResult(
+                    update: ClipboardHistoryTagDefinitionUpdate(
+                        removedMembershipCount: removedMembershipCount,
+                        unprotectedEntryCount: newlyUnprotected.count
+                    ),
+                    didMutate: definitionExists || removedMembershipCount > 0
                 )
             }
         }
+        if result.didMutate {
+            publishMutation()
+        }
+        return result.update
     }
 
     public func replaceTagDefinitions(
@@ -356,15 +378,42 @@ extension ClipboardHistoryModule {
         }
         let database = try requiredDatabase()
         let timestamp = now().timeIntervalSince1970
-        return try mapMutationStorageFailure {
+        let normalizedDefinitions = zip(definitions, names).map {
+            ClipboardHistoryTagDefinition(
+                id: $0.0.id,
+                displayName: $0.1
+            )
+        }
+        let result: TagDefinitionUpdateMutationResult = try mapMutationStorageFailure {
             try database.write { database in
-                let oldDefinitions = Set(
-                    try String.fetchAll(
-                        database,
-                        sql: "SELECT id FROM clipboard_tag_definitions"
+                let currentDefinitions = try Row.fetchAll(
+                    database,
+                    sql: """
+                        SELECT id, display_name
+                        FROM clipboard_tag_definitions
+                        ORDER BY display_order, id
+                        """
+                ).map {
+                    ClipboardHistoryTagDefinition(
+                        id: $0["id"],
+                        displayName: $0["display_name"]
                     )
+                }
+                guard currentDefinitions != normalizedDefinitions else {
+                    return TagDefinitionUpdateMutationResult(
+                        update: ClipboardHistoryTagDefinitionUpdate(
+                            removedMembershipCount: 0,
+                            unprotectedEntryCount: 0
+                        ),
+                        didMutate: false
+                    )
+                }
+                let oldDefinitionIDs = Set(
+                    currentDefinitions.map(\.id)
                 )
-                let removedDefinitions = oldDefinitions.subtracting(tagIDs)
+                let removedDefinitions = oldDefinitionIDs.subtracting(
+                    tagIDs
+                )
                 let removedMembershipCount: Int
                 if removedDefinitions.isEmpty {
                     removedMembershipCount = 0
@@ -408,7 +457,7 @@ extension ClipboardHistoryModule {
                 )
                 try database.execute(sql: "DELETE FROM clipboard_tag_definitions")
                 for (displayOrder, definition) in
-                    definitions.enumerated()
+                    normalizedDefinitions.enumerated()
                 {
                     try database.execute(
                         sql: """
@@ -418,7 +467,7 @@ extension ClipboardHistoryModule {
                             """,
                         arguments: [
                             definition.id,
-                            names[displayOrder],
+                            definition.displayName,
                             displayOrder,
                         ]
                     )
@@ -469,16 +518,21 @@ extension ClipboardHistoryModule {
                         arguments: [timestamp, entryID]
                     )
                 }
-                if oldDefinitions != tagIDs || removedMembershipCount > 0 {
-                    try Self.bumpHistoryRevision(in: database)
-                    try Self.bumpSearchIndexGeneration(in: database)
-                }
-                return ClipboardHistoryTagDefinitionUpdate(
-                    removedMembershipCount: removedMembershipCount,
-                    unprotectedEntryCount: newlyUnprotected.count
+                try Self.bumpHistoryRevision(in: database)
+                try Self.bumpSearchIndexGeneration(in: database)
+                return TagDefinitionUpdateMutationResult(
+                    update: ClipboardHistoryTagDefinitionUpdate(
+                        removedMembershipCount: removedMembershipCount,
+                        unprotectedEntryCount: newlyUnprotected.count
+                    ),
+                    didMutate: true
                 )
             }
         }
+        if result.didMutate {
+            publishMutation()
+        }
+        return result.update
     }
 
     public func prepareRetentionChange(
@@ -495,7 +549,8 @@ extension ClipboardHistoryModule {
                     return RetentionPreparationResult(
                         preparation: .applied(period),
                         payloadPaths: [],
-                        deletedEntryIDs: []
+                        deletedEntryIDs: [],
+                        didMutate: false
                     )
                 }
                 let affectedIDs = try retentionReductionEntryIDs(
@@ -513,7 +568,8 @@ extension ClipboardHistoryModule {
                     return RetentionPreparationResult(
                         preparation: .confirmationRequired(preview),
                         payloadPaths: [],
-                        deletedEntryIDs: []
+                        deletedEntryIDs: [],
+                        didMutate: false
                     )
                 }
 
@@ -528,7 +584,8 @@ extension ClipboardHistoryModule {
                 return RetentionPreparationResult(
                     preparation: .applied(period),
                     payloadPaths: payloadPaths,
-                    deletedEntryIDs: Set(expiredIDs)
+                    deletedEntryIDs: Set(expiredIDs),
+                    didMutate: true
                 )
             }
         } catch let error as ClipboardHistoryModuleError {
@@ -538,6 +595,9 @@ extension ClipboardHistoryModule {
         }
         cancelDerivedJobs(for: preparation.deletedEntryIDs)
         await enqueueReclamation(for: preparation.payloadPaths)
+        if preparation.didMutate {
+            publishMutation()
+        }
         return preparation.preparation
     }
 
@@ -573,6 +633,20 @@ extension ClipboardHistoryModule {
         }
         let database = try requiredDatabase()
         let date = now()
+        let finalizesClear: Bool
+        if case .clear = payload.operation {
+            finalizesClear = true
+        } else {
+            finalizesClear = false
+        }
+        if finalizesClear {
+            isFinalizingClear = true
+        }
+        defer {
+            if finalizesClear {
+                isFinalizingClear = false
+            }
+        }
         let result: ConfirmationApplyResult
         do {
             result = try await database.write {
@@ -607,7 +681,8 @@ extension ClipboardHistoryModule {
                             )
                         ),
                         payloadPaths: [],
-                        deletedEntryIDs: []
+                        deletedEntryIDs: [],
+                        didMutate: false
                     )
                 }
 
@@ -620,14 +695,18 @@ extension ClipboardHistoryModule {
                 if case .retention(let period) = payload.operation {
                     try setRetentionPeriod(period, in: database)
                 }
-                if currentIDs.isEmpty, allDeletedIDs.isEmpty {
-                    try Self.bumpHistoryRevision(in: database)
+                let didMutate = switch payload.operation {
+                case .retention:
+                    true
+                case .clear:
+                    !allDeletedIDs.isEmpty
                 }
                 try faultInjector.check(.databaseTransaction)
                 return ConfirmationApplyResult(
                     outcome: .applied(deletedCount: currentIDs.count),
                     payloadPaths: payloadPaths,
-                    deletedEntryIDs: allDeletedIDs
+                    deletedEntryIDs: allDeletedIDs,
+                    didMutate: didMutate
                 )
             }
         } catch let error as ClipboardHistoryModuleError {
@@ -635,8 +714,17 @@ extension ClipboardHistoryModule {
         } catch {
             throw ClipboardHistoryModuleError.storageFailure
         }
+        if case .clear = payload.operation,
+            case .applied = result.outcome
+        {
+            await captureMonitor?.establishBaseline()
+            isFinalizingClear = false
+        }
         cancelDerivedJobs(for: result.deletedEntryIDs)
         await enqueueReclamation(for: result.payloadPaths)
+        if result.didMutate {
+            publishMutation()
+        }
         return result.outcome
     }
 
@@ -644,13 +732,39 @@ extension ClipboardHistoryModule {
         _ isFavorite: Bool,
         for entryID: ClipboardHistoryEntryID,
         in database: DatabasePool
-    ) throws -> ClipboardHistoryMutationOutcome {
+    ) throws -> MutationApplyResult {
         let storedID = entryID.value.uuidString.lowercased()
         let timestamp = now()
         return try mapMutationStorageFailure {
             try database.write { database in
                 guard try isLiveEntry(storedID, at: timestamp, in: database) else {
-                    return .notFound
+                    return MutationApplyResult(
+                        outcome: .notFound,
+                        didMutate: false
+                    )
+                }
+                let currentFavorite = try Bool.fetchOne(
+                    database,
+                    sql: """
+                        SELECT is_favorite
+                        FROM clipboard_entries
+                        WHERE id = ?
+                        """,
+                    arguments: [storedID]
+                ) ?? false
+                if currentFavorite == isFavorite {
+                    return MutationApplyResult(
+                        outcome: .updated(
+                            try Self.entry(
+                                from: try requiredEntryRow(
+                                    storedID,
+                                    in: database
+                                ),
+                                in: database
+                            )
+                        ),
+                        didMutate: false
+                    )
                 }
                 let wasProtected = try protectionState(
                     for: storedID,
@@ -677,11 +791,17 @@ extension ClipboardHistoryModule {
                 }
                 try Self.bumpHistoryRevision(in: database)
                 try Self.bumpSearchIndexGeneration(in: database)
-                return .updated(
-                    try Self.entry(
-                        from: try requiredEntryRow(storedID, in: database),
-                        in: database
-                    )
+                return MutationApplyResult(
+                    outcome: .updated(
+                        try Self.entry(
+                            from: try requiredEntryRow(
+                                storedID,
+                                in: database
+                            ),
+                            in: database
+                        )
+                    ),
+                    didMutate: true
                 )
             }
         }
@@ -691,13 +811,16 @@ extension ClipboardHistoryModule {
         _ tagIDs: Set<String>,
         for entryID: ClipboardHistoryEntryID,
         in database: DatabasePool
-    ) throws -> ClipboardHistoryMutationOutcome {
+    ) throws -> MutationApplyResult {
         let storedID = entryID.value.uuidString.lowercased()
         let timestamp = now()
         return try mapMutationStorageFailure {
             try database.write { database in
                 guard try isLiveEntry(storedID, at: timestamp, in: database) else {
-                    return .notFound
+                    return MutationApplyResult(
+                        outcome: .notFound,
+                        didMutate: false
+                    )
                 }
                 let validTagIDs = Set(
                     try String.fetchAll(
@@ -708,6 +831,31 @@ extension ClipboardHistoryModule {
                 let invalidTagIDs = tagIDs.subtracting(validTagIDs)
                 guard invalidTagIDs.isEmpty else {
                     throw ClipboardHistoryModuleError.invalidTagIDs(invalidTagIDs)
+                }
+                let currentTagIDs = Set(
+                    try String.fetchAll(
+                        database,
+                        sql: """
+                            SELECT tag_id
+                            FROM clipboard_entry_tags
+                            WHERE entry_id = ?
+                            """,
+                        arguments: [storedID]
+                    )
+                )
+                if currentTagIDs == tagIDs {
+                    return MutationApplyResult(
+                        outcome: .updated(
+                            try Self.entry(
+                                from: try requiredEntryRow(
+                                    storedID,
+                                    in: database
+                                ),
+                                in: database
+                            )
+                        ),
+                        didMutate: false
+                    )
                 }
                 let wasProtected = try protectionState(
                     for: storedID,
@@ -742,11 +890,17 @@ extension ClipboardHistoryModule {
                 }
                 try Self.bumpHistoryRevision(in: database)
                 try Self.bumpSearchIndexGeneration(in: database)
-                return .updated(
-                    try Self.entry(
-                        from: try requiredEntryRow(storedID, in: database),
-                        in: database
-                    )
+                return MutationApplyResult(
+                    outcome: .updated(
+                        try Self.entry(
+                            from: try requiredEntryRow(
+                                storedID,
+                                in: database
+                            ),
+                            in: database
+                        )
+                    ),
+                    didMutate: true
                 )
             }
         }
@@ -756,7 +910,7 @@ extension ClipboardHistoryModule {
         _ text: String,
         for entryID: ClipboardHistoryEntryID,
         in database: DatabasePool
-    ) async throws -> ClipboardHistoryMutationOutcome {
+    ) async throws -> MutationApplyResult {
         guard !text.isEmpty else {
             throw ClipboardHistoryModuleError.invalidTextEdit
         }
@@ -787,7 +941,13 @@ extension ClipboardHistoryModule {
         do {
             result = try await database.write { database in
                 guard try isLiveEntry(storedID, at: date, in: database) else {
-                    return TextEditResult(outcome: .notFound, payloadPaths: [])
+                    return TextEditResult(
+                        outcome: MutationApplyResult(
+                            outcome: .notFound,
+                            didMutate: false
+                        ),
+                        payloadPaths: []
+                    )
                 }
                 let itemCount =
                     try Int.fetchOne(
@@ -983,11 +1143,17 @@ extension ClipboardHistoryModule {
                 try Self.bumpSearchIndexGeneration(in: database)
                 try faultInjector.check(.databaseTransaction)
                 return TextEditResult(
-                    outcome: .updated(
-                        try Self.entry(
-                            from: try requiredEntryRow(storedID, in: database),
-                            in: database
-                        )
+                    outcome: MutationApplyResult(
+                        outcome: .updated(
+                            try Self.entry(
+                                from: try requiredEntryRow(
+                                    storedID,
+                                    in: database
+                                ),
+                                in: database
+                            )
+                        ),
+                        didMutate: true
                     ),
                     payloadPaths: payloadPaths
                 )
@@ -1451,17 +1617,34 @@ private struct RetentionPreparationResult {
     let preparation: ClipboardHistoryRetentionChangePreparation
     let payloadPaths: [String]
     let deletedEntryIDs: Set<String>
+    let didMutate: Bool
 }
 
 private struct ConfirmationApplyResult {
     let outcome: ClipboardHistoryDestructiveApplyOutcome
     let payloadPaths: [String]
     let deletedEntryIDs: Set<String>
+    let didMutate: Bool
 }
 
 private struct TextEditResult {
-    let outcome: ClipboardHistoryMutationOutcome
+    let outcome: ClipboardHistoryModule.MutationApplyResult
     let payloadPaths: [String]
+}
+
+private struct TagAssignmentMutationResult: Sendable {
+    let assignment: ClipboardHistoryTagAssignment
+    let didMutate: Bool
+}
+
+private struct TagDefinitionMutationResult: Sendable {
+    let definition: ClipboardHistoryTagDefinition
+    let didMutate: Bool
+}
+
+private struct TagDefinitionUpdateMutationResult: Sendable {
+    let update: ClipboardHistoryTagDefinitionUpdate
+    let didMutate: Bool
 }
 
 private enum ConfirmationOperation: Codable {

--- a/Tests/AnyDoorTests/BuiltinCatalogInvariantTests.swift
+++ b/Tests/AnyDoorTests/BuiltinCatalogInvariantTests.swift
@@ -52,11 +52,15 @@ struct BuiltinCatalogInvariantTests {
     /// The full production provider set: Core providers plus every plugin's.
     @MainActor
     private static func allProviders() throws -> [any BuiltinProvider] {
-        try BuiltinProviderRegistry.makeAll(
-            clipboardHistoryModule: makeClipboardHistoryModule(),
+        let module = try makeClipboardHistoryModule()
+        return BuiltinProviderRegistry.makeAll(
+            clipboardProduction: ClipboardProductionAdapter(
+                module: module,
+                selfWrites: module.pasteboardSelfWrites
+            ),
             onKeepAwakeChange: { _ in }
         )
-            + makeProductionPlugins().flatMap(\.providers)
+            + (try makeProductionPlugins()).flatMap(\.providers)
     }
 
     private static func makeClipboardHistoryModule() throws

--- a/Tests/AnyDoorTests/ClipboardProductionAdapterTests.swift
+++ b/Tests/AnyDoorTests/ClipboardProductionAdapterTests.swift
@@ -1,0 +1,209 @@
+import AppKit
+import Foundation
+import XCTest
+
+@testable import AnyDoor
+@testable import ClipboardHistory
+
+@MainActor
+final class ClipboardProductionAdapterTests: XCTestCase {
+    func testExplicitProductionsWriteSemanticValuesAndAvoidPassiveDuplicates()
+        async throws
+    {
+        let fixture = try Fixture()
+        defer { fixture.removeStore() }
+        let monitor = ClipboardHistoryCaptureMonitor(
+            module: fixture.module,
+            pasteboard: fixture.pasteboard,
+            installsSystemObservers: false
+        )
+        await monitor.setEnabled(true)
+
+        let ocr = try await fixture.adapter.produceOCR("recognized text")
+        XCTAssertEqual(
+            fixture.pasteboard.string(forType: .string),
+            "recognized text"
+        )
+        XCTAssertEqual(ocr.pasteboardChangeCount, fixture.pasteboard.changeCount)
+        await monitor.observeForTesting()
+
+        let qr = try await fixture.adapter.produceQRCode("https://example.com")
+        XCTAssertEqual(
+            fixture.pasteboard.string(forType: .string),
+            "https://example.com"
+        )
+        XCTAssertEqual(qr.pasteboardChangeCount, fixture.pasteboard.changeCount)
+        await monitor.observeForTesting()
+
+        let color = try await fixture.adapter.produceColor(
+            hex: "#AABBCC",
+            pasteboardValue: "rgb(170 187 204)"
+        )
+        XCTAssertEqual(
+            fixture.pasteboard.string(forType: .string),
+            "rgb(170 187 204)"
+        )
+        XCTAssertEqual(
+            color.pasteboardChangeCount,
+            fixture.pasteboard.changeCount
+        )
+        await monitor.observeForTesting()
+
+        let (image, png) = try Self.makeImage()
+        let screenshot = try await fixture.adapter.produceScreenshot(
+            image: image,
+            png: png,
+            copyToPasteboard: true
+        )
+        XCTAssertEqual(
+            screenshot.pasteboardChangeCount,
+            fixture.pasteboard.changeCount
+        )
+        XCTAssertNotNil(fixture.pasteboard.data(forType: .tiff))
+        await monitor.observeForTesting()
+
+        let page = try await fixture.module.page(.init())
+        XCTAssertEqual(page.entries.count, 4)
+        XCTAssertEqual(page.entries.map(\.id), [
+            screenshot.capture.entryID,
+            color.capture.entryID,
+            qr.capture.entryID,
+            ocr.capture.entryID,
+        ])
+        XCTAssertEqual(page.entries[0].facets, [.image, .screenshot])
+        XCTAssertTrue(page.entries[1].facets.contains(.color))
+        XCTAssertTrue(page.entries[2].facets.contains(.qrCode))
+        XCTAssertEqual(page.entries[3].previewText, "recognized text")
+        XCTAssertTrue(
+            page.entries.allSatisfy { $0.source == .anyDoor }
+        )
+    }
+
+    func testScreenshotCanRecordWithoutChangingPasteboard() async throws {
+        let fixture = try Fixture()
+        defer { fixture.removeStore() }
+        fixture.pasteboard.clearContents()
+        XCTAssertTrue(
+            fixture.pasteboard.setString("keep me", forType: .string)
+        )
+        let initialChangeCount = fixture.pasteboard.changeCount
+        let (image, png) = try Self.makeImage()
+
+        let outcome = try await fixture.adapter.produceScreenshot(
+            image: image,
+            png: png,
+            copyToPasteboard: false
+        )
+
+        XCTAssertNil(outcome.pasteboardChangeCount)
+        XCTAssertEqual(fixture.pasteboard.changeCount, initialChangeCount)
+        XCTAssertEqual(
+            fixture.pasteboard.string(forType: .string),
+            "keep me"
+        )
+        let page = try await fixture.module.page(.init())
+        XCTAssertEqual(page.entries.map(\.id), [outcome.capture.entryID])
+        XCTAssertEqual(page.entries.first?.facets, [.image, .screenshot])
+    }
+
+    func testCaptureFailureIsThrownAndSuppressedWriteIsNotPassivelyCaptured()
+        async throws
+    {
+        let fixture = try Fixture(faults: [.databaseTransaction])
+        defer { fixture.removeStore() }
+        let monitor = ClipboardHistoryCaptureMonitor(
+            module: fixture.module,
+            pasteboard: fixture.pasteboard,
+            installsSystemObservers: false
+        )
+        await monitor.setEnabled(true)
+
+        do {
+            _ = try await fixture.adapter.produceOCR("cannot persist")
+            XCTFail("Expected explicit capture to fail")
+        } catch {
+            XCTAssertEqual(
+                error as? ClipboardHistoryModuleError,
+                .storageFailure
+            )
+        }
+
+        XCTAssertEqual(
+            fixture.pasteboard.string(forType: .string),
+            "cannot persist"
+        )
+        await monitor.observeForTesting()
+        let page = try await fixture.module.page(.init())
+        XCTAssertTrue(page.entries.isEmpty)
+    }
+
+    func testCopyingRecordedScreenshotSuppressesWithoutCreatingCapture()
+        async throws
+    {
+        let fixture = try Fixture()
+        defer { fixture.removeStore() }
+        let monitor = ClipboardHistoryCaptureMonitor(
+            module: fixture.module,
+            pasteboard: fixture.pasteboard,
+            installsSystemObservers: false
+        )
+        await monitor.setEnabled(true)
+        let (image, _) = try Self.makeImage()
+
+        let changeCount = try fixture.adapter.copyExistingScreenshot(image)
+
+        XCTAssertEqual(changeCount, fixture.pasteboard.changeCount)
+        await monitor.observeForTesting()
+        let page = try await fixture.module.page(.init())
+        XCTAssertTrue(page.entries.isEmpty)
+    }
+
+    private static func makeImage() throws -> (NSImage, Data) {
+        let image = NSImage(size: NSSize(width: 2, height: 2))
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 2, height: 2)).fill()
+        image.unlockFocus()
+        return (image, try XCTUnwrap(image.pngData()))
+    }
+}
+
+@MainActor
+private final class Fixture {
+    let directory: URL
+    let module: ClipboardHistoryModule
+    let pasteboard: NSPasteboard
+    let adapter: ClipboardProductionAdapter
+
+    init(faults: Set<ClipboardHistoryFaultPoint> = []) throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AnyDoor-ClipboardProduction-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        module = try ClipboardHistoryModule(
+            testingDatabaseURL: directory
+                .appendingPathComponent("history.sqlite"),
+            databaseKey: Data(repeating: 0x42, count: 32),
+            faultInjector: ClipboardHistoryFaultInjector(points: faults)
+        )
+        pasteboard = NSPasteboard(
+            name: NSPasteboard.Name(
+                "AnyDoor-ClipboardProduction-\(UUID().uuidString)"
+            )
+        )
+        adapter = ClipboardProductionAdapter(
+            module: module,
+            selfWrites: module.pasteboardSelfWrites,
+            pasteboard: pasteboard
+        )
+    }
+
+    func removeStore() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}

--- a/Tests/ClipboardHistoryTests/ClipboardHistoryMigrationTests.swift
+++ b/Tests/ClipboardHistoryTests/ClipboardHistoryMigrationTests.swift
@@ -631,7 +631,9 @@ final class ClipboardHistoryMigrationTests: XCTestCase {
             )
         }
         let entryID = UUID()
-        let module = fixture.makeModule()
+        let center = NotificationCenter()
+        let recorder = ClipboardHistoryMutationRecorder(center: center)
+        let module = fixture.makeModule(notificationCenter: center)
 
         _ = try await module.migrateLegacy(
             fixture.request(
@@ -655,6 +657,7 @@ final class ClipboardHistoryMigrationTests: XCTestCase {
                 retentionPeriod: .unlimited
             )
         )
+        recorder.reset()
 
         let migrated = try await module.legacyFileDiagnostics(
             for: ClipboardHistoryEntryID(entryID)
@@ -684,10 +687,28 @@ final class ClipboardHistoryMigrationTests: XCTestCase {
             )
         )
         XCTAssertEqual(outcome, .restored(memberCount: 1))
+        XCTAssertEqual(recorder.count, 1)
         XCTAssertEqual(
             try Data(contentsOf: destination),
             Data("captured".utf8)
         )
+        let repeatedOutcome = try await module.restoreLegacyOwnedFiles(
+            ClipboardHistoryLegacyFileRestoreRequest(
+                entryID: ClipboardHistoryEntryID(entryID),
+                destinations: [
+                    ClipboardHistoryLegacyFileDestination(
+                        memberID: ClipboardHistoryLegacyFileMemberID(
+                            itemIndex: 1,
+                            memberIndex: 0
+                        ),
+                        url: destination,
+                        collisionPolicy: .reuseIfIdentical
+                    )
+                ]
+            )
+        )
+        XCTAssertEqual(repeatedOutcome, .alreadyRestored(memberCount: 1))
+        XCTAssertEqual(recorder.count, 1)
     }
 
     func testOwnedFileRestoreCommitsAllMembersAndPreservesIdentity()
@@ -1645,14 +1666,16 @@ private final class LegacyMigrationFixture {
     func makeModule(
         now: Date? = nil,
         faultInjector: ClipboardHistoryFaultInjector =
-            ClipboardHistoryFaultInjector()
+            ClipboardHistoryFaultInjector(),
+        notificationCenter: NotificationCenter = .default
     ) -> ClipboardHistoryModule {
         let currentDate = now ?? self.now
         return ClipboardHistoryModule(
             testingStoreRoot: storeRoot,
             keyStore: keyStore,
             faultInjector: faultInjector,
-            now: { currentDate }
+            now: { currentDate },
+            notificationCenter: notificationCenter
         )
     }
 

--- a/Tests/ClipboardHistoryTests/ClipboardHistoryMonitorTests.swift
+++ b/Tests/ClipboardHistoryTests/ClipboardHistoryMonitorTests.swift
@@ -483,6 +483,55 @@ final class ClipboardHistoryCaptureMonitorTests: XCTestCase {
     }
 
     @MainActor
+    func testConfirmedClearAdvancesTheActiveMonitorBaseline() async throws {
+        let fixture = try MonitorTemporaryStore()
+        let center = NotificationCenter()
+        let recorder = ClipboardHistoryMutationRecorder(center: center)
+        let module = ClipboardHistoryModule(
+            testingStoreRoot: fixture.url,
+            keyStore: MonitorMemoryKeyStore(),
+            notificationCenter: center
+        )
+        let pasteboard = NSPasteboard(
+            name: .init("dev.bybee.AnyDoor.monitor.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setString("baseline", forType: .string)
+        let monitor = ClipboardHistoryCaptureMonitor(
+            module: module,
+            pasteboard: pasteboard,
+            installsSystemObservers: false
+        )
+        await monitor.setEnabled(true)
+        await module.installCaptureMonitorForTesting(monitor)
+
+        pasteboard.clearContents()
+        pasteboard.setString("stored history", forType: .string)
+        await monitor.observeForTesting()
+        XCTAssertEqual(recorder.count, 1)
+        let storedPage = try await module.page(.init())
+        XCTAssertEqual(storedPage.entries.count, 1)
+        recorder.reset()
+        pasteboard.clearContents()
+        pasteboard.setString("pending clipboard", forType: .string)
+
+        let preview = try await module.previewClearHistory(
+            scope: .includingProtected
+        )
+        let clearOutcome = try await module.confirm(preview.token)
+        XCTAssertEqual(
+            clearOutcome,
+            .applied(deletedCount: 1)
+        )
+        XCTAssertEqual(recorder.count, 1)
+
+        await monitor.observeForTesting()
+        let page = try await module.page(.init())
+        XCTAssertEqual(page.entries, [])
+        XCTAssertEqual(recorder.count, 1)
+    }
+
+    @MainActor
     func testBaselineResumeAndSelfWritesNeverImportCurrentPasteboard() async throws {
         let fixture = try MonitorTemporaryStore()
         let module = ClipboardHistoryModule(

--- a/Tests/ClipboardHistoryTests/ClipboardHistoryMutationNotificationTests.swift
+++ b/Tests/ClipboardHistoryTests/ClipboardHistoryMutationNotificationTests.swift
@@ -1,0 +1,307 @@
+import AppKit
+import Foundation
+import XCTest
+
+@testable import ClipboardHistory
+
+final class ClipboardHistoryMutationNotificationTests: XCTestCase {
+    func testConfirmedEmptyClearDoesNotPublishMutation() async throws {
+        let fixture = try MutationNotificationStore()
+        let center = NotificationCenter()
+        let recorder = ClipboardHistoryMutationRecorder(center: center)
+        let module = fixture.makeModule(notificationCenter: center)
+
+        let preview = try await module.previewClearHistory(
+            scope: .includingProtected
+        )
+        XCTAssertEqual(preview.affectedCount, 0)
+        let outcome = try await module.confirm(preview.token)
+        XCTAssertEqual(
+            outcome,
+            .applied(deletedCount: 0)
+        )
+        XCTAssertEqual(recorder.count, 0)
+    }
+
+    func testCaptureAndApplyPublishOnlyCommittedChanges() async throws {
+        let fixture = try MutationNotificationStore()
+        let center = NotificationCenter()
+        let recorder = ClipboardHistoryMutationRecorder(center: center)
+        let failureSwitch = MutationFailureSwitch()
+        let module = fixture.makeModule(
+            faultInjector: ClipboardHistoryFaultInjector { point in
+                point == .databaseTransaction && failureSwitch.isEnabled
+            },
+            notificationCenter: center
+        )
+
+        let captured = try await module.capture(
+            textRequest("captured")
+        )
+        XCTAssertEqual(recorder.count, 1)
+
+        let pasteboardRequest = await MainActor.run {
+            let pasteboard = NSPasteboard(
+                name: .init(
+                    "dev.bybee.AnyDoor.mutation.\(UUID().uuidString)"
+                )
+            )
+            pasteboard.clearContents()
+            return ClipboardHistoryPasteboardCaptureRequest(
+                pasteboard: pasteboard
+            )
+        }
+        let skipped = try await module.capture(
+            pasteboardRequest,
+            source: .unknown
+        )
+        XCTAssertEqual(skipped, .skipped(.empty))
+        XCTAssertEqual(recorder.count, 1)
+
+        let missing = ClipboardHistoryEntryID(UUID())
+        let missingOutcome = try await module.apply(.delete(missing))
+        XCTAssertEqual(
+            missingOutcome,
+            .notFound
+        )
+        XCTAssertEqual(recorder.count, 1)
+
+        _ = try await module.apply(
+            .setFavorite(captured.entryID, true)
+        )
+        XCTAssertEqual(recorder.count, 2)
+
+        _ = try await module.apply(
+            .setFavorite(captured.entryID, true)
+        )
+        _ = try await module.apply(.setTags(captured.entryID, []))
+        XCTAssertEqual(recorder.count, 2)
+
+        failureSwitch.isEnabled = true
+        do {
+            _ = try await module.apply(
+                .editText(captured.entryID, "replacement")
+            )
+            XCTFail("Expected the committed mutation to fail")
+        } catch {
+            XCTAssertEqual(
+                error as? ClipboardHistoryModuleError,
+                .storageFailure
+            )
+        }
+        XCTAssertEqual(recorder.count, 2)
+    }
+
+    func testTagAndRetentionPublicationSkipsNoOpsAndStaleConfirmation()
+        async throws
+    {
+        let fixture = try MutationNotificationStore()
+        let center = NotificationCenter()
+        let recorder = ClipboardHistoryMutationRecorder(center: center)
+        let clock = MutationTestClock(
+            Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        let module = fixture.makeModule(
+            clock: clock,
+            notificationCenter: center
+        )
+        let captured = try await module.capture(textRequest("tagged"))
+        recorder.reset()
+
+        let assignment = try await module.createTagDefinition(
+            named: "Work",
+            assigningTo: captured.entryID
+        )
+        XCTAssertEqual(recorder.count, 1)
+
+        _ = try await module.createTagDefinition(
+            named: "Work",
+            assigningTo: captured.entryID
+        )
+        _ = try await module.renameTagDefinition(
+            id: assignment.definition.id,
+            to: "Work"
+        )
+        _ = try await module.replaceTagDefinitions(
+            with: [assignment.definition]
+        )
+        _ = try await module.deleteTagDefinition(id: "missing")
+        XCTAssertEqual(recorder.count, 1)
+
+        _ = try await module.renameTagDefinition(
+            id: assignment.definition.id,
+            to: "Projects"
+        )
+        XCTAssertEqual(recorder.count, 2)
+        let importedDefinition = ClipboardHistoryTagDefinition(
+            id: assignment.definition.id,
+            displayName: "Imported"
+        )
+        _ = try await module.replaceTagDefinitions(
+            with: [importedDefinition]
+        )
+        _ = try await module.replaceTagDefinitions(
+            with: [importedDefinition]
+        )
+        XCTAssertEqual(recorder.count, 3)
+
+        let samePeriod = try await module.prepareRetentionChange(
+            to: .thirtyDays
+        )
+        XCTAssertEqual(samePeriod, .applied(.thirtyDays))
+        XCTAssertEqual(recorder.count, 3)
+
+        let directChange = try await module.prepareRetentionChange(
+            to: .unlimited
+        )
+        XCTAssertEqual(directChange, .applied(.unlimited))
+        XCTAssertEqual(recorder.count, 4)
+
+        _ = try await module.capture(textRequest("old"))
+        recorder.reset()
+        clock.now = clock.now.addingTimeInterval(2 * 86_400)
+        _ = try await module.prepareRetentionChange(to: .thirtyDays)
+        recorder.reset()
+        guard case .confirmationRequired(let preview) =
+            try await module.prepareRetentionChange(to: .oneDay)
+        else {
+            return XCTFail("Expected a destructive retention preview")
+        }
+        XCTAssertEqual(recorder.count, 0)
+
+        _ = try await module.capture(textRequest("new revision"))
+        recorder.reset()
+        guard case .stale = try await module.confirm(preview.token) else {
+            return XCTFail("Expected the confirmation to become stale")
+        }
+        XCTAssertEqual(recorder.count, 0)
+
+        guard case .confirmationRequired(let refreshed) =
+            try await module.prepareRetentionChange(to: .oneDay)
+        else {
+            return XCTFail("Expected a refreshed retention preview")
+        }
+        let confirmed = try await module.confirm(refreshed.token)
+        XCTAssertEqual(
+            confirmed,
+            .applied(deletedCount: 1)
+        )
+        XCTAssertEqual(recorder.count, 1)
+    }
+
+    private func textRequest(
+        _ text: String
+    ) -> ClipboardHistoryCaptureRequest {
+        ClipboardHistoryCaptureRequest(
+            source: .unknown,
+            content: .text(text)
+        )
+    }
+}
+
+final class ClipboardHistoryMutationRecorder: @unchecked Sendable {
+    private let center: NotificationCenter
+    private let lock = NSLock()
+    private var value = 0
+    private var observer: NSObjectProtocol?
+
+    var count: Int {
+        lock.withLock { value }
+    }
+
+    init(center: NotificationCenter) {
+        self.center = center
+        observer = center.addObserver(
+            forName: .clipboardHistoryV2DidMutate,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.lock.withLock {
+                self.value += 1
+            }
+        }
+    }
+
+    deinit {
+        if let observer {
+            center.removeObserver(observer)
+        }
+    }
+
+    func reset() {
+        lock.withLock { value = 0 }
+    }
+}
+
+private final class MutationNotificationStore {
+    let root: URL
+    private let keyStore = MutationNotificationKeyStore()
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "AnyDoor-ClipboardMutationNotification-\(UUID().uuidString)"
+        )
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func makeModule(
+        clock: MutationTestClock = MutationTestClock(Date()),
+        faultInjector: ClipboardHistoryFaultInjector =
+            ClipboardHistoryFaultInjector(),
+        notificationCenter: NotificationCenter
+    ) -> ClipboardHistoryModule {
+        ClipboardHistoryModule(
+            testingStoreRoot: root,
+            keyStore: keyStore,
+            faultInjector: faultInjector,
+            now: { clock.now },
+            notificationCenter: notificationCenter
+        )
+    }
+}
+
+private struct MutationNotificationKeyStore:
+    ClipboardHistoryMasterKeyStoring
+{
+    private static let key = Data(repeating: 0x8A, count: 32)
+
+    func load() -> ClipboardHistoryMasterKeyResult {
+        .key(Self.key)
+    }
+
+    func create() -> ClipboardHistoryMasterKeyResult {
+        .key(Self.key)
+    }
+
+    func delete() -> ClipboardHistoryMasterKeyResult {
+        .missing
+    }
+}
+
+private final class MutationTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    var now: Date {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+
+    init(_ now: Date) {
+        value = now
+    }
+}
+
+private final class MutationFailureSwitch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var isEnabled: Bool {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+}


### PR DESCRIPTION
## Summary

- make `ClipboardHistoryModule` own successful mutation publication and Clear History monitoring-baseline completion
- centralize explicit AnyDoor clipboard production behind one injected host adapter
- remove duplicate host, monitor, and presentation mutation notifications
- add focused notification, clear-baseline, pasteboard-suppression, and adapter tests

## Architecture

This completes the external seam described by ADR-0025 without adding repository or notification protocols. The module now publishes a mutation event only after a committed change, while the host adapter owns the suppress-write-capture sequence for OCR, QR, picked colors, screenshots, and capture OCR.

## Review

- Claude Code: approved the explicit production adapter package, all acceptance criteria passed
- Grok 4.6: approved the module mutation-completion package and verified that the integrated result has one successful mutation publisher

## Verification

- `swift build --build-tests`
- `swift test --skip-build` with the CI-equivalent throwaway unlocked default keychain: 1768 tests, 0 failures, 5 environment-gated skips
- Swift Testing catalog suites: 33 tests, 0 failures
- package-focused Clipboard History tests: 38 tests, 0 failures
- package-focused adapter/catalog tests: 13 tests, 0 failures
- `git diff --check`
