### PR TITLE
feat(palette): prioritize title prefix matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ versioning.
 
 ### Changed
 
+- Command Palette search now ranks a title that starts with the query ahead of
+  a later or fuzzier match, so `wa` surfaces Warp before Keep Awake.
 - Pasting from the clipboard wall now restores the destination through Launch
   Services before synthesizing Command-V. On macOS 14+, direct activation from
   an accessory app could be ignored, closing the wall without inserting the

--- a/Sources/AnyDoor/Services/CommandPaletteMatch.swift
+++ b/Sources/AnyDoor/Services/CommandPaletteMatch.swift
@@ -9,13 +9,23 @@ import Foundation
 enum CommandPaletteQueryMatch {
     /// Lower is better. Exact titles stay ahead of a mere prefix; a prefix
     /// stays ahead of substring, word-later, alias, or subtitle hits.
-    enum Rank: Int, Comparable {
+    enum Rank: Int, CaseIterable, Comparable {
         case exact = 0
         case prefix = 1
         case other = 2
 
         static func < (lhs: Rank, rhs: Rank) -> Bool {
             lhs.rawValue < rhs.rawValue
+        }
+
+        /// Distinguishes a title-search slice when the same section header is
+        /// emitted once per rank tier.
+        var identitySuffix: String {
+            switch self {
+            case .exact: return "exact"
+            case .prefix: return "prefix"
+            case .other: return "other"
+            }
         }
     }
 
@@ -69,11 +79,43 @@ enum CommandPaletteQueryMatch {
         .map { (item: $0.0, rank: $0.1) }
     }
 
+    /// Emits each section once per rank tier that has survivors, in tier order
+    /// then original section order. Flattened items are therefore globally
+    /// rank-correct; a section may appear more than once if it spans tiers.
+    static func rankedByGlobalTiers<Section, Item>(
+        _ sections: [Section],
+        items: (Section) -> [Item],
+        rank: (Item) -> Rank?
+    ) -> [(section: Section, items: [Item], rank: Rank)] {
+        let prepared = sections.map { section in
+            let scored = items(section).enumerated().compactMap { index, item -> (Item, Int, Rank)? in
+                guard let rank = rank(item) else { return nil }
+                return (item, index, rank)
+            }
+            return (section, scored)
+        }
+        return Rank.allCases.flatMap { band in
+            prepared.compactMap { section, scored -> (Section, [Item], Rank)? in
+                let slice = scored.filter { $0.2 == band }.sorted { $0.1 < $1.1 }.map(\.0)
+                guard !slice.isEmpty else { return nil }
+                return (section, slice, band)
+            }
+        }
+    }
+
     private static func rank(title: String, needle: String) -> Rank {
         if title.localizedCaseInsensitiveCompare(needle) == .orderedSame {
             return .exact
         }
-        if title.range(of: needle, options: [.caseInsensitive, .anchored]) != nil {
+        // Same comparison family as `localizedCaseInsensitiveContains`:
+        // current-locale, case-insensitive, including Unicode equivalence.
+        // Do not drop the locale — a nil-locale `.anchored` range can refuse
+        // prefix rank to a candidate the contains check already accepted.
+        if title.range(
+            of: needle,
+            options: [.caseInsensitive, .anchored],
+            locale: .current
+        ) != nil {
             return .prefix
         }
         return .other

--- a/Sources/AnyDoor/Services/CommandPaletteMatch.swift
+++ b/Sources/AnyDoor/Services/CommandPaletteMatch.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Membership and ranking for a command-palette text query.
+///
+/// A candidate is the same set `localizedCaseInsensitiveContains` already
+/// produced: ranking only orders those survivors so a title that starts with
+/// the query outranks a later or fuzzier hit. Query normalization is a
+/// whitespace trim, matching the palette's existing filter.
+enum CommandPaletteQueryMatch {
+    /// Lower is better. Exact titles stay ahead of a mere prefix; a prefix
+    /// stays ahead of substring, word-later, alias, or subtitle hits.
+    enum Rank: Int, Comparable {
+        case exact = 0
+        case prefix = 1
+        case other = 2
+
+        static func < (lhs: Rank, rhs: Rank) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    /// Stable sort key: rank first, then the item's original index so equal
+    /// ranks keep the established order.
+    struct Key: Comparable {
+        let rank: Rank
+        let index: Int
+
+        static func < (lhs: Key, rhs: Key) -> Bool {
+            if lhs.rank != rhs.rank { return lhs.rank < rhs.rank }
+            return lhs.index < rhs.index
+        }
+    }
+
+    static func normalizedQuery(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Best rank across `titles` (exact / prefix / later-in-text). `secondary`
+    /// fields (aliases, subtitles) can only contribute `.other`, so they never
+    /// outrank a real title prefix. `nil` means the candidate set excludes
+    /// this item — the same membership as today's contains checks.
+    static func rank(titles: [String], secondary: [String] = [], query: String) -> Rank? {
+        let needle = normalizedQuery(query)
+        guard !needle.isEmpty else { return nil }
+
+        var best: Rank?
+        for title in titles where !title.isEmpty {
+            guard title.localizedCaseInsensitiveContains(needle) else { continue }
+            let rank = rank(title: title, needle: needle)
+            if best.map({ rank < $0 }) ?? true {
+                best = rank
+            }
+            if best == .exact { return .exact }
+        }
+        if let best { return best }
+        if secondary.contains(where: { $0.localizedCaseInsensitiveContains(needle) }) {
+            return .other
+        }
+        return nil
+    }
+
+    /// Filters out non-candidates and stably sorts the rest by rank.
+    static func ranked<T>(_ items: [T], rank: (T) -> Rank?) -> [(item: T, rank: Rank)] {
+        items.enumerated().compactMap { index, item -> (T, Rank, Key)? in
+            guard let rank = rank(item) else { return nil }
+            return (item, rank, Key(rank: rank, index: index))
+        }
+        .sorted { $0.2 < $1.2 }
+        .map { (item: $0.0, rank: $0.1) }
+    }
+
+    private static func rank(title: String, needle: String) -> Rank {
+        if title.localizedCaseInsensitiveCompare(needle) == .orderedSame {
+            return .exact
+        }
+        if title.range(of: needle, options: [.caseInsensitive, .anchored]) != nil {
+            return .prefix
+        }
+        return .other
+    }
+}

--- a/Sources/AnyDoor/Views/CommandPaletteState.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteState.swift
@@ -9,16 +9,18 @@ struct CommandPaletteSection: Identifiable {
     /// string; Core sections keep the typed convenience initializer.
     let titleKey: String
     let entries: [PanelEntry]
-    var id: String { titleKey }
+    /// `titleKey` plus an optional rank-tier suffix so a header can appear
+    /// once per tier without colliding in `ForEach`.
+    let id: String
 
     init(titleKey: L10n.Key, entries: [PanelEntry]) {
-        self.titleKey = titleKey.rawValue
-        self.entries = entries
+        self.init(rawTitleKey: titleKey.rawValue, entries: entries)
     }
 
-    init(rawTitleKey: String, entries: [PanelEntry]) {
+    init(rawTitleKey: String, entries: [PanelEntry], identitySuffix: String? = nil) {
         self.titleKey = rawTitleKey
         self.entries = entries
+        self.id = identitySuffix.map { "\(rawTitleKey)#\($0)" } ?? rawTitleKey
     }
 }
 
@@ -874,22 +876,21 @@ final class CommandPaletteState {
         return sections
     }
 
-    /// Filter `allSections` and order them so a title prefix outranks a later
-    /// or fuzzier hit, including across section boundaries. Equal ranks keep
-    /// the original section/entry order.
+    /// Filter `allSections` and emit one slice per rank tier so flattened
+    /// order is globally rank-correct. A section that spans tiers is shown
+    /// once per tier (same header) rather than dragging a later hit above a
+    /// prefix in another section. Equal ranks keep the original section and
+    /// entry order.
     private func rankedRootSections(query: String) -> [CommandPaletteSection] {
-        let prepared = allSections.enumerated().compactMap {
-            sectionIndex, section -> (CommandPaletteSection, CommandPaletteQueryMatch.Key)? in
-            let matches = CommandPaletteQueryMatch.ranked(section.entries) {
-                rootRank(of: $0, query: query)
-            }
-            guard let best = matches.map(\.rank).min() else { return nil }
-            return (
-                CommandPaletteSection(rawTitleKey: section.titleKey, entries: matches.map(\.item)),
-                CommandPaletteQueryMatch.Key(rank: best, index: sectionIndex)
+        CommandPaletteQueryMatch.rankedByGlobalTiers(allSections, items: \.entries) {
+            rootRank(of: $0, query: query)
+        }.map { section, entries, rank in
+            CommandPaletteSection(
+                rawTitleKey: section.titleKey,
+                entries: entries,
+                identitySuffix: rank.identitySuffix
             )
         }
-        return prepared.sorted { $0.1 < $1.1 }.map(\.0)
     }
 
     private func rootRank(of entry: PanelEntry, query: String) -> CommandPaletteQueryMatch.Rank? {

--- a/Sources/AnyDoor/Views/CommandPaletteState.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteState.swift
@@ -845,16 +845,13 @@ final class CommandPaletteState {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return allSections }
         var sections = rankedRootSections(query: trimmed)
-        // Insert special sections at index 0 in reverse priority order, so the
-        // last inserted ends up on top. Final order: quicklink argument, dev-tool
-        // keyword-completion hint, calc, conversion, ports, plugin rows (hosts),
-        // dev tools.
+        // Insert dedicated synthetic sections at index 0 in reverse priority
+        // order, so the last inserted ends up on top. Final order: quicklink
+        // argument, dev-tool keyword-completion hint, calc, conversion, ports,
+        // dev tools. Normal plugin root rows rank with Core sections rather
+        // than occupying a reserved slot.
         if let dev = devToolsSection(matching: trimmed) {
             sections.insert(dev, at: 0)
-        }
-        // Reversed so on-screen order follows registration order.
-        for section in pluginRowSections(matching: trimmed).reversed() {
-            sections.insert(section, at: 0)
         }
         if let ports = portSection(matching: trimmed) {
             sections.insert(ports, at: 0)
@@ -876,14 +873,16 @@ final class CommandPaletteState {
         return sections
     }
 
-    /// Filter `allSections` and emit one slice per rank tier so flattened
-    /// order is globally rank-correct. A section that spans tiers is shown
-    /// once per tier (same header) rather than dragging a later hit above a
-    /// prefix in another section. Equal ranks keep the original section and
-    /// entry order.
+    /// Filter Core and plugin root sections and emit one slice per rank tier
+    /// so flattened order is globally rank-correct, including when a plugin
+    /// `.other` hit would otherwise sit above a Core title prefix. A section
+    /// that spans tiers is shown once per tier (same header). Equal ranks
+    /// keep the original section and entry order (plugin sources first,
+    /// then Core `allSections`).
     private func rankedRootSections(query: String) -> [CommandPaletteSection] {
-        CommandPaletteQueryMatch.rankedByGlobalTiers(allSections, items: \.entries) {
-            rootRank(of: $0, query: query)
+        let combined = pluginRowSections(matching: query) + allSections
+        return CommandPaletteQueryMatch.rankedByGlobalTiers(combined, items: \.entries) {
+            rankedRootRank(of: $0, query: query)
         }.map { section, entries, rank in
             CommandPaletteSection(
                 rawTitleKey: section.titleKey,
@@ -891,6 +890,19 @@ final class CommandPaletteState {
                 identitySuffix: rank.identitySuffix
             )
         }
+    }
+
+    private func rankedRootRank(
+        of entry: PanelEntry,
+        query: String
+    ) -> CommandPaletteQueryMatch.Rank? {
+        if case .pluginRow(_, let descriptor) = entry.source {
+            // Already-filtered plugin rows (including section-title-only
+            // survivors and status placeholders) stay in `.other` rather
+            // than being dropped by a nil rank.
+            return Self.pluginRowRank(descriptor, query: query) ?? .other
+        }
+        return rootRank(of: entry, query: query)
     }
 
     private func rootRank(of entry: PanelEntry, query: String) -> CommandPaletteQueryMatch.Rank? {

--- a/Sources/AnyDoor/Views/CommandPaletteState.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteState.swift
@@ -785,10 +785,13 @@ final class CommandPaletteState {
         guard case .options(let optionsLevel) = level else { return [] }
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return optionsLevel.entries }
-        return optionsLevel.entries.filter {
-            $0.title.localizedCaseInsensitiveContains(trimmed)
-                || ($0.subtitle?.localizedCaseInsensitiveContains(trimmed) ?? false)
-        }
+        return CommandPaletteQueryMatch.ranked(optionsLevel.entries) { entry in
+            CommandPaletteQueryMatch.rank(
+                titles: [entry.title],
+                secondary: [entry.subtitle].compactMap { $0 },
+                query: trimmed
+            )
+        }.map(\.item)
     }
 
     /// Bumped when an async plugin row source finishes (re)loading, so a visible
@@ -839,12 +842,7 @@ final class CommandPaletteState {
         }
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return allSections }
-        var sections = allSections.compactMap { section in
-            let matched = section.entries.filter { entry in
-                rootEntry(entry, matches: trimmed)
-            }
-            return matched.isEmpty ? nil : CommandPaletteSection(rawTitleKey: section.titleKey, entries: matched)
-        }
+        var sections = rankedRootSections(query: trimmed)
         // Insert special sections at index 0 in reverse priority order, so the
         // last inserted ends up on top. Final order: quicklink argument, dev-tool
         // keyword-completion hint, calc, conversion, ports, plugin rows (hosts),
@@ -876,10 +874,30 @@ final class CommandPaletteState {
         return sections
     }
 
-    private func rootEntry(_ entry: PanelEntry, matches query: String) -> Bool {
-        entry.localizedTitle().localizedCaseInsensitiveContains(query)
-            || entry.title.localizedCaseInsensitiveContains(query)
-            || entry.searchAliases.contains { $0.localizedCaseInsensitiveContains(query) }
+    /// Filter `allSections` and order them so a title prefix outranks a later
+    /// or fuzzier hit, including across section boundaries. Equal ranks keep
+    /// the original section/entry order.
+    private func rankedRootSections(query: String) -> [CommandPaletteSection] {
+        let prepared = allSections.enumerated().compactMap {
+            sectionIndex, section -> (CommandPaletteSection, CommandPaletteQueryMatch.Key)? in
+            let matches = CommandPaletteQueryMatch.ranked(section.entries) {
+                rootRank(of: $0, query: query)
+            }
+            guard let best = matches.map(\.rank).min() else { return nil }
+            return (
+                CommandPaletteSection(rawTitleKey: section.titleKey, entries: matches.map(\.item)),
+                CommandPaletteQueryMatch.Key(rank: best, index: sectionIndex)
+            )
+        }
+        return prepared.sorted { $0.1 < $1.1 }.map(\.0)
+    }
+
+    private func rootRank(of entry: PanelEntry, query: String) -> CommandPaletteQueryMatch.Rank? {
+        CommandPaletteQueryMatch.rank(
+            titles: [entry.localizedTitle(), entry.title],
+            secondary: entry.searchAliases,
+            query: query
+        )
     }
 
     /// Builds one section per registered plugin row source, listing every row
@@ -948,8 +966,9 @@ final class CommandPaletteState {
     /// palette). Mirrors Raycast: typing an extension's display name surfaces
     /// all of its rows, so a query matching `sectionTitle` shows every row;
     /// otherwise each row is kept when the query matches its own title or
-    /// subtitle (`pluginRowMatches`). Case-insensitive throughout. An empty
-    /// query yields nothing — plugin rows are query-gated at the root.
+    /// subtitle (`pluginRowMatches`). Survivors are then ranked so a title
+    /// prefix outranks a later or subtitle hit. Case-insensitive throughout.
+    /// An empty query yields nothing — plugin rows are query-gated at the root.
     nonisolated static func filterRootPluginRows(
         _ rows: [PluginRowDescriptor],
         query: String,
@@ -957,16 +976,46 @@ final class CommandPaletteState {
     ) -> [PluginRowDescriptor] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
-        if sectionTitle.localizedCaseInsensitiveContains(trimmed) { return rows }
-        return rows.filter { pluginRowMatches($0, query: trimmed) }
+        let filtered = if sectionTitle.localizedCaseInsensitiveContains(trimmed) {
+            rows
+        } else {
+            rows.filter { pluginRowMatches($0, query: trimmed) }
+        }
+        return rankedPluginRows(filtered, query: trimmed)
     }
 
     /// Whether a plugin row matches a query on its own text — title or subtitle,
     /// case-insensitively. Shared by the root and pushed-list levels; the root
     /// level additionally shows every row when the section title itself matches.
     nonisolated static func pluginRowMatches(_ row: PluginRowDescriptor, query: String) -> Bool {
-        row.title.localizedCaseInsensitiveContains(query)
-            || (row.subtitle?.localizedCaseInsensitiveContains(query) ?? false)
+        pluginRowRank(row, query: query) != nil
+    }
+
+    /// Title prefix / exact ranks outrank a subtitle or later-in-title hit.
+    /// Rows kept only because the section title matched (no row-text hit) stay
+    /// at `.other` so they sort after real title matches without dropping.
+    nonisolated private static func rankedPluginRows(
+        _ rows: [PluginRowDescriptor],
+        query: String
+    ) -> [PluginRowDescriptor] {
+        rows.enumerated()
+            .map { index, row in
+                let rank = pluginRowRank(row, query: query) ?? .other
+                (row, CommandPaletteQueryMatch.Key(rank: rank, index: index))
+            }
+            .sorted { $0.1 < $1.1 }
+            .map(\.0)
+    }
+
+    nonisolated private static func pluginRowRank(
+        _ row: PluginRowDescriptor,
+        query: String
+    ) -> CommandPaletteQueryMatch.Rank? {
+        CommandPaletteQueryMatch.rank(
+            titles: [row.title],
+            secondary: [row.subtitle].compactMap { $0 },
+            query: query
+        )
     }
 
     /// The two host-synthesized status rows for an async plugin row source. Both
@@ -1250,9 +1299,14 @@ final class CommandPaletteState {
             // level matches each row's title or subtitle only (not the section
             // title). An empty query shows all, like the options level.
             let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-            content = .rows(trimmed.isEmpty ? rows : rows.filter {
-                Self.pluginRowMatches($0, query: trimmed)
-            })
+            content = .rows(
+                trimmed.isEmpty
+                    ? rows
+                    : Self.rankedPluginRows(
+                        rows.filter { Self.pluginRowMatches($0, query: trimmed) },
+                        query: trimmed
+                    )
+            )
         }
         return Self.pluginContentEntries(sourceKey: listLevel.sourceKey, content: content)
     }

--- a/Sources/AnyDoor/Views/CommandPaletteState.swift
+++ b/Sources/AnyDoor/Views/CommandPaletteState.swift
@@ -1012,9 +1012,9 @@ final class CommandPaletteState {
         query: String
     ) -> [PluginRowDescriptor] {
         rows.enumerated()
-            .map { index, row in
+            .map { index, row -> (PluginRowDescriptor, CommandPaletteQueryMatch.Key) in
                 let rank = pluginRowRank(row, query: query) ?? .other
-                (row, CommandPaletteQueryMatch.Key(rank: rank, index: index))
+                return (row, CommandPaletteQueryMatch.Key(rank: rank, index: index))
             }
             .sorted { $0.1 < $1.1 }
             .map(\.0)

--- a/Tests/AnyDoorTests/CommandPaletteMatchTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteMatchTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import AnyDoor
+
+final class CommandPaletteMatchTests: XCTestCase {
+
+    func testTitlePrefixOutranksLaterSubstring() {
+        XCTAssertEqual(rank(title: "Warp", query: "wa"), .prefix)
+        XCTAssertEqual(rank(title: "Keep Awake", query: "wa"), .other)
+        XCTAssertLessThan(
+            CommandPaletteQueryMatch.Rank.prefix,
+            CommandPaletteQueryMatch.Rank.other
+        )
+    }
+
+    func testPrefixRankIsCaseInsensitive() {
+        XCTAssertEqual(rank(title: "Warp", query: "WA"), .prefix)
+        XCTAssertEqual(rank(title: "WARP", query: "wa"), .prefix)
+        XCTAssertEqual(rank(title: "warp", query: "Wa"), .prefix)
+    }
+
+    func testExactTitleOutranksPrefix() {
+        XCTAssertEqual(rank(title: "Wa", query: "wa"), .exact)
+        XCTAssertEqual(rank(title: "Warp", query: "wa"), .prefix)
+        XCTAssertLessThan(
+            CommandPaletteQueryMatch.Rank.exact,
+            CommandPaletteQueryMatch.Rank.prefix
+        )
+    }
+
+    func testWhitespaceNormalizedQueryStillPrefixes() {
+        XCTAssertEqual(rank(title: "Warp", query: "  wa  "), .prefix)
+        XCTAssertEqual(rank(title: "Keep Awake", query: "\twa\n"), .other)
+    }
+
+    func testAliasOnlyMatchIsOtherAndStillACandidate() {
+        let rank = CommandPaletteQueryMatch.rank(
+            titles: ["GitHub"],
+            secondary: ["gh"],
+            query: "gh"
+        )
+        XCTAssertEqual(rank, .other)
+    }
+
+    func testAliasCannotOutrankATitlePrefix() {
+        let aliasHit = CommandPaletteQueryMatch.rank(
+            titles: ["Keep Awake"],
+            secondary: ["wa"],
+            query: "wa"
+        )
+        let prefixHit = CommandPaletteQueryMatch.rank(titles: ["Warp"], query: "wa")
+        XCTAssertEqual(aliasHit, .other)
+        XCTAssertEqual(prefixHit, .prefix)
+        XCTAssertLessThan(prefixHit!, aliasHit!)
+    }
+
+    func testNonCandidateReturnsNil() {
+        XCTAssertNil(rank(title: "Finder", query: "wa"))
+        XCTAssertNil(CommandPaletteQueryMatch.rank(titles: ["Warp"], query: "   "))
+        XCTAssertNil(CommandPaletteQueryMatch.rank(titles: ["Warp"], query: ""))
+    }
+
+    func testRankedDropsNonCandidatesAndKeepsEqualRankOrder() {
+        let titles = ["Keep Awake", "Finder", "Always On", "Watch", "Water"]
+        let ranked = CommandPaletteQueryMatch.ranked(titles) {
+            CommandPaletteQueryMatch.rank(titles: [$0], query: "wa")
+        }
+        XCTAssertEqual(ranked.map(\.item), ["Watch", "Water", "Keep Awake", "Always On"])
+        XCTAssertEqual(ranked.map(\.rank), [.prefix, .prefix, .other, .other])
+    }
+
+    func testRankedPrefersExactThenPrefixThenOther() {
+        let titles = ["Keep Awake", "Watch", "Wa"]
+        let ranked = CommandPaletteQueryMatch.ranked(titles) {
+            CommandPaletteQueryMatch.rank(titles: [$0], query: "wa")
+        }
+        XCTAssertEqual(ranked.map(\.item), ["Wa", "Watch", "Keep Awake"])
+        XCTAssertEqual(ranked.map(\.rank), [.exact, .prefix, .other])
+    }
+
+    private func rank(title: String, query: String) -> CommandPaletteQueryMatch.Rank? {
+        CommandPaletteQueryMatch.rank(titles: [title], query: query)
+    }
+}

--- a/Tests/AnyDoorTests/CommandPaletteMatchTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteMatchTests.swift
@@ -77,6 +77,37 @@ final class CommandPaletteMatchTests: XCTestCase {
         XCTAssertEqual(ranked.map(\.rank), [.exact, .prefix, .other])
     }
 
+    func testPrefixRankFollowsLocalizedUnicodeEquivalence() {
+        // Precomposed É (U+00C9) vs decomposed e + combining acute. Candidate
+        // matching uses localized case-insensitive contains against the
+        // current locale; prefix rank must accept the same start.
+        let precomposed = "\u{00C9}clair"
+        let decomposed = "e\u{0301}"
+        XCTAssertEqual(rank(title: precomposed, query: decomposed), .prefix)
+        XCTAssertEqual(rank(title: "Keep \u{00C9}clair", query: decomposed), .other)
+        XCTAssertEqual(rank(title: "E\u{0301}clair", query: "\u{00E9}"), .prefix)
+    }
+
+    func testExactRankFollowsLocalizedUnicodeEquivalence() {
+        XCTAssertEqual(
+            rank(title: "\u{00C9}clair", query: "e\u{0301}clair"),
+            .exact
+        )
+    }
+
+    func testGlobalTiersLiftALaterSectionPrefixAboveAnEarlierOther() {
+        let sections = [
+            (name: "commands", titles: ["Watch", "Keep Awake"]),
+            (name: "apps", titles: ["Warp"]),
+        ]
+        let ranked = CommandPaletteQueryMatch.rankedByGlobalTiers(sections, items: \.titles) {
+            CommandPaletteQueryMatch.rank(titles: [$0], query: "wa")
+        }
+        XCTAssertEqual(ranked.map(\.section.name), ["commands", "apps", "commands"])
+        XCTAssertEqual(ranked.flatMap(\.items), ["Watch", "Warp", "Keep Awake"])
+        XCTAssertEqual(ranked.map(\.rank), [.prefix, .prefix, .other])
+    }
+
     private func rank(title: String, query: String) -> CommandPaletteQueryMatch.Rank? {
         CommandPaletteQueryMatch.rank(titles: [title], query: query)
     }

--- a/Tests/AnyDoorTests/CommandPalettePluginStateTests.swift
+++ b/Tests/AnyDoorTests/CommandPalettePluginStateTests.swift
@@ -883,6 +883,43 @@ final class CommandPalettePluginStateTests: XCTestCase {
         XCTAssertEqual(filtered.count, Self.v2exRows.count)
     }
 
+    /// A title prefix outranks a later-in-title hit, even when the prefix row
+    /// was registered later.
+    func testRowTitlePrefixOutranksLaterSubstring() {
+        let rows = [
+            PluginRowDescriptor(id: "awake", title: "Keep Awake", symbol: "cup.and.saucer", commit: .closeThenAct),
+            PluginRowDescriptor(id: "warp", title: "Warp", symbol: "app.fill", commit: .closeThenAct),
+        ]
+        let filtered = CommandPaletteState.filterRootPluginRows(
+            rows, query: "wa", sectionTitle: "Apps"
+        )
+        XCTAssertEqual(filtered.map(\.id), ["warp", "awake"])
+    }
+
+    /// Prefix ranking is case-insensitive and ignores surrounding whitespace.
+    func testRowTitlePrefixRankingIsNormalized() {
+        let rows = [
+            PluginRowDescriptor(id: "awake", title: "keep awake", symbol: "cup.and.saucer", commit: .closeThenAct),
+            PluginRowDescriptor(id: "warp", title: "WARP", symbol: "app.fill", commit: .closeThenAct),
+        ]
+        let filtered = CommandPaletteState.filterRootPluginRows(
+            rows, query: "  Wa  ", sectionTitle: "Apps"
+        )
+        XCTAssertEqual(filtered.map(\.id), ["warp", "awake"])
+    }
+
+    /// Equal ranks keep registration order.
+    func testEqualRankPluginRowsKeepOriginalOrder() {
+        let rows = [
+            PluginRowDescriptor(id: "watch", title: "Watch", symbol: "app.fill", commit: .closeThenAct),
+            PluginRowDescriptor(id: "warp", title: "Warp", symbol: "app.fill", commit: .closeThenAct),
+        ]
+        let filtered = CommandPaletteState.filterRootPluginRows(
+            rows, query: "wa", sectionTitle: "Apps"
+        )
+        XCTAssertEqual(filtered.map(\.id), ["watch", "warp"])
+    }
+
     /// When the section title does not match, rows filter by their own title.
     func testRowTitleMatchNarrowsWithinSource() {
         let filtered = CommandPaletteState.filterRootPluginRows(

--- a/Tests/AnyDoorTests/CommandPaletteTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteTests.swift
@@ -875,6 +875,44 @@ final class CommandPaletteTests: XCTestCase {
     }
 
     @MainActor
+    func testPrefixOutranksLaterHitEvenWhenTheyShareASection() {
+        let watch = titledEntry("Watch", bundleID: "watch")
+        let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
+        let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(
+                    titleKey: .commandPaletteSectionCommands,
+                    entries: [watch, keepAwake]
+                ),
+                CommandPaletteSection(
+                    titleKey: .commandPaletteSectionApplications,
+                    entries: [warp]
+                ),
+            ],
+            hyperFlags: 0,
+            rowSources: []
+        )
+        state.query = "wa"
+
+        // Watch (prefix) must not drag Keep Awake (other) above Warp (prefix).
+        XCTAssertEqual(state.flatEntries.map(\.title), ["Watch", "Warp", "Keep Awake"])
+        XCTAssertEqual(
+            state.filteredSections.map(\.titleKey),
+            [
+                L10n.Key.commandPaletteSectionCommands.rawValue,
+                L10n.Key.commandPaletteSectionApplications.rawValue,
+                L10n.Key.commandPaletteSectionCommands.rawValue,
+            ]
+        )
+        XCTAssertEqual(
+            Set(state.filteredSections.map(\.id)).count,
+            state.filteredSections.count,
+            "split rank-tier slices of the same header need distinct identities"
+        )
+    }
+
+    @MainActor
     func testEmptyQueryKeepsOriginalSectionOrder() {
         let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
         let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")

--- a/Tests/AnyDoorTests/CommandPaletteTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteTests.swift
@@ -806,6 +806,90 @@ final class CommandPaletteTests: XCTestCase {
         XCTAssertFalse(state.isCurrencyContext)
     }
 
+    // MARK: - Prefix ranking
+
+    @MainActor
+    func testTitlePrefixOutranksLaterSubstringAcrossSections() {
+        let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
+        let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(titleKey: .commandPaletteSectionCommands, entries: [keepAwake]),
+                CommandPaletteSection(titleKey: .commandPaletteSectionApplications, entries: [warp]),
+            ],
+            hyperFlags: 0,
+            rowSources: []
+        )
+        state.query = "wa"
+
+        XCTAssertEqual(state.flatEntries.map(\.title), ["Warp", "Keep Awake"])
+        XCTAssertEqual(
+            state.filteredSections.map(\.titleKey),
+            [
+                L10n.Key.commandPaletteSectionApplications.rawValue,
+                L10n.Key.commandPaletteSectionCommands.rawValue,
+            ]
+        )
+    }
+
+    @MainActor
+    func testPrefixRankingIsCaseInsensitiveAndNormalized() {
+        let keepAwake = titledEntry("keep awake", bundleID: "keep-awake")
+        let warp = titledEntry("WARP", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(titleKey: .commandPaletteSectionCommands, entries: [keepAwake]),
+                CommandPaletteSection(titleKey: .commandPaletteSectionApplications, entries: [warp]),
+            ],
+            hyperFlags: 0,
+            rowSources: []
+        )
+        state.query = "  Wa  "
+
+        XCTAssertEqual(state.flatEntries.map(\.title), ["WARP", "keep awake"])
+    }
+
+    @MainActor
+    func testEqualRankKeepsOriginalSectionAndEntryOrder() {
+        let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
+        let alwaysOn = titledEntry("Always On", bundleID: "always-on")
+        let watch = titledEntry("Watch", bundleID: "com.apple.watch")
+        let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(
+                    titleKey: .commandPaletteSectionCommands,
+                    entries: [keepAwake, alwaysOn]
+                ),
+                CommandPaletteSection(
+                    titleKey: .commandPaletteSectionApplications,
+                    entries: [watch, warp]
+                ),
+            ],
+            hyperFlags: 0,
+            rowSources: []
+        )
+        state.query = "wa"
+
+        XCTAssertEqual(state.flatEntries.map(\.title), ["Watch", "Warp", "Keep Awake", "Always On"])
+    }
+
+    @MainActor
+    func testEmptyQueryKeepsOriginalSectionOrder() {
+        let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
+        let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(titleKey: .commandPaletteSectionCommands, entries: [keepAwake]),
+                CommandPaletteSection(titleKey: .commandPaletteSectionApplications, entries: [warp]),
+            ],
+            hyperFlags: 0,
+            rowSources: []
+        )
+
+        XCTAssertEqual(state.flatEntries.map(\.title), ["Keep Awake", "Warp"])
+    }
+
     private struct StubScanner: PortScanning {
         let records: [PortRecord]
 
@@ -854,6 +938,15 @@ final class CommandPaletteTests: XCTestCase {
         keyword: String?
     ) -> QuicklinkTemplateCandidate {
         QuicklinkTemplateCandidate(id: id, title: title, keyword: keyword, link: link)
+    }
+
+    private func titledEntry(_ title: String, bundleID: String) -> PanelEntry {
+        .paletteRow(
+            source: .installedApp(bundleID: bundleID, path: "/Applications/\(bundleID).app"),
+            displayOrder: 0,
+            title: title,
+            symbol: "app.fill"
+        )
     }
 
     private func portRecord(port: UInt16, pid: pid_t, processName: String) -> PortRecord {

--- a/Tests/AnyDoorTests/CommandPaletteTests.swift
+++ b/Tests/AnyDoorTests/CommandPaletteTests.swift
@@ -913,6 +913,25 @@ final class CommandPaletteTests: XCTestCase {
     }
 
     @MainActor
+    func testPluginOtherMatchDoesNotOutrankCoreTitlePrefix() {
+        let keepAwake = HostProfile(name: "Keep Awake", isActive: false)
+        let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")
+        let state = CommandPaletteState(
+            sections: [
+                CommandPaletteSection(
+                    titleKey: .commandPaletteSectionApplications,
+                    entries: [warp]
+                ),
+            ],
+            hyperFlags: 0,
+            rowSources: [hostsRowSourceRegistration(profiles: [keepAwake])]
+        )
+        state.query = "wa"
+
+        XCTAssertEqual(state.flatEntries.map(\.title), ["Warp", "Keep Awake"])
+    }
+
+    @MainActor
     func testEmptyQueryKeepsOriginalSectionOrder() {
         let keepAwake = titledEntry("Keep Awake", bundleID: "keep-awake")
         let warp = titledEntry("Warp", bundleID: "dev.warp.Warp")


### PR DESCRIPTION
## Summary
- rank exact and title-prefix Command Palette matches ahead of later, subtitle, alias, and fuzzy matches
- apply stable global ranking across Core and plugin root sections while preserving existing dedicated-section priorities
- add regression coverage for cross-section ordering, localized Unicode matching, plugin rows, and deterministic ties

## Test plan
- [x] `swift build --build-tests`
- [x] `swift test`

## Known trade-off
- A source section spanning multiple rank tiers can render its header more than once (for example, Commands → Applications → Commands). This preserves source identity while maintaining globally ranked visible results.